### PR TITLE
feat: add link component

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * [feedback](packages/feedback/README.md) - Availity feedback with simley faces react component.
 * [hooks](packages/hooks/README.md) - Custom Hooks that can be used in any projects.
 * [icon](packages/icon/README.md) - Icon Component using sizes and icons from availity-uikit.
-* [list-group](packages/link/README.md) - Availity Link component
+* [link](packages/link/README.md) - Availity Link component
 * [list-group](packages/list-group/README.md) - List Group with some Availity flair.
 * [list-group-item](packages/list-group-item/README.md) - List Group Item with some Availity flair.
 * [page-header](packages/page-header/README.md) - The standard page header for Availity Portal Applications.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * [feedback](packages/feedback/README.md) - Availity feedback with simley faces react component.
 * [hooks](packages/hooks/README.md) - Custom Hooks that can be used in any projects.
 * [icon](packages/icon/README.md) - Icon Component using sizes and icons from availity-uikit.
+* [list-group](packages/link/README.md) - Availity Link component
 * [list-group](packages/list-group/README.md) - List Group with some Availity flair.
 * [list-group-item](packages/list-group-item/README.md) - List Group Item with some Availity flair.
 * [page-header](packages/page-header/README.md) - The standard page header for Availity Portal Applications.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -35,6 +35,7 @@
 		"@availity/feedback": "^4.1.2",
 		"@availity/hooks": "^1.3.0",
 		"@availity/icon": "^0.4.0",
+		"@availity/link": "^1.0.0",
 		"@availity/list-group": "^1.1.4",
 		"@availity/list-group-item": "^1.1.4",
 		"@availity/localstorage-core": "^2.5.0",

--- a/packages/docs/stories/link.stories.js
+++ b/packages/docs/stories/link.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import README from '@availity/link/README.md';
+import AvLink from '@availity/link';
+
+storiesOf('Components|Link', module)
+  .addParameters({
+    readme: {
+      // Show readme at the addons panel
+      sidebar: README,
+      // eslint-disable-next-line react/prop-types
+      StoryPreview: ({ children }) => <div>{children}</div>,
+    },
+  })
+  .add('with absolute url', () => (
+    <div className="py-3">
+      <AvLink url="https://github.com/Availity" target="_blank">
+        Availity Github
+      </AvLink>
+    </div>
+  ))
+  .add('with relative url', () => (
+    <div className="py-3">
+      <AvLink url="/public/apps/my-app" target="_blank">
+        My Application
+      </AvLink>
+    </div>
+  ));

--- a/packages/link/CHANGELOG.md
+++ b/packages/link/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+

--- a/packages/link/Link.d.ts
+++ b/packages/link/Link.d.ts
@@ -1,0 +1,10 @@
+export interface AvLinkProps {
+    url: string;
+    target?: string;
+    tag?: React.ReactType | string;
+    children?: any;
+}
+
+declare const AvLink: React.FunctionComponent<AvLinkProps>;
+
+export default AvLink;

--- a/packages/link/Link.d.ts
+++ b/packages/link/Link.d.ts
@@ -3,6 +3,7 @@ export interface AvLinkProps {
     target?: string;
     tag?: React.ReactType | string;
     children?: any;
+    onClick?: Function;
 }
 
 declare const AvLink: React.FunctionComponent<AvLinkProps>;

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isAbsoluteUrl from 'is-absolute-url';
+import { isAbsoluteUrl } from '@availity/resolve-url';
 
 // if absolute, return url. otherwise loadappify the url
 export const getUrl = (url = '') => {

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import isAbsoluteUrl from 'is-absolute-url';
+
+// if absolute, return url. otherwise loadappify the url
+export const getUrl = (url = '') => {
+  const absolute = isAbsoluteUrl(url);
+  if (absolute) return url;
+
+  return `/public/apps/home/#!/loadApp?appUrl=${encodeURIComponent(url)}`;
+};
+
+const AvLink = ({ tag: Tag, url, target, children, ...props }) => (
+  <Tag href={getUrl(url)} target={target} data-testid="av-link-tag" {...props}>
+    {children}
+  </Tag>
+);
+
+AvLink.defaultProps = {
+  tag: 'a',
+};
+
+AvLink.propTypes = {
+  url: PropTypes.string.isRequired,
+  target: PropTypes.string,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  children: PropTypes.node,
+};
+
+export default AvLink;

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -10,8 +10,14 @@ export const getUrl = (url = '') => {
   return `/public/apps/home/#!/loadApp?appUrl=${encodeURIComponent(url)}`;
 };
 
-const AvLink = ({ tag: Tag, url, target, children, ...props }) => (
-  <Tag href={getUrl(url)} target={target} data-testid="av-link-tag" {...props}>
+const AvLink = ({ tag: Tag, url, target, children, onClick, ...props }) => (
+  <Tag
+    href={getUrl(url)}
+    target={target}
+    onClick={event => onClick && onClick(event, getUrl(url))}
+    data-testid="av-link-tag"
+    {...props}
+  >
     {children}
   </Tag>
 );
@@ -25,6 +31,7 @@ AvLink.propTypes = {
   target: PropTypes.string,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
+  onClick: PropTypes.func,
 };
 
 export default AvLink;

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -27,4 +27,4 @@ import AvLink from '@availity/link';
 - **`url`**: String. Required. The url of the page the link goes to
 - **`target`**: String. Optional. Where to open the linked document
 - **`tag`**: React component. Optional. The tag to use in the link that gets rendered. Defaults to an `<a>` tag
-
+- **`onClick`**: Function. Optional. Function to run onClick of the tag. The first argument that gets passed to `onClick` is the event. The second is the processed `url`.

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -1,0 +1,30 @@
+# @availity/link
+
+> Simple link component that renders an `<a>` tag with the `href` formatted to leverage loadApp so that when the link is opened in a new tab, it gets loaded inside the home page's iframe
+
+## Installation
+
+```bash
+npm install @availity/link --save
+```
+
+### Usage
+
+```javascript
+import React from 'react';
+import AvLink from '@availity/link';
+// ...
+<Container>
+  <AvLink url="/public/apps/my-app" target="newBody">
+    {/* ... */}
+  </AvLink>
+</Container>
+// ...
+```
+
+#### Props
+
+- **`url`**: String. Required. The url of the page the link goes to
+- **`target`**: String. Optional. Where to open the linked document
+- **`tag`**: React component. Optional. The tag to use in the link that gets rendered. Defaults to an `<a>` tag
+

--- a/packages/link/index.d.ts
+++ b/packages/link/index.d.ts
@@ -1,0 +1,3 @@
+export { default } from './Link';
+export * from './Link';
+

--- a/packages/link/index.js
+++ b/packages/link/index.js
@@ -1,0 +1,3 @@
+import AvLink from './Link';
+
+export default AvLink;

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@availity/link",
+  "version": "1.0.0",
+  "author": "Tyson Warner <tyson.warner@availity.com>",
+  "description": "React component that renders an a tag with the `href` formatted to leverage loadApp",
+  "main": "index.js",
+  "keywords": [
+    "react",
+    "availity"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "prop-types": "^15.5.8",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0"
+  },
+  "dependencies": {
+    "is-absolute-url": "^3.0.0"
+  }
+}

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -28,6 +28,6 @@
     "react": "^16.3.0"
   },
   "dependencies": {
-    "is-absolute-url": "^3.0.0"
+    "@availity/resolve-url": "^1.1.0"
   }
 }

--- a/packages/link/test/Link.test.js
+++ b/packages/link/test/Link.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, cleanup } from 'react-testing-library';
+import AvLink from '..';
+
+afterEach(cleanup);
+
+describe('AvLink', () => {
+  test('should render absolute url', () => {
+    const { getByTestId } = render(
+      <AvLink url="https://github.com/Availity">Vim</AvLink>
+    );
+
+    const tag = getByTestId('av-link-tag');
+
+    expect(tag.getAttribute('href')).toBe('https://github.com/Availity');
+  });
+
+  test('should render formatted url when url prop is relative', () => {
+    const { getByTestId } = render(
+      <AvLink url="/public/apps/my-app">My App</AvLink>
+    );
+
+    const tag = getByTestId('av-link-tag');
+    const expected =
+      '/public/apps/home/#!/loadApp?appUrl=%2Fpublic%2Fapps%2Fmy-app';
+
+    expect(tag.getAttribute('href')).toBe(expected);
+  });
+});


### PR DESCRIPTION
A simple link component that handles the logic to make urls compatible for loadApp. Meaning, it renders a link that when clicked in a new tab, will open inside the iframe of the home page.