### PR TITLE
fix(favorites): fix favorites sent in avMessage when favorites deleted

### DIFF
--- a/packages/favorites/FavoritesContext.js
+++ b/packages/favorites/FavoritesContext.js
@@ -79,9 +79,9 @@ const Favorites = ({ children }) => {
     });
   };
 
-  const sendUpdate = () => {
+  const sendUpdate = faves => {
     const message = {
-      favorites,
+      favorites: faves,
     };
 
     avMessages.send({
@@ -94,9 +94,11 @@ const Favorites = ({ children }) => {
     const result = await submitFavorites(
       clone(favorites).filter(favorite => favorite.id !== id)
     );
-    setFavorites(get(result, 'data.favorites'));
 
-    sendUpdate();
+    const newFavorites = get(result, 'data.favorites');
+    setFavorites(newFavorites);
+
+    sendUpdate(newFavorites);
   };
 
   const openMaxModal = () => {


### PR DESCRIPTION
corrects issue where when a favorite is unfavorited, it's not removed from the payload sent in the post message sent to `window.parent`. We fix this by sending the favorites returned from the settings api in the post message