### PR TITLE
chore(docs): trying to increase performance on the doc builds

### DIFF
--- a/packages/docs/.storybook/webpack.config.js
+++ b/packages/docs/.storybook/webpack.config.js
@@ -31,20 +31,7 @@ module.exports = ({ config: defaultConfig }) => {
     enforce: 'pre',
   });
 
-  defaultConfig.module.rules.push({
-    test: /\.(ts|tsx)$/,
-    use: ['awesome-typescript-loader', 'react-docgen-typescript-loader'],
-    enforce: 'pre',
-  });
-
-  defaultConfig.resolve.extensions = [
-    '.js',
-    '.jsx',
-    '.ts',
-    '.tsx',
-    '.scss',
-    '.css',
-  ];
+  defaultConfig.resolve.extensions = ['.js', '.jsx', '.scss', '.css'];
   defaultConfig.resolve.alias['axios'] = path.resolve(
     path.join(__dirname, '../node_modules', 'axios')
   );

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
 	"main": "index.js",
 	"scripts": {
 		"start": "start-storybook -p 2222 -c .storybook -s ./static",
-		"build": "build-storybook -c .storybook -s ./static -o ../../docs",
+		"build": "build-storybook -c .storybook -s ./static -o ../../docs --quiet",
 		"deploy-docs": "storybook-to-ghpages",
 		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook"


### PR DESCRIPTION
Looks like turning the debug logs for the build to off decreased the build time by 30 seconds and also removing the ts loaders helped some as well.