### PR TITLE
Feat/page header feedback props

### DIFF
--- a/packages/docs/stories/feedback.stories.js
+++ b/packages/docs/stories/feedback.stories.js
@@ -31,6 +31,7 @@ storiesOf('Actions|Feedback', module)
               { label: 'News and Announcements', value: 'news' },
             ]
           : [],
+        staticFields: [{ name: 'staticFields1', value: 'my-static-value' }],
       }}
       color={select(
         'Button Color',

--- a/packages/docs/stories/feedback.stories.js
+++ b/packages/docs/stories/feedback.stories.js
@@ -31,7 +31,7 @@ storiesOf('Actions|Feedback', module)
               { label: 'News and Announcements', value: 'news' },
             ]
           : [],
-        staticFields: [{ name: 'staticFields1', value: 'my-static-value' }],
+        staticFields: { staticKey: 'my-static-value' },
       }}
       color={select(
         'Button Color',

--- a/packages/feedback/FeedbackForm.d.ts
+++ b/packages/feedback/FeedbackForm.d.ts
@@ -14,6 +14,7 @@ export interface FeedBackFormProps {
     faceOptions?: Array<FaceOption>;
     aboutOptions?: Array<AboutOption>;
     prompt?: string;
+    staticFields?: object;
 }
 
 declare const FeedBackForm: React.FunctionComponent<FeedBackFormProps>;

--- a/packages/feedback/FeedbackForm.js
+++ b/packages/feedback/FeedbackForm.js
@@ -21,6 +21,7 @@ const FeedbackForm = ({
   onFeedbackSent,
   prompt,
   additionalComments,
+  staticFields,
 }) => {
   const [active, setActive] = useState(null);
   const [invalid, toggleInvalid] = useToggle(false);
@@ -147,6 +148,17 @@ const FeedbackForm = ({
                   }}
                 />
               )}
+              {staticFields.map(staticField => (
+                <AvField
+                  data-testid={`feedback-static-field-${staticField.name}`}
+                  type="text"
+                  key={staticField.name}
+                  name={staticField.name}
+                  value={staticField.value}
+                  validate={{}}
+                  hidden
+                />
+              ))}
             </React.Fragment>
           ) : null}
         </ModalBody>
@@ -185,6 +197,9 @@ FeedbackForm.propTypes = {
   onClose: PropTypes.func,
   prompt: PropTypes.string,
   additionalComments: PropTypes.bool,
+  staticFields: PropTypes.arrayOf(
+    PropTypes.shape({ name: PropTypes.string, value: PropTypes.string })
+  ),
 };
 
 FeedbackForm.defaultProps = {
@@ -207,6 +222,7 @@ FeedbackForm.defaultProps = {
   ],
   aboutOptions: [],
   additionalComments: false,
+  staticFields: [],
 };
 
 export default FeedbackForm;

--- a/packages/feedback/FeedbackForm.js
+++ b/packages/feedback/FeedbackForm.js
@@ -43,6 +43,7 @@ const FeedbackForm = ({
       userAgent: window.navigator.userAgent,
       submitTime: new Date(),
       ...values, // Spread the form values onto the logger
+      ...staticFields, // Spread the static key value pairs onto the logger
     });
 
     setSent(values);
@@ -148,17 +149,6 @@ const FeedbackForm = ({
                   }}
                 />
               )}
-              {staticFields.map(staticField => (
-                <AvField
-                  data-testid={`feedback-static-field-${staticField.name}`}
-                  type="text"
-                  key={staticField.name}
-                  name={staticField.name}
-                  value={staticField.value}
-                  validate={{}}
-                  hidden
-                />
-              ))}
             </React.Fragment>
           ) : null}
         </ModalBody>
@@ -197,9 +187,7 @@ FeedbackForm.propTypes = {
   onClose: PropTypes.func,
   prompt: PropTypes.string,
   additionalComments: PropTypes.bool,
-  staticFields: PropTypes.arrayOf(
-    PropTypes.shape({ name: PropTypes.string, value: PropTypes.string })
-  ),
+  staticFields: PropTypes.object,
 };
 
 FeedbackForm.defaultProps = {
@@ -222,7 +210,6 @@ FeedbackForm.defaultProps = {
   ],
   aboutOptions: [],
   additionalComments: false,
-  staticFields: [],
 };
 
 export default FeedbackForm;

--- a/packages/feedback/README.md
+++ b/packages/feedback/README.md
@@ -63,7 +63,7 @@ This is the underlying form which is exposed in case you need to gather feedback
 - **`prompt`**: String. Optional. Text which prompts/asks the user to provide feedback. Default: `"Tell us what you think about ${appName}."`
 - **`onFeedbackSent`**: Function. Optional. Callback for when the feedback is submitted. It will be called with the feedback object.
 - **`additionalComments`**: Boolean. Default `false`. If `true` will show and optional comments field below.
-- **`staticFields`**: Array of Objects containing **`name`** and **`value`**. Optional. Renders hidden form inputs to DOM. Allows non-user-selected values to be sent when feedback is submitted.
+- **`staticFields`**: Object. Optional. Static (non-user-entered) key/value pairs to be sent in feedback submission
 
 ##### Usage
 

--- a/packages/feedback/README.md
+++ b/packages/feedback/README.md
@@ -63,6 +63,7 @@ This is the underlying form which is exposed in case you need to gather feedback
 - **`prompt`**: String. Optional. Text which prompts/asks the user to provide feedback. Default: `"Tell us what you think about ${appName}."`
 - **`onFeedbackSent`**: Function. Optional. Callback for when the feedback is submitted. It will be called with the feedback object.
 - **`additionalComments`**: Boolean. Default `false`. If `true` will show and optional comments field below.
+- **`staticFields`**: Array of Objects containing **`name`** and **`value`**. Optional. Renders hidden form inputs to DOM. Allows non-user-selected values to be sent when feedback is submitted.
 
 ##### Usage
 

--- a/packages/feedback/tests/FeedbackForm.test.js
+++ b/packages/feedback/tests/FeedbackForm.test.js
@@ -156,4 +156,21 @@ describe('FeedbackForm', () => {
       getByPlaceholderText('Additional Comments... (Optional)')
     ).toBeDefined();
   });
+
+  test('should render static fields', () => {
+    const { getByText, getByTestId } = render(
+      <FeedbackForm
+        name="Payer Space"
+        staticFields={[{ name: 'myStaticField', value: 'myStaticFieldValue' }]}
+      />
+    );
+
+    fireEvent.click(getByText('Smiley face'));
+
+    const staticFieldInput = getByTestId('feedback-static-field-myStaticField');
+
+    expect(staticFieldInput).toBeDefined();
+    expect(staticFieldInput.getAttribute('hidden')).toBe('');
+    expect(staticFieldInput.getAttribute('value')).toBe('myStaticFieldValue');
+  });
 });

--- a/packages/feedback/tests/FeedbackForm.test.js
+++ b/packages/feedback/tests/FeedbackForm.test.js
@@ -156,21 +156,4 @@ describe('FeedbackForm', () => {
       getByPlaceholderText('Additional Comments... (Optional)')
     ).toBeDefined();
   });
-
-  test('should render static fields', () => {
-    const { getByText, getByTestId } = render(
-      <FeedbackForm
-        name="Payer Space"
-        staticFields={[{ name: 'myStaticField', value: 'myStaticFieldValue' }]}
-      />
-    );
-
-    fireEvent.click(getByText('Smiley face'));
-
-    const staticFieldInput = getByTestId('feedback-static-field-myStaticField');
-
-    expect(staticFieldInput).toBeDefined();
-    expect(staticFieldInput.getAttribute('hidden')).toBe('');
-    expect(staticFieldInput.getAttribute('value')).toBe('myStaticFieldValue');
-  });
 });

--- a/packages/page-header/PageHeader.d.ts
+++ b/packages/page-header/PageHeader.d.ts
@@ -13,6 +13,7 @@ export interface PageHeaderProps {
     payerId?: string;
     component?: React.ReactType;
     feedback?: boolean;
+    feedbackProps?: any;
     children?: React.ReactType;
     crumbs?: Array<CrumbType> | React.ReactType;
     iconSrc?: string;

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -16,6 +16,7 @@ const PageHeader = ({
   branded,
   crumbs,
   feedback,
+  feedbackProps,
   component,
   tag: Tag,
   clientId,
@@ -65,6 +66,7 @@ const PageHeader = ({
           <Feedback
             appName={appName}
             className={`float-md-right d-inline-block ${payerId ? 'mx-3' : ''}`}
+            {...feedbackProps}
           />
         )}
       </Tag>
@@ -82,6 +84,7 @@ PageHeader.propTypes = {
   payerId: PropTypes.string,
   component: PropTypes.element,
   feedback: PropTypes.bool,
+  feedbackProps: PropTypes.shape({ ...Feedback.propTypes }),
   children: PropTypes.node,
   crumbs: PropTypes.oneOfType([
     PropTypes.arrayOf(

--- a/packages/page-header/README.md
+++ b/packages/page-header/README.md
@@ -32,6 +32,7 @@ The standard Availity application header which appears at the top of the page. I
 - **`branded`**: String. Optional. Triggers the app icon's "branded" styles. Only used if the app icon should appear.
 - **`payerId`**: String. Optional. The ID of the payer if the application is payer specific. If provided the payer logo will appear and not the app icon.
 - **`feedback`**: Boolean. Optional. If `true` the feedback loop button will appear. Default: `false`.
+- **`feedbackProps`**: See [Feedback](../feedback/README.md). Props to send to `<Feedback />` component
 - **`crumbs`**: Array(Object) or [BreadCrumbs](../breadcrumbs/README.md) . Optional. Array of Objects contains `name` (String) and `url` (string) properties. Optional. The ancestor pages which gets passed to the `Breadcrumbs` component. See the children props sections of the @availity/Breadcrumbs documentation
 - **`component`**: Component. Optional. Allow rendering of an optional component in the top right of the header.
 - **`clientId`**: String. Optional. client id to use in [PayerLogo](../payer-logo/README.md)


### PR DESCRIPTION
- feat(page-header): add feedbackProps prop type
    > makes it possible to leverage all of the `<Feedback />` props inside of the `<PageHeader />` component
- feat(feedback): add staticFields prop to feedback form
    > makes it possible to send static values to feedback submission by spreading key/value pairs to `avLogMessagesApi.info` request