### PR TITLE
fix(breadcrumbs): removed prop validation for breadcrumb item type

### DIFF
--- a/packages/breadcrumbs/Breadcrumbs.js
+++ b/packages/breadcrumbs/Breadcrumbs.js
@@ -48,43 +48,7 @@ Breadcrumbs.propTypes = {
   ),
   active: PropTypes.string.isRequired,
   emptyState: PropTypes.string,
-  children: (props, propName, componentName) => {
-    if (!props.children) {
-      return null;
-    }
-    let error = null;
-
-    // multi children
-    if (Array.isArray(props.children)) {
-      props.children.forEach(nextChild => {
-        if (nextChild.type.name !== 'BreadcrumbItem') {
-          error = new Error(
-            `${componentName} children should be of type BreadcrumbItem`
-          );
-        }
-      });
-    }
-    // single child
-    else if (props.children.type) {
-      if (props.children.type.name !== 'BreadcrumbItem') {
-        error = new Error(
-          `${componentName} children should be of type BreadcrumbItem`
-        );
-      }
-    }
-    // ??? this happens in certain react tree implementations
-    else {
-      const prop = props[propName];
-      React.Children.forEach(prop, child => {
-        if (child.type !== BreadcrumbItem) {
-          error = new Error(
-            `${componentName} children should be of type BreadCrumbItem`
-          );
-        }
-      });
-    }
-    return error;
-  },
+  children: PropTypes.node,
 };
 
 Breadcrumbs.defaultProps = {

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -28,7 +28,7 @@ const PageHeader = ({
   return (
     <React.Fragment>
       <div className="d-flex align-items-start">
-        {crumbs && crumbs.type === Breadcrumbs ? (
+        {React.isValidElement(crumbs) ? (
           crumbs
         ) : (
           <Breadcrumbs crumbs={crumbs} active={appName || children} />


### PR DESCRIPTION
The prop validation for breadcrumb item type was causing some headaches. In some scenarios with `react-hot-loader` the `type.name` of the component changes to `ProxyFacade` and you can revert to the displayName but that is also a changeable feature. 