### PR TITLE
Pagination/addons

### DIFF
--- a/packages/docs/stories/pagination.stories.js
+++ b/packages/docs/stories/pagination.stories.js
@@ -74,6 +74,9 @@ storiesOf('Components|Pagination', module)
         </Col>
         <PaginationControls
           className="pt-2"
+          pageRange={number('Page Range', 5, { min: 1 }) || 1}
+          breakLabel={boolean('Break Label', true)}
+          marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
           directionLinks={boolean('Direction Links', true)}
           autoHide={boolean('Auto Hide Controls', true)}
         />
@@ -103,6 +106,9 @@ storiesOf('Components|Pagination', module)
         </Col>
         <PaginationControls
           className="pt-2"
+          pageRange={number('Page Range', 5, { min: 1 }) || 1}
+          breakLabel={boolean('Break Label', true)}
+          marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
           directionLinks={boolean('Direction Links', true)}
         />
       </div>

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -52,7 +52,8 @@ This is the controls for the pagination, with the page selector and optionally v
 
 - **`directionLinks`**: boolean. default `false`. If enabled, will show next and previous arrows on the controls
 - **`autoHide`**: boolean. default `true`. If enabled and there are no items, the component will be hidden.
-
+- **`pageRange`**: number. default 5. The number of pages to display at a time.
+- **`marginPages`**: number. default 2. The number of pages you want to display on the ends when there are more pages than the page range.
 #### Example usage
 
 ```javascript

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -28,7 +28,7 @@ This is the provider component for pagination to work. All the inner components 
 
 - **`items`**: Array or Function, required. If Array, defaults `totalCount` to length of array, and pages values are sliced from the Array. If a function, will call it with the current page as an argument and expected to return an array of items.
 - **`itemsPerPage`**: number. default `10`. The total amount of items to render at a time. ( After all the filtering )
-
+- **`onPageChange`**: function. optional. When the user changes the page, this will be called after the new page has been set.
 
 
 #### Example usage

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -19,7 +19,12 @@ export const usePagination = () => useContext(PaginationContext);
  * @param {Function|Object} items - The Items or function to use for pagination
  * @param {number} itemsPerPage - The items to show per page
  */
-const Pagination = ({ items: theItems, itemsPerPage, children }) => {
+const Pagination = ({
+  items: theItems,
+  itemsPerPage,
+  onPageChange,
+  children,
+}) => {
   const [currentPage, setPage] = useState(1);
   const [pageData, setPageData] = useState({
     total: theItems != null && !isFunction(theItems) ? theItems.totalCount : 0,
@@ -79,6 +84,10 @@ const Pagination = ({ items: theItems, itemsPerPage, children }) => {
   const updatePage = page => {
     toggleLoading(true);
     setPage(page);
+
+    if (onPageChange) {
+      onPageChange(page);
+    }
   };
 
   // boom roasted
@@ -99,6 +108,7 @@ const Pagination = ({ items: theItems, itemsPerPage, children }) => {
 Pagination.propTypes = {
   items: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
   itemsPerPage: PropTypes.number,
+  onPageChange: PropTypes.func,
   children: PropTypes.node,
 };
 

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -45,7 +45,7 @@ const PaginationControls = ({
   const createBreak = index => (
     <PaginationItem key={index} data-testid={`control-page-${index}`}>
       <PaginationLink onClick={() => handleBreakClick(index)} type="button">
-        ...
+        &hellip;
       </PaginationLink>
     </PaginationItem>
   );

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -1,10 +1,98 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable guard-for-in */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 import { usePagination } from './Pagination';
 
-const PaginationControls = ({ directionLinks, autoHide, ...rest }) => {
+const PaginationControls = ({
+  directionLinks,
+  autoHide,
+  pageRange,
+  marginPages,
+  ...rest
+}) => {
   const { pages, currentPage, setPage } = usePagination();
+  const pageCount = pages.length;
+
+  const createItem = pageNumber => (
+    <PaginationItem
+      key={pageNumber}
+      active={currentPage === pageNumber}
+      data-testid={`control-page-${pageNumber}`}
+    >
+      <PaginationLink onClick={() => setPage(pageNumber)} type="button">
+        {pageNumber}
+      </PaginationLink>
+    </PaginationItem>
+  );
+
+  const getForwardJump = () => {
+    const forwardJump = currentPage + pageRange;
+    return forwardJump >= pageCount ? pageCount : forwardJump;
+  };
+
+  const getBackwardJump = () => {
+    const backwardJump = currentPage - pageRange;
+
+    return backwardJump < 1 ? 1 : backwardJump;
+  };
+
+  const handleBreakClick = index => {
+    setPage(currentPage < index ? getForwardJump() : getBackwardJump());
+  };
+
+  const createBreak = index => (
+    <PaginationItem key={index} data-testid={`control-page-${index}`}>
+      <PaginationLink onClick={() => handleBreakClick(index)} type="button">
+        ...
+      </PaginationLink>
+    </PaginationItem>
+  );
+
+  // Todo - Look into creating a PR for allowing custom components in the below repo
+  // https://github.com/AdeleD/react-paginate/blob/master/react_components/PaginationBoxView.js#L216
+  const paginate = () => {
+    const items = [];
+    const selected = currentPage - 1;
+
+    if (pageCount <= pageRange) {
+      for (let index = 0; index < pageCount; index++) {
+        items.push(createItem(index + 1));
+      }
+    } else {
+      let leftSide = pageRange / 2;
+      let rightSide = pageRange - leftSide;
+
+      if (selected > pageCount - leftSide) {
+        rightSide = pageCount - selected;
+        leftSide = pageRange - rightSide;
+      } else if (selected < leftSide) {
+        leftSide = selected;
+        rightSide = pageRange - leftSide;
+      }
+
+      let breakView;
+
+      pages.forEach((pageNumber, index) => {
+        if (
+          pageNumber <= marginPages ||
+          pageNumber > pageCount - marginPages ||
+          (index >= selected - leftSide && index <= selected + rightSide)
+        ) {
+          items.push(createItem(pageNumber));
+          return;
+        }
+
+        if (items[items.length - 1] !== breakView) {
+          breakView = createBreak(pageNumber);
+          items.push(breakView);
+        }
+      });
+    }
+
+    return items;
+  };
 
   return (
     <React.Fragment>
@@ -26,26 +114,16 @@ const PaginationControls = ({ directionLinks, autoHide, ...rest }) => {
           ) : (
             ''
           )}
-          {pages.map(pageNumber => (
-            <PaginationItem
-              key={pageNumber}
-              active={currentPage === pageNumber}
-              data-testid={`control-page-${pageNumber}`}
-            >
-              <PaginationLink onClick={() => setPage(pageNumber)} type="button">
-                {pageNumber}
-              </PaginationLink>
-            </PaginationItem>
-          ))}
+          {paginate()}
           {directionLinks ? (
             <PaginationItem
-              disabled={currentPage === pages.length}
+              disabled={currentPage === pageCount}
               data-testid="pagination-control-next"
             >
               <PaginationLink
                 data-testid="pagination-control-next-link"
                 onClick={() =>
-                  currentPage === pages.length ? null : setPage(currentPage + 1)
+                  currentPage === pageCount ? null : setPage(currentPage + 1)
                 }
                 type="button"
                 next
@@ -65,10 +143,14 @@ const PaginationControls = ({ directionLinks, autoHide, ...rest }) => {
 PaginationControls.propTypes = {
   directionLinks: PropTypes.bool,
   autoHide: PropTypes.bool, // If there are no items to show. This component will not show
+  pageRange: PropTypes.number,
+  marginPages: PropTypes.number,
 };
 
 PaginationControls.defaultProps = {
   directionLinks: false,
   autoHide: true,
+  pageRange: 5,
+  marginPages: 2,
 };
 export default PaginationControls;

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -114,4 +114,47 @@ describe('Pagination', () => {
       })
     );
   });
+
+  test('should call onPageChange when page changes', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+    ];
+
+    const mockOnPageChange = jest.fn(page => page);
+
+    const { getByTestId } = render(
+      <Pagination
+        onPageChange={mockOnPageChange}
+        items={items}
+        itemsPerPage={1}
+      >
+        <PaginationJson />
+        <PaginationControls directionLinks />
+      </Pagination>
+    );
+
+    let paginationCon = await waitForElement(() =>
+      getByTestId('pagination-con')
+    );
+
+    expect(paginationCon).toBeDefined();
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: [items[0]],
+      })
+    );
+
+    fireEvent.click(getByTestId('pagination-control-next-link'));
+
+    // Wait for component to render nothing
+    waitForDomChange(() => getByTestId('pagination-con'));
+
+    // Get the component now with the new page data
+    paginationCon = await waitForElement(() => getByTestId('pagination-con'));
+
+    expect(mockOnPageChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -65,4 +65,35 @@ describe('Pagination Controls', () => {
 
     expect(paginationControls).not.toBe(null);
   });
+
+  test('should only show first 2 pages', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={2} marginPages={1} directionLinks />
+      </Pagination>
+    );
+
+    const paginationControls = await waitForElement(() =>
+      getByTestId('pagination-controls-con')
+    );
+
+    expect(paginationControls).not.toBe(null);
+
+    expect(getByTestId('pagination-control-previous')).toBeDefined();
+    expect(getByTestId('pagination-control-next')).toBeDefined();
+
+    const breakLine = getByTestId('control-page-4');
+
+    expect(breakLine.firstChild.textContent).toBe('...');
+
+    expect(breakLine.nextSibling.firstChild.textContent).toBe('5');
+  });
 });

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -92,7 +92,7 @@ describe('Pagination Controls', () => {
 
     const breakLine = getByTestId('control-page-4');
 
-    expect(breakLine.firstChild.textContent).toBe('...');
+    expect(breakLine.firstChild.textContent.charCodeAt(0)).toBe(8230);
 
     expect(breakLine.nextSibling.firstChild.textContent).toBe('5');
   });

--- a/packages/pagination/types/Pagination.d.ts
+++ b/packages/pagination/types/Pagination.d.ts
@@ -2,6 +2,7 @@ export interface PaginationProps {
     items: Array<Object> | Function;
     itemsPerPage?: number;
     children?: React.ReactType;
+    onPageChange?: Function;
 }
 
 declare const Pagination: React.FunctionComponent<PaginationProps>;

--- a/packages/pagination/types/PaginationControls.d.ts
+++ b/packages/pagination/types/PaginationControls.d.ts
@@ -1,6 +1,8 @@
 export interface PaginationControlsProps {
     directionLinks?: Boolean;
     autoHide?: Boolean;
+    marginPages?: number;
+    pageRange?: number;
 }
 
 declare const PaginationControls: React.FunctionComponent<PaginationControlsProps>;


### PR DESCRIPTION
[Inspiration](https://github.com/AdeleD/react-paginate)

They have a similar library here but there would have to be a significant PR there in order to get the desired results we want with hooks. I plan on looking into this in the future but for now I have added similar logic.

Features:
- onPageChange callback for `Pagination` Provider
- Margin Pages & Page Ranges for `PaginationControls`

![screen shot 2019-03-05 at 10 47 20 am](https://user-images.githubusercontent.com/14143881/53817724-239f4300-3f34-11e9-8865-fafc587dcb1e.png)
