### PR TITLE
Updated Reactstrap

### DIFF
--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -28,10 +28,10 @@
     "react-dom": "^16.8.3",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -73,7 +73,7 @@
 		"react-dom": "^16.8.3",
 		"react-router": "^4.3.1",
 		"react-router-dom": "^4.3.1",
-		"reactstrap": "^7.0.0",
+		"reactstrap": "^8.0.0",
 		"sass-loader": "^7.0.1",
 		"storybook-react-router": "^1.0.2",
 		"storybook-readme": "^5.0.0",

--- a/packages/favorites/package.json
+++ b/packages/favorites/package.json
@@ -35,14 +35,15 @@
     "lodash.max": "^4.0.1",
     "lodash.reduce": "^4.6.0",
     "lodash.sortby": "^4.7.0",
-    "prop-types": "^15.5.8",
-    "reactstrap": "^7.1.0"
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react-dom": "^16.8.3",
+    "reactstrap": "^8.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0",
+    "reactstrap": "^8.0.0 || ^7.1.0"
   }
 }

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -33,11 +33,11 @@
     "axios": "^0.18.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   },
   "peerDependencies": {
     "@availity/api-axios": "^2.0.0",
     "react": "^16.3.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   }
 }

--- a/packages/list-group-item/package.json
+++ b/packages/list-group-item/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8"
@@ -29,6 +29,6 @@
   "devDependencies": {
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   }
 }

--- a/packages/list-group/package.json
+++ b/packages/list-group/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8"
@@ -29,6 +29,6 @@
   "devDependencies": {
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   }
 }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   },
   "gitHead": "49d436db19e42e3c16b4185b12e9dfcce60ec253"
 }

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -10,6 +10,7 @@ const PaginationControls = ({
   autoHide,
   pageRange,
   marginPages,
+  breakLabel,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -83,7 +84,7 @@ const PaginationControls = ({
           (index >= selected - leftSide && index <= selected + rightSide)
         ) {
           items.push(createItem(pageNumber));
-        } else if (items[items.length - 1] !== breakView) {
+        } else if (items[items.length - 1] !== breakView && breakLabel) {
           breakView = createBreak(pageNumber);
           items.push(breakView);
         }
@@ -144,6 +145,7 @@ PaginationControls.propTypes = {
   autoHide: PropTypes.bool, // If there are no items to show. This component will not show
   pageRange: PropTypes.number,
   marginPages: PropTypes.number,
+  breakLabel: PropTypes.bool
 };
 
 PaginationControls.defaultProps = {
@@ -151,5 +153,6 @@ PaginationControls.defaultProps = {
   autoHide: true,
   pageRange: 5,
   marginPages: 2,
+  breakLabel: true
 };
 export default PaginationControls;

--- a/packages/reactstrap-validation-date/package.json
+++ b/packages/reactstrap-validation-date/package.json
@@ -28,13 +28,13 @@
     "react": "^16.8.3",
     "react-date-range": "^0.9.4",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   },
   "peerDependencies": {
     "availity-reactstrap-validation": "^2.0.0",
     "moment": "^2.22.1",
     "react": "^16.3.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/packages/reactstrap-validation-select/package.json
+++ b/packages/reactstrap-validation-select/package.json
@@ -30,14 +30,14 @@
     "axios": "^0.18.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "reactstrap": "^7.0.0"
+    "reactstrap": "^8.0.0"
   },
   "peerDependencies": {
     "@availity/api-axios": "^2.0.0",
     "availity-reactstrap-validation": "^2.0.0",
     "availity-uikit": "^3.0.0-beta.19",
     "react": "^16.0.0",
-    "reactstrap": "^7.0.0 || ^6.0.0"
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   },
   "dependencies": {
     "@thesharpieone/react-select-async-pagination": "^2.0.0",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -27,7 +27,7 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-dropzone": "^7.0.1",
-    "reactstrap": "^7.0.0 || ^6.0.0",
+    "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },
   "dependencies": {
@@ -39,7 +39,7 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-dropzone": "^7.0.1",
-    "reactstrap": "^7.0.0",
+    "reactstrap": "^8.0.0",
     "tus-js-client": "1.5.1"
   }
 }


### PR DESCRIPTION
closes #101 

Every breaking change we make for any future components we can also just require the upgrade of reactstrap to v8 to eventually dump support for previous major versions.