### PR TITLE
feat(favorites): added export for context

### DIFF
--- a/packages/favorites/FavoritesContext.js
+++ b/packages/favorites/FavoritesContext.js
@@ -23,7 +23,7 @@ const AV_INTERNAL_GLOBALS = {
   MY_TOP_APPS_UPDATED: 'av:topApps:updated',
 };
 
-const FavoritesContext = createContext();
+export const FavoritesContext = createContext();
 
 const avSplunkAnalytics = new AvSplunkAnalytics(AvLogMessages, true);
 

--- a/packages/favorites/index.js
+++ b/packages/favorites/index.js
@@ -1,5 +1,5 @@
 import FavoriteHeart from './FavoriteHeart';
-import Favorites, { useFavorites } from './FavoritesContext';
+import Favorites, { useFavorites, FavoritesContext } from './FavoritesContext';
 
 export default Favorites;
-export { useFavorites, FavoriteHeart };
+export { FavoritesContext, useFavorites, FavoriteHeart };


### PR DESCRIPTION
Gives the ability for someone to `useContext(FavoritesContext)` and be able to use all the favorites in a component rather than 1 by 1.

Useful for the nav where we display all of the favorites in the navbar.