### PR TITLE
feat(av-loadable): init work on common availity loadable

### DIFF
--- a/packages/av-loadable/AvLoadable.js
+++ b/packages/av-loadable/AvLoadable.js
@@ -1,0 +1,16 @@
+import Loadable from 'react-loadable';
+
+import Loading from './Loading';
+
+function AvLoadable(opts) {
+  return Loadable(
+    Object.assign(
+      {
+        loading: Loading,
+      },
+      opts
+    )
+  );
+}
+
+export default AvLoadable;

--- a/packages/av-loadable/Loading.js
+++ b/packages/av-loadable/Loading.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Loader from 'react-block-ui/lib/Loader';
+import { Button } from 'reactstrap';
+
+const Loading = ({ pastDelay, error, timedOut, retry }) => {
+  if (!pastDelay) return null;
+
+  let text = 'Loading';
+  if (error) {
+    text = 'Error!';
+  } else if (pastDelay) {
+    text = 'Taking a long time';
+  }
+
+  const ShowButton = (error || timedOut) && (
+    <div>
+      <Button onClick={retry}>Retry</Button>
+    </div>
+  );
+  const ShowLoader = !error && <Loader />;
+
+  return (
+    <div>
+      {text}
+      {ShowLoader}
+      {ShowButton}
+    </div>
+  );
+};
+
+Loading.propTypes = {
+  pastDelay: PropTypes.bool,
+  error: PropTypes.object,
+  timedOut: PropTypes.bool,
+  retry: PropTypes.func,
+};
+
+export default Loading;

--- a/packages/av-loadable/index.js
+++ b/packages/av-loadable/index.js
@@ -1,0 +1,3 @@
+import AvLoadable from './AvLoadable';
+
+export default AvLoadable;

--- a/packages/av-loadable/package.json
+++ b/packages/av-loadable/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@availity/av-loadable",
+  "version": "1.5.2",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Evan Sharp <evan.sharp@availity.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://artifactory.availity.com/artifactory/api/npm/local-npm/"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0",
+    "reactstrap": "^6.1.0",
+    "react-block-ui": "^1.1.1"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8",
+    "react-block-ui": "^1.0.0",
+    "react-loadable": "^5.4.0"
+  },
+  "devDependencies": {
+    "react": "^16.3.0",
+    "react-block-ui": "^1.0.0",
+    "react-dom": "^16.3.0",
+    "reactstrap": "^6.1.0"
+  }
+}


### PR DESCRIPTION
Wanted to share some initial work on creating a common Loader component for https://github.com/jamiebuilds/react-loadable
using our block-ui