### PR TITLE
fix(docs): static file path was not being pulled correctly

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
 	"main": "index.js",
 	"scripts": {
 		"start": "start-storybook -p 2222 -c .storybook -s ./static",
-		"build": "build-storybook -c .storybook -o ../../docs",
+		"build": "build-storybook -c .storybook -s ./static -o ../../docs",
 		"deploy-docs": "storybook-to-ghpages",
 		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook"


### PR DESCRIPTION
The `payer-logo` component pulls static url's for the logos in which they are not present in the build folder due to the exclusion of the `./static` folder.