### PR TITLE
fix(favorites): send post message to window.parent when favorite added

### DIFF
--- a/packages/favorites/FavoritesContext.js
+++ b/packages/favorites/FavoritesContext.js
@@ -40,7 +40,7 @@ const Favorites = ({ children }) => {
     avMessages.subscribe(
       AV_INTERNAL_GLOBALS.FAVORITES_CHANGED,
       (event, data) => {
-        setFavorites(get(data, 'favorites') || []);
+        setFavorites(get(data, 'message.favorites') || []);
       }
     );
 
@@ -129,9 +129,12 @@ const Favorites = ({ children }) => {
 
     const result = await submitFavorites(newData);
 
-    setFavorites(get(result, 'data.favorites'));
+    const newFavorites = get(result, 'data.favorites');
+    setFavorites(newFavorites);
 
-    const isFavorited = findwhere(favorites, { id });
+    sendUpdate(newFavorites);
+
+    const isFavorited = findwhere(newFavorites, { id });
 
     return !!isFavorited;
   };

--- a/packages/favorites/FavoritesContext.js
+++ b/packages/favorites/FavoritesContext.js
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useEffectAsync } from '@availity/hooks';
 import avMessages from '@availity/message-core';
-import { AvSplunkAnalytics } from '@availity/analytics-core';
 import get from 'lodash.get';
 import isUndefined from 'lodash.isundefined';
 import isNumber from 'lodash.isnumber';
@@ -11,7 +10,7 @@ import reduce from 'lodash.reduce';
 import clone from 'lodash.clone';
 import max from 'lodash.max';
 import findwhere from 'lodash.findwhere';
-import { avSettingsApi, AvLogMessages } from '@availity/api-axios';
+import { avSettingsApi, avLogMessagesApi } from '@availity/api-axios';
 
 const MAX_FAVORITES = 60;
 const NAV_APP_ID = 'Gateway-AvNavigation';
@@ -24,8 +23,6 @@ const AV_INTERNAL_GLOBALS = {
 };
 
 export const FavoritesContext = createContext();
-
-const avSplunkAnalytics = new AvSplunkAnalytics(AvLogMessages, true);
 
 const Favorites = ({ children }) => {
   const [favorites, setFavorites] = useState([]);
@@ -108,7 +105,7 @@ const Favorites = ({ children }) => {
       event: 'modal-open',
     };
 
-    avSplunkAnalytics.trackEvent(atMaxLog);
+    avLogMessagesApi.info(atMaxLog);
 
     avMessages.send(AV_INTERNAL_GLOBALS.MAX_FAVORITES);
   };

--- a/packages/favorites/__test__/FavoriteHeart.test.js
+++ b/packages/favorites/__test__/FavoriteHeart.test.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import 'react-testing-library/cleanup-after-each';
-import {
-  fireEvent,
-  render,
-  waitForElement,
-  cleanup,
-} from 'react-testing-library';
+import { fireEvent, render, waitForElement } from 'react-testing-library';
 import { avSettingsApi } from '@availity/api-axios';
 import avMessages from '@availity/message-core';
 import Favorites, { FavoriteHeart } from '..';
@@ -90,7 +85,6 @@ avSettingsApi.getApplication = jest.fn(() =>
 
 describe('FavoriteHeart', () => {
   afterEach(() => {
-    cleanup();
     jest.clearAllMocks();
   });
 

--- a/packages/favorites/__test__/FavoriteHeart.test.js
+++ b/packages/favorites/__test__/FavoriteHeart.test.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import 'react-testing-library/cleanup-after-each';
-import { fireEvent, render, waitForElement } from 'react-testing-library';
+import {
+  fireEvent,
+  render,
+  waitForElement,
+  cleanup,
+} from 'react-testing-library';
 import { avSettingsApi } from '@availity/api-axios';
 import avMessages from '@availity/message-core';
 import Favorites, { FavoriteHeart } from '..';
@@ -85,10 +90,11 @@ avSettingsApi.getApplication = jest.fn(() =>
 
 describe('FavoriteHeart', () => {
   afterEach(() => {
+    cleanup();
     jest.clearAllMocks();
   });
 
-  test('should render not favorited', async () => {
+  test('should render favorited', async () => {
     const { container, getByText } = render(
       <Favorites>
         <FavoriteHeart id="123" />
@@ -100,7 +106,7 @@ describe('FavoriteHeart', () => {
     await waitForElement(() => getByText('This item is favorited.'));
   });
 
-  test('should render favorited', async () => {
+  test('should render not favorited', async () => {
     const { container, getByText } = render(
       <Favorites>
         <FavoriteHeart id="1234" />
@@ -110,25 +116,6 @@ describe('FavoriteHeart', () => {
     expect(container.querySelector('#av-favorite-heart-1234')).toBeDefined();
 
     await waitForElement(() => getByText('This item is not favorited.'));
-  });
-
-  test('should call onChange once toggled', async () => {
-    const onChange = jest.fn(() => {});
-    const { container, getByText } = render(
-      <Favorites>
-        <FavoriteHeart onChange={onChange} id="1234" />
-      </Favorites>
-    );
-
-    const heart = container.querySelector('#av-favorite-heart-1234');
-
-    expect(heart).toBeDefined();
-
-    await waitForElement(() => getByText('This item is not favorited.'));
-
-    fireEvent.click(heart);
-
-    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   test('should update when avMessage event triggers from elsewhere', async () => {
@@ -148,7 +135,7 @@ describe('FavoriteHeart', () => {
 
     avMessages.send({
       event: 'av:favorites:changed',
-      data: { favorites: [] },
+      message: { favorites: [] },
     });
 
     await waitForElement(() => getByText('This item is not favorited.'));
@@ -191,5 +178,73 @@ describe('FavoriteHeart', () => {
     expect(avMessages.send.mock.calls[0][0].message.favorites).toEqual([
       { id: '456', pos: 0 },
     ]);
+  });
+
+  test('should add favorite and send post message with updated favorites', async () => {
+    avSettingsApi.setApplication = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          favorites: [
+            {
+              id: '123',
+              pos: 0,
+            },
+            {
+              id: '456',
+              pos: 1,
+            },
+            {
+              id: '789',
+              pos: 2,
+            },
+          ],
+        },
+      })
+    );
+
+    const { container, getByText } = render(
+      <Favorites>
+        <FavoriteHeart id="789" />
+      </Favorites>
+    );
+
+    const heart = container.querySelector('#av-favorite-heart-789');
+
+    expect(heart).toBeDefined();
+
+    await waitForElement(() => getByText('This item is not favorited.'));
+
+    // Simulate user favoriting item
+    fireEvent.click(heart);
+
+    await waitForElement(() => getByText('This item is favorited.'));
+
+    expect(avMessages.send).toHaveBeenCalledTimes(1);
+    expect(avMessages.send.mock.calls[0][0].event).toBe('av:favorites:update');
+    // Test that post message sent to window.parent sends favorites returned from settings api
+    expect(avMessages.send.mock.calls[0][0].message.favorites).toEqual([
+      { id: '123', pos: 0 },
+      { id: '456', pos: 1 },
+      { id: '789', pos: 2 },
+    ]);
+  });
+
+  test('should call onChange once toggled', async () => {
+    const onChange = jest.fn(() => {});
+    const { container, getByText } = render(
+      <Favorites>
+        <FavoriteHeart onChange={onChange} id="1234" />
+      </Favorites>
+    );
+
+    const heart = container.querySelector('#av-favorite-heart-1234');
+
+    expect(heart).toBeDefined();
+
+    await waitForElement(() => getByText('This item is not favorited.'));
+
+    fireEvent.click(heart);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
when `addFavorite` gets run, we send a post message to parent with the result of the settings call, letting the parent know of new favorites. 