### PR TITLE
refactor(pagination): added aria attrs and container props

### DIFF
--- a/packages/pagination/src/PaginationContent.js
+++ b/packages/pagination/src/PaginationContent.js
@@ -11,6 +11,7 @@ const PaginationContent = ({
   itemKey,
   loader,
   containerTag,
+  containerProps,
   ...rest
 }) => {
   const { page, loading } = usePagination();
@@ -18,7 +19,9 @@ const PaginationContent = ({
   return (
     <BlockUI
       data-testid="pagination-content-con"
+      role={containerProps.role || 'list'}
       keepInView
+      {...containerProps}
       tag={containerTag}
       blocking={loader && loading}
       message={loadingMessage}
@@ -44,12 +47,14 @@ PaginationContent.propTypes = {
   loadingMessage: PropTypes.node,
   itemKey: PropTypes.string,
   loader: PropTypes.bool,
+  containerProps: PropTypes.object,
   containerTag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 PaginationContent.defaultProps = {
   loader: false,
   containerTag: 'div',
+  containerProps: {},
 };
 
 export default PaginationContent;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -18,6 +18,8 @@ const PaginationControls = ({
     <PaginationItem
       key={pageNumber}
       active={currentPage === pageNumber}
+      aria-label={`Page ${pageNumber}`}
+      aria-current={currentPage === pageNumber}
       data-testid={`control-page-${pageNumber}`}
     >
       <PaginationLink onClick={() => setPage(pageNumber)} type="button">

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -74,9 +74,8 @@ const PaginationControls = ({
       }
 
       let breakView;
-      let index;
       let pageNumber;
-      for (index = 0; index < pageCount; index++) {
+      for (let index = 0; index < pageCount; index++) {
         pageNumber = index + 1;
         if (
           pageNumber <= marginPages ||


### PR DESCRIPTION
PaginationContent:
- Added containerProps for passing additional props to the container. Kept the `containerTag` prop so we can keep as a minor change.

PaginationControls:
- Added `aria-label` to announce control as `Page 1` rather than `Item 1, Button`.
- Added `aria-current` to announce the selected page as the active one.