### PR TITLE
fix(upload)Input expects string for size attribute

### DIFF
--- a/packages/upload/FilePicker.js
+++ b/packages/upload/FilePicker.js
@@ -106,7 +106,7 @@ FilePicker.propTypes = {
   children: PropTypes.func,
   name: PropTypes.string,
   allowedFileTypes: PropTypes.arrayOf(PropTypes.string),
-  maxSize: PropTypes.number,
+  maxSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 FilePicker.defaultProps = {

--- a/packages/upload/FilePicker.js
+++ b/packages/upload/FilePicker.js
@@ -91,7 +91,7 @@ class FilePicker extends Component {
             ? allowedFileTypes.join(',')
             : undefined
         }
-        size={maxSize}
+        size={maxSize + ''}
         {...props}
         onChange={this.onChange}
       />


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `size` of type `number` supplied to `Input`, expected `string`.
    in Input (created by FilePicker)
    in FilePicker (created by FilePickerBtn)