### PR TITLE
fix(reactstrap-validation-select): update styles in input-groups

### DIFF
--- a/packages/reactstrap-validation-select/styles.scss
+++ b/packages/reactstrap-validation-select/styles.scss
@@ -20,21 +20,37 @@
 .av-select .av__placeholder {
   color: #666;
 }
+
 .av__value-container {
   width: 90%;
 }
+
 .av__value-container--is-multi.av__value-container--has-value.av__value-container {
   width: 85%;
 }
-.av__value-container > div,
+
+.av__value-container>div,
 .av__input,
-.av__input > input {
+.av__input>input {
   max-width: 99%;
 }
-.av__input > input + div {
+
+.av__input>input+div {
   max-width: 100%;
 }
+
 svg,
 use {
   pointer-events: none;
+}
+
+.av-select.form-control {
+  padding: 0;
+  border-width: 0;
+  .av__control {
+    border-radius: inherit;
+    &.av__control--is-focused {
+      z-index: 3;
+    }
+  }
 }


### PR DESCRIPTION
How Current styles look: 
![screen shot 2019-01-23 at 10 37 18 am](https://user-images.githubusercontent.com/4523739/51617888-25b8bf80-1efb-11e9-8623-13e17021cb33.png)

With style changes: 
![screen shot 2019-01-23 at 10 36 46 am](https://user-images.githubusercontent.com/4523739/51617902-2cdfcd80-1efb-11e9-962d-35bd88f1edc7.png)

One change not seen here that could be added to PR, in my use I needed to add this in order to make sure the dropdown rendered above some stuff lower in the page with z-indexes changed in our UI-kit. Would it be worth adding this to the css? 
```javascript
styles: {{
  menu: styles => ({ ...styles, zIndex: 5 }),
}}
```