### PR TITLE
fix(reactstrap-validation-date): fix for toLowerCase() error in AvDate.js

### DIFF
--- a/packages/reactstrap-validation-date/AvDate.js
+++ b/packages/reactstrap-validation-date/AvDate.js
@@ -123,10 +123,14 @@ class AvDate extends Component {
 
   onFieldChange = event => {
     event.persist();
+    const dateValidation = /^(0?[1-9]|1[0-2])\/(0?[1-9]|1\d|2\d|3[01])\/(19|20)\d{2}$/;
     const value = event && event.target ? event.target.value : event;
-    this.setState({ value, open: false }, () => {
-      if (this.props.onChange) this.props.onChange(event, value);
-    });
+    const date = dateValidation.exec(value);
+    if (date !== null) {
+      this.setState({ value, open: false }, () => {
+        if (this.props.onChange) this.props.onChange(event, value);
+      });
+    }
   };
 
   onPickerChange = value => {


### PR DESCRIPTION
	clicking on the Calendar component after entering a space in AvInput component causes issue

	* added date validation to fix
	* will only setState if input is a valid date