### PR TITLE
refactor(feature): updated aria attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7277,24 +7277,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7304,12 +7308,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -7318,34 +7324,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7354,25 +7366,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7381,13 +7397,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7403,7 +7421,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7417,13 +7436,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7432,7 +7453,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7441,7 +7463,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7451,18 +7474,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -7470,13 +7496,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -7484,12 +7512,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -7498,7 +7528,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7507,7 +7538,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7515,13 +7547,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7532,7 +7566,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7550,7 +7585,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7560,13 +7596,15 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7576,7 +7614,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7588,18 +7627,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -7607,19 +7649,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7629,19 +7674,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7653,7 +7701,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -7661,7 +7710,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7676,7 +7726,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7685,42 +7736,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -7730,7 +7788,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7739,7 +7798,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -7747,13 +7807,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7768,13 +7830,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7783,12 +7847,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }

--- a/packages/breadcrumbs/Breadcrumbs.js
+++ b/packages/breadcrumbs/Breadcrumbs.js
@@ -5,7 +5,9 @@ import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 const Breadcrumbs = ({ crumbs, active, emptyState, ...props }) => (
   <Breadcrumb {...props}>
     <BreadcrumbItem>
-      <a href="/public/apps/dashboard">Home</a>
+      <a href="/public/apps/dashboard" aria-label="Home">
+        Home
+      </a>
     </BreadcrumbItem>
 
     {crumbs &&
@@ -13,7 +15,9 @@ const Breadcrumbs = ({ crumbs, active, emptyState, ...props }) => (
       crumbs.map(crumb => (
         <BreadcrumbItem key={crumb.name + crumb.url}>
           {crumb.name && crumb.url ? (
-            <a href={crumb.url}>{crumb.name}</a>
+            <a aria-label={crumb.name} href={crumb.url}>
+              {crumb.name}
+            </a>
           ) : (
             <span>{emptyState}</span>
           )}

--- a/packages/breadcrumbs/tests/__snapshots__/Breadcrumbs.test.js.snap
+++ b/packages/breadcrumbs/tests/__snapshots__/Breadcrumbs.test.js.snap
@@ -12,6 +12,7 @@ exports[`Breadcrumbs should render 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="Home"
         href="/public/apps/dashboard"
       >
         Home
@@ -39,6 +40,7 @@ exports[`Breadcrumbs should render child as current page 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="Home"
         href="/public/apps/dashboard"
       >
         Home
@@ -66,6 +68,7 @@ exports[`Breadcrumbs should render crumbs 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="Home"
         href="/public/apps/dashboard"
       >
         Home
@@ -75,6 +78,7 @@ exports[`Breadcrumbs should render crumbs 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="my grand parent page"
         href="/parent-page"
       >
         my grand parent page
@@ -84,6 +88,7 @@ exports[`Breadcrumbs should render crumbs 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="my parent page"
         href="/grand-parent-page"
       >
         my parent page
@@ -111,6 +116,7 @@ exports[`Breadcrumbs should render crumbs with missing values 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="Home"
         href="/public/apps/dashboard"
       >
         Home
@@ -120,6 +126,7 @@ exports[`Breadcrumbs should render crumbs with missing values 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="my grand parent page"
         href="/parent-page"
       >
         my grand parent page
@@ -154,6 +161,7 @@ exports[`Breadcrumbs should render custom ellipse 1`] = `
       class="breadcrumb-item"
     >
       <a
+        aria-label="Home"
         href="/public/apps/dashboard"
       >
         Home

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -30,7 +30,7 @@ const PageHeader = ({
       <div className="d-flex align-items-start">
         <Breadcrumbs crumbs={crumbs} active={appName || children} /> {component}
       </div>
-      <h1 className="h4 page-header page-header-brand" {...props}>
+      <h4 className="page-header page-header-brand" {...props}>
         <div className="page-header-title">
           {!payerId && appAbbr && (
             <AppIcon color={iconColor} branded={branded} title={appName}>
@@ -52,7 +52,7 @@ const PageHeader = ({
             className="float-md-right d-inline-block"
           />
         )}
-      </h1>
+      </h4>
     </React.Fragment>
   );
 };

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -17,6 +17,7 @@ const PageHeader = ({
   crumbs: ogCrumbs,
   feedback,
   component,
+  tag: Tag,
   ...props
 }) => {
   let crumbs = ogCrumbs;
@@ -30,7 +31,7 @@ const PageHeader = ({
       <div className="d-flex align-items-start">
         <Breadcrumbs crumbs={crumbs} active={appName || children} /> {component}
       </div>
-      <h4 className="page-header page-header-brand" {...props}>
+      <Tag className="page-header page-header-brand" {...props}>
         <div className="page-header-title">
           {!payerId && appAbbr && (
             <AppIcon color={iconColor} branded={branded} title={appName}>
@@ -52,7 +53,7 @@ const PageHeader = ({
             className="float-md-right d-inline-block"
           />
         )}
-      </h4>
+      </Tag>
     </React.Fragment>
   );
 };
@@ -74,6 +75,11 @@ PageHeader.propTypes = {
       url: PropTypes.string,
     })
   ),
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+};
+
+PageHeader.defaultProps = {
+  tag: 'h1',
 };
 
 export default PageHeader;

--- a/packages/page-header/tests/__snapshots__/PageHeader.test.js.snap
+++ b/packages/page-header/tests/__snapshots__/PageHeader.test.js.snap
@@ -32,7 +32,7 @@ exports[`PageHeader should render 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -41,7 +41,7 @@ exports[`PageHeader should render 1`] = `
        
       Payer Space
     </div>
-  </h4>
+  </h1>
 </div>
 `;
 
@@ -77,7 +77,7 @@ exports[`PageHeader should render app icon 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -92,7 +92,7 @@ exports[`PageHeader should render app icon 1`] = `
        
       Payer Space
     </div>
-  </h4>
+  </h1>
 </div>
 `;
 
@@ -128,7 +128,7 @@ exports[`PageHeader should render app icon color 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -143,7 +143,7 @@ exports[`PageHeader should render app icon color 1`] = `
        
       Payer Space
     </div>
-  </h4>
+  </h1>
 </div>
 `;
 
@@ -179,7 +179,7 @@ exports[`PageHeader should render app icon color branded 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -197,7 +197,7 @@ exports[`PageHeader should render app icon color branded 1`] = `
        
       Payer Space
     </div>
-  </h4>
+  </h1>
 </div>
 `;
 
@@ -233,7 +233,7 @@ exports[`PageHeader should render children 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -244,7 +244,7 @@ exports[`PageHeader should render children 1`] = `
         this is cool
       </p>
     </div>
-  </h4>
+  </h1>
 </div>
 `;
 
@@ -280,7 +280,7 @@ exports[`PageHeader should render feedback 1`] = `
     </nav>
      
   </div>
-  <h4
+  <h1
     class="page-header page-header-brand"
   >
     <div
@@ -383,6 +383,6 @@ exports[`PageHeader should render feedback 1`] = `
         </div>
       </div>
     </div>
-  </h4>
+  </h1>
 </div>
 `;

--- a/packages/page-header/tests/__snapshots__/PageHeader.test.js.snap
+++ b/packages/page-header/tests/__snapshots__/PageHeader.test.js.snap
@@ -16,6 +16,7 @@ exports[`PageHeader should render 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -31,8 +32,8 @@ exports[`PageHeader should render 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -40,7 +41,7 @@ exports[`PageHeader should render 1`] = `
        
       Payer Space
     </div>
-  </h1>
+  </h4>
 </div>
 `;
 
@@ -60,6 +61,7 @@ exports[`PageHeader should render app icon 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -75,8 +77,8 @@ exports[`PageHeader should render app icon 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -90,7 +92,7 @@ exports[`PageHeader should render app icon 1`] = `
        
       Payer Space
     </div>
-  </h1>
+  </h4>
 </div>
 `;
 
@@ -110,6 +112,7 @@ exports[`PageHeader should render app icon color 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -125,8 +128,8 @@ exports[`PageHeader should render app icon color 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -140,7 +143,7 @@ exports[`PageHeader should render app icon color 1`] = `
        
       Payer Space
     </div>
-  </h1>
+  </h4>
 </div>
 `;
 
@@ -160,6 +163,7 @@ exports[`PageHeader should render app icon color branded 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -175,8 +179,8 @@ exports[`PageHeader should render app icon color branded 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -193,7 +197,7 @@ exports[`PageHeader should render app icon color branded 1`] = `
        
       Payer Space
     </div>
-  </h1>
+  </h4>
 </div>
 `;
 
@@ -213,6 +217,7 @@ exports[`PageHeader should render children 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -228,8 +233,8 @@ exports[`PageHeader should render children 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -239,7 +244,7 @@ exports[`PageHeader should render children 1`] = `
         this is cool
       </p>
     </div>
-  </h1>
+  </h4>
 </div>
 `;
 
@@ -259,6 +264,7 @@ exports[`PageHeader should render feedback 1`] = `
           class="breadcrumb-item"
         >
           <a
+            aria-label="Home"
             href="/public/apps/dashboard"
           >
             Home
@@ -274,8 +280,8 @@ exports[`PageHeader should render feedback 1`] = `
     </nav>
      
   </div>
-  <h1
-    class="h4 page-header page-header-brand"
+  <h4
+    class="page-header page-header-brand"
   >
     <div
       class="page-header-title"
@@ -377,6 +383,6 @@ exports[`PageHeader should render feedback 1`] = `
         </div>
       </div>
     </div>
-  </h1>
+  </h4>
 </div>
 `;


### PR DESCRIPTION
Updated Aria Attributes for:
- Breadcrumbs: added aria-labels for `a` tags.

- Page Header: Only 1 `h1` tag is allowed per page. We should not be putting the h1 element inside the page header in the case its not the main element of focus.