### PR TITLE
fix(reactstrap-validation-select): fix width of multivalue options

### DIFF
--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -217,7 +217,7 @@ class AvSelect extends AvBaseInput {
           },
           multiValue: provided => ({
             ...provided,
-            width: '85%',
+            width: 'auto',
           }),
           input: provided => ({
             ...provided,


### PR DESCRIPTION
**Before**
<img width="612" alt="Screen Shot 2019-05-07 at 9 53 26 AM" src="https://user-images.githubusercontent.com/2113576/57305197-a7012000-70ae-11e9-9cba-2cba27482656.png">

**After**
<img width="534" alt="Screen Shot 2019-05-07 at 9 58 42 AM" src="https://user-images.githubusercontent.com/2113576/57305264-c26c2b00-70ae-11e9-9820-6f797783ebca.png">
