### PR TITLE
feat(app-icon): added image src and alt properties to app-icon

### DIFF
--- a/packages/app-icon/AppIcon.d.ts
+++ b/packages/app-icon/AppIcon.d.ts
@@ -4,6 +4,8 @@ export interface AppIconProps {
     size?: string;
     branded?: boolean;
     className?: string;
+    src?: string;
+    alt?: string;
     children?: any;
 }
 

--- a/packages/app-icon/AppIcon.js
+++ b/packages/app-icon/AppIcon.js
@@ -5,6 +5,8 @@ function AppIcon({
   tag: Tag,
   color,
   size,
+  src: image,
+  alt,
   branded,
   className,
   children,
@@ -15,13 +17,18 @@ function AppIcon({
     'app-icon',
     branded ? `app-icon-branded-${color}` : `app-icon-${color}`,
     size && `app-icon-${size}`,
+    image && 'border-0',
   ]
     .filter(a => a)
     .join(' ');
 
   return (
     <Tag {...props} className={classname}>
-      {children}
+      {image ? (
+        <img className="w-100 h-100 align-baseline" src={image} alt={alt} />
+      ) : (
+        children
+      )}
       {branded && <span className="caret" />}
     </Tag>
   );
@@ -34,6 +41,18 @@ AppIcon.propTypes = {
   className: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
+  src: PropTypes.string,
+  alt: (props, propName) => {
+    if (
+      (props.src !== undefined &&
+        props.src !== null &&
+        props[propName] === undefined) ||
+      props[propName] === null
+    ) {
+      return new Error('AppIcon requires and alt property for image src.');
+    }
+    return null;
+  },
 };
 
 AppIcon.defaultProps = {

--- a/packages/app-icon/README.md
+++ b/packages/app-icon/README.md
@@ -28,6 +28,8 @@ A component which outputs one of the "App Icons" from [Availity UI Kit](http://a
 - **`size`**: string, optional. Potential values: `"lg"`, `"xl"`
 - **`color`**: string, optional. Potential values: `"black"`, `"blue"`, `"green"`, `"orange"`. Default value: `"black"`
 - **`branded`**: boolean, optional. Triggers "branded" styles.
+- **`src`**: string, optional. If image source is provided will render this instead of children.
+- **`alt`**: string, required for `src` prop. the alt property for your image source
 - All other props will be passed through; `className` will be merged.
 
 ##### Usage

--- a/packages/app-icon/tests/AppIcon.test.js
+++ b/packages/app-icon/tests/AppIcon.test.js
@@ -59,4 +59,12 @@ describe('AppIcon', () => {
     expect(container.firstChild.tagName.toLowerCase()).toEqual('i');
     expect(container).toMatchSnapshot();
   });
+
+  test('should render with image', () => {
+    const { container } = render(
+      <AppIcon src="/path-to-some-image" alt="icon" />
+    );
+    const image = container.querySelectorAll('img')[0];
+    expect(image.src).toEqual('http://localhost/path-to-some-image');
+  });
 });

--- a/packages/docs/stories/app-icon.stories.js
+++ b/packages/docs/stories/app-icon.stories.js
@@ -38,6 +38,8 @@ storiesOf('Icons|App', module)
       )}
       branded={boolean('Branded', false)}
       className={text('ClassName')}
+      src={text('Image')}
+      alt={text('alt')}
     >
       {text('Application Abbreviation', 'AI')}
     </AppIcon>

--- a/packages/docs/stories/page-header.stories.js
+++ b/packages/docs/stories/page-header.stories.js
@@ -46,6 +46,8 @@ storiesOf('Page|Header', module)
         },
         'black'
       )}
+      iconSrc={text('AppIcon Image')}
+      iconAlt={text('AppIcon Alt')}
     >
       {text('Application Name', 'Payer Space')}
     </PageHeader>

--- a/packages/page-header/PageHeader.d.ts
+++ b/packages/page-header/PageHeader.d.ts
@@ -15,6 +15,8 @@ export interface PageHeaderProps {
     feedback?: boolean;
     children?: React.ReactType;
     crumbs?: Array<CrumbType> | React.ReactType;
+    iconSrc?: string;
+    iconAlt?: string;
     clientId?: string;
 }
 

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -19,6 +19,8 @@ const PageHeader = ({
   component,
   tag: Tag,
   clientId,
+  iconSrc,
+  iconAlt,
   ...props
 }) => {
   if (spaceId || spaceName) {
@@ -39,7 +41,13 @@ const PageHeader = ({
       <Tag className="page-header page-header-brand" {...props}>
         <div className="page-header-title">
           {!payerId && appAbbr && (
-            <AppIcon color={iconColor} branded={branded} title={appName}>
+            <AppIcon
+              color={iconColor}
+              branded={branded}
+              title={appName}
+              src={iconSrc}
+              alt={iconAlt}
+            >
               {appAbbr}
             </AppIcon>
           )}{' '}
@@ -86,6 +94,8 @@ PageHeader.propTypes = {
   ]),
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   clientId: PropTypes.string,
+  iconSrc: PropTypes.string,
+  iconAlt: PropTypes.string,
 };
 
 PageHeader.defaultProps = {

--- a/packages/page-header/README.md
+++ b/packages/page-header/README.md
@@ -35,6 +35,8 @@ The standard Availity application header which appears at the top of the page. I
 - **`crumbs`**: Array(Object) or [BreadCrumbs](../breadcrumbs/README.md) . Optional. Array of Objects contains `name` (String) and `url` (string) properties. Optional. The ancestor pages which gets passed to the `Breadcrumbs` component. See the children props sections of the @availity/Breadcrumbs documentation
 - **`component`**: Component. Optional. Allow rendering of an optional component in the top right of the header.
 - **`clientId`**: String. Optional. client id to use in [PayerLogo](../payer-logo/README.md)
+- **`iconSrc`**: String. Optional. Image source for `AppIcon` instead of `appAbbr`
+-**`iconAlt`**: String. Required if `iconSrc`. Image alt property of `AppIcon`
 
 ##### PageHeader Usage
 


### PR DESCRIPTION
In some cases users can use a logo or image for the app icon and still maintain the proper aspect ratios. Added in `src` and `alt` props if you want to display the `AppIcon` as an image.