### PR TITLE
fix(reactstrap-validation-date): fixed z-index issue

### DIFF
--- a/packages/reactstrap-validation-date/AvDate.js
+++ b/packages/reactstrap-validation-date/AvDate.js
@@ -175,6 +175,9 @@ class AvDate extends Component {
             type="button"
             onClick={this.togglePicker}
             disabled={props.disabled}
+            style={{
+              zIndex: 'auto',
+            }}
           >
             <span className="icon icon-calendar" />
             <span className="sr-only">Toggle Calendar</span>

--- a/packages/reactstrap-validation-date/AvDateRange.js
+++ b/packages/reactstrap-validation-date/AvDateRange.js
@@ -382,6 +382,7 @@ export default class AvDateRange extends Component {
             style={{
               lineHeight:
                 this.state.format === isoDateFormat ? '1.4' : undefined,
+              zIndex: 'auto',
             }}
           >
             <span className="icon icon-calendar" />

--- a/packages/reactstrap-validation-date/tests/__snapshots__/AvDate.test.js.snap
+++ b/packages/reactstrap-validation-date/tests/__snapshots__/AvDate.test.js.snap
@@ -28,6 +28,7 @@ exports[`AvDate should render 1`] = `
         <button
           class="btn btn-light"
           id="standAlone-btn"
+          style="z-index: auto;"
           type="button"
         >
           <span


### PR DESCRIPTION
The input-group-addon automatically adds a z-index:2 onto any nested button component inside. Fixed this by adding a hardcoded z-index style to the button component that gets the class.
![Screen Shot 2019-05-03 at 5 28 26 PM](https://user-images.githubusercontent.com/14143881/57166662-e2f36700-6dc8-11e9-9ca7-af9d735ea378.png)
