### PR TITLE
feat(hooks): added new package containing common hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://availity.github.io/availity-react
 * [breadcrumbs](packages/breadcrumbs/README.md) - Breadscrumbs component for Spaces platform.
 * [feature](packages/feature/README.md) - Check environment features for the current environment to determine if a particular feature is enabled.
 * [feedback](packages/feedback/README.md) - Availity feedback with simley faces react component.
+* [hooks](packages/hooks/README.md) - Custom Hooks that can be used in any projects.
 * [list-group](packages/list-group/README.md) - List Group with some Availity flair.
 * [list-group-item](packages/list-group-item/README.md) - List Group Item with some Availity flair.
 * [page-header](packages/page-header/README.md) - The standard page header for Availity Portal Applications.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -32,6 +32,7 @@
 		"@availity/breadcrumbs": "^1.2.0",
 		"@availity/feature": "^1.1.1",
 		"@availity/feedback": "^1.1.1",
+		"@availity/hooks": "^1.0.0",
 		"@availity/list-group": "^1.1.1",
 		"@availity/list-group-item": "^1.1.1",
 		"@availity/localstorage-core": "^2.5.0",

--- a/packages/docs/stories/hooks.stories.js
+++ b/packages/docs/stories/hooks.stories.js
@@ -1,0 +1,54 @@
+/* eslint-disable react/prop-types */
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import { text } from '@storybook/addon-knobs/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { useToggle, useEffectAsync } from '@availity/hooks';
+import { Button, Card } from 'reactstrap';
+
+import README from '@availity/hooks/README.md';
+import { setInterval } from 'core-js';
+
+const asyncFunction = data =>
+  new Promise(resolve => setInterval(() => resolve(data), 1000));
+
+const Component = ({ initialValue = false }) => {
+  const [isToggled, toggle] = useToggle(initialValue);
+
+  return (
+    <Button onClick={toggle} color="primary">
+      {isToggled ? 'World' : 'Hello'}
+    </Button>
+  );
+};
+
+const AsyncComponent = ({ mockData }) => {
+  const [loading, toggle] = useToggle(true);
+  const [state, setState] = useState(null);
+
+  useEffectAsync(async () => {
+    if (!loading) {
+      toggle();
+    }
+
+    const newState = await asyncFunction(mockData);
+
+    setState(newState);
+    toggle();
+  }, [mockData]);
+
+  return <Card>{loading ? 'Loading...' : state}</Card>;
+};
+
+storiesOf('Hooks|useToggle', module)
+  .addDecorator(withReadme([README]))
+  .add('default', () => <Component />)
+  .add('with initialValue', () => <Component initialValue />);
+
+storiesOf('Hooks|useEffectAsync', module)
+  .addDecorator(withReadme([README]))
+  .addDecorator(withKnobs)
+  .add('default', () => (
+    <AsyncComponent mockData={text('Data', 'Test Data')} />
+  ));

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,0 +1,78 @@
+# @availity/hooks
+
+> Re-usable hooks for components and apps.
+
+## Installation
+
+```bash
+npm install @availity/hooks --save
+```
+
+### Usage
+
+```javascript
+import React from 'react';
+import { useToggle, useEffectAsync } from '@availity/hooks';
+// ...
+const Component = ({asyncFunction}) => {
+    const [loading,toggleLoading] = useToggle(true);
+
+    useEffectAsync(async () => {
+        // ... do async things
+        await asyncFunction();
+
+        toggleLoading();
+    },[]);
+
+    return <div>{loading ? "Hello" : "World"}</div>
+};
+// ...
+```
+
+#### useToggle
+Simple hook that returns a boolean that can easily be toggled. Useful for loaders, and simple toggle components.
+
+##### Arguments
+
+- **`initialState`**: Boolean. Optional. The intital state of the toggle. Default: `false`.
+
+##### useToggle Usage
+
+```javascript
+import React from 'react';
+import { useToggle } from '@availity/hooks';
+// ...
+const Component = () => {
+    const [isToggled,toggle] = useToggle();
+
+    return <div onClick={toggle}>{isToggled ? 'Hello' : 'World'</div>;
+}
+// ...
+```
+
+#### useEffectAsync
+Hook that will allow asynchronous functions to be called in the standard `useEffect` React hook.
+
+##### Arguments
+
+- **`effect`**: The effect to be called just like the function given to `useEffect`.
+- **`inputs`**: The watch params for the effect just like the second arg in `useEffect`.
+
+##### useEffectAsync Usage
+
+```javascript
+import React, { useState } from 'react';
+import { useEffectAsync } from '@availity/hooks';
+// ...
+const Component = ({asyncFunction}) => {
+    const [state, setState] = useState('Hello');
+    useEffectAsync(async () => {
+        const newState = await asyncFunction();
+
+        setState(newState);
+    },[]);
+
+    return <div>{state}</div>
+};
+// ...
+```

--- a/packages/hooks/index.d.ts
+++ b/packages/hooks/index.d.ts
@@ -1,0 +1,5 @@
+import useEffectAsync from './FeeuseEffectAsyncdback';
+import useToggle from './useToggle';
+
+
+export { useEffectAsync, useToggle };

--- a/packages/hooks/index.js
+++ b/packages/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useToggle } from './useToggle';
+export { default as useEffectAsync } from './useEffectAsync';

--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -1,0 +1,164 @@
+{
+	"name": "@availity/hooks",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.3.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.3.1.tgz",
+			"integrity": "sha1-V0sD6OipiY6vSocqkuogt4Rvbyo=",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.12.0"
+			}
+		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+			"integrity": "sha1-gBPyr1Sit9c19xVg/zYNOoF2qHs=",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "4.0.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.0.0.tgz",
+			"integrity": "sha1-cN55Ht8CFATD/WFaqJEYrgQy5ak=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"dom-testing-library": {
+			"version": "3.16.8",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/dom-testing-library/-/dom-testing-library-3.16.8.tgz",
+			"integrity": "sha1-JlSbJJ8TGiXkM56+yfyqLnZCUn8=",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.1.5",
+				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"pretty-format": "^24.0.0",
+				"wait-for-expect": "^1.1.0"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"pretty-format": {
+			"version": "24.0.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-24.0.0.tgz",
+			"integrity": "sha1-y2WZ/XOsCI437WgvYSkeRnj0hZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0"
+			}
+		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
+		"react": {
+			"version": "16.8.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/react/-/react-16.8.2.tgz",
+			"integrity": "sha1-gwZFlv6qmNnChXxN6uGEi1QsnAw=",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.13.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.8.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/react-dom/-/react-dom-16.8.2.tgz",
+			"integrity": "sha1-fIppVF3VVNRdZkQiMLoEpqCjw9M=",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.13.2"
+			}
+		},
+		"react-is": {
+			"version": "16.8.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/react-is/-/react-is-16.8.2.tgz",
+			"integrity": "sha1-CYkdMkytHLDB8tkfcKcaS+403w8="
+		},
+		"react-testing-library": {
+			"version": "5.9.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/react-testing-library/-/react-testing-library-5.9.0.tgz",
+			"integrity": "sha1-4cilhtLyy9XwA1R0ypAlju8f7OY=",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"dom-testing-library": "^3.13.1"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha1-+hpxVEdkwDb4xJsToIsllMn4oN4=",
+			"dev": true
+		},
+		"scheduler": {
+			"version": "0.13.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/scheduler/-/scheduler-0.13.2.tgz",
+			"integrity": "sha1-lp6u4nZKUdLpeyCmCWOyVGvv+Po=",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"wait-for-expect": {
+			"version": "1.1.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/wait-for-expect/-/wait-for-expect-1.1.0.tgz",
+			"integrity": "sha1-Zgc3XD950yrdNc0sh84T81Gj1FM=",
+			"dev": true
+		}
+	}
+}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@availity/hooks",
+  "version": "1.0.0",
+  "author": "Kyle Gray <kyle.gray@availity.com>",
+  "description": "A group of pre-built hooks that are common in most apps",
+  "main": "index.js",
+  "keywords": [
+    "react",
+    "availity"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "react-testing-library": "^5.4.4"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  }
+}

--- a/packages/hooks/tests/useEffectAsync.test.js
+++ b/packages/hooks/tests/useEffectAsync.test.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { render, waitForElement, act } from 'react-testing-library';
+import { useEffectAsync } from '..';
+import 'react-testing-library/cleanup-after-each';
+
+// eslint-disable-next-line react/prop-types
+const Component = ({ asyncFunc }) => {
+  const [state, setState] = useState('Hello');
+
+  useEffectAsync(async () => {
+    const newState = await asyncFunc();
+
+    act(() => setState(newState));
+  }, []);
+
+  return <div data-testid="effect-test">{state}</div>;
+};
+
+describe('useEffectAsync', () => {
+  test('should render "Hello" then "World"', async () => {
+    // Create Async Method
+    const asyncFunc = () => Promise.resolve('World');
+    // Render
+    const { getByTestId } = render(<Component asyncFunc={asyncFunc} />);
+
+    // Expect the component to render "Hello"
+    expect(getByTestId('effect-test').textContent).toEqual('Hello');
+
+    // Wait for the Async Function to be called after mounting
+    await waitForElement(() => getByTestId('effect-test'));
+
+    // Expect the component to render "World"
+    expect(getByTestId('effect-test').textContent).toEqual('World');
+  });
+});

--- a/packages/hooks/tests/useToggle.test.js
+++ b/packages/hooks/tests/useToggle.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent } from 'react-testing-library';
+import { useToggle } from '..';
+import 'react-testing-library/cleanup-after-each';
+
+// eslint-disable-next-line react/prop-types
+const Component = ({ initialToggle = false }) => {
+  const [isToggled, toggle] = useToggle(initialToggle);
+
+  return (
+    <button type="button" data-testid="toggle-test" onClick={toggle}>
+      {isToggled ? 'Hello' : 'World'}
+    </button>
+  );
+};
+
+describe('useToggle', () => {
+  test('should render "Hello"', () => {
+    const { getByTestId } = render(<Component />);
+
+    expect(getByTestId('toggle-test').textContent).toEqual('World');
+  });
+
+  test('should render "World"', () => {
+    const { getByTestId } = render(<Component initialToggle />);
+
+    expect(getByTestId('toggle-test').textContent).toEqual('Hello');
+  });
+
+  test('should toggle the state when clicked', () => {
+    const { getByTestId } = render(<Component />);
+
+    const button = getByTestId('toggle-test');
+
+    expect(button.textContent).toEqual('World');
+
+    fireEvent.click(button);
+
+    expect(getByTestId('toggle-test').textContent).toEqual('Hello');
+  });
+});

--- a/packages/hooks/useEffectAsync.d.ts
+++ b/packages/hooks/useEffectAsync.d.ts
@@ -1,0 +1,3 @@
+declare const useEffectAsync: Function;
+
+export default useEffectAsync;

--- a/packages/hooks/useEffectAsync.js
+++ b/packages/hooks/useEffectAsync.js
@@ -1,0 +1,7 @@
+import { useEffect } from 'react';
+
+export default function useEffectAsync(effect, inputs) {
+  useEffect(() => {
+    effect();
+  }, inputs);
+}

--- a/packages/hooks/useToggle.d.ts
+++ b/packages/hooks/useToggle.d.ts
@@ -1,0 +1,3 @@
+declare const useToggle: Function;
+
+export default useToggle;

--- a/packages/hooks/useToggle.js
+++ b/packages/hooks/useToggle.js
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+export default function(initialState = false) {
+  const [state, setState] = useState(initialState);
+  const toggle = () => setState(state => !state);
+
+  return [state, toggle];
+}


### PR DESCRIPTION
Created some simple hooks that are going to be re-used across projects. There are already a number of libraries out there right now with a bunch of hooks but its still too early to pick one as they are all volatile. 

Eventually we can implement an external hooks library but for now there are only a very small amount that we need and will minimize the bundle footprint since a lot of these other libs are 10kb+.

Once this or another lib is accepted the other components in the library can easily be migrated to hooks due to the minor version bump of React 16.