### PR TITLE
refactor(reactstrap-validation-date): added prop for changing out icon

### DIFF
--- a/packages/reactstrap-validation-date/AvDate.js
+++ b/packages/reactstrap-validation-date/AvDate.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/default-props-match-prop-types */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, InputGroupAddon, Popover } from 'reactstrap';
@@ -6,6 +7,7 @@ import {
   inputType,
   isoDateFormat,
 } from 'availity-reactstrap-validation/lib/AvValidator/utils';
+import Icon from '@availity/icon';
 import { Calendar } from 'react-date-range';
 import { AvInput } from 'availity-reactstrap-validation';
 import './styles.scss';
@@ -46,7 +48,10 @@ const theme = {
 };
 
 class AvDate extends Component {
-  static propTypes = AvInput.propTypes;
+  static propTypes = {
+    ...AvInput.propTypes,
+    calendarIcon: PropTypes.node,
+  };
 
   static contextTypes = {
     FormCtrl: PropTypes.object.isRequired,
@@ -55,6 +60,7 @@ class AvDate extends Component {
   static defaultProps = {
     type: 'text',
     datepicker: true,
+    calendarIcon: <Icon name="calendar" />,
   };
 
   static getDerivedStateFromProps = ({ value }, prevState) => {
@@ -145,7 +151,7 @@ class AvDate extends Component {
   };
 
   render() {
-    const { datepicker, ...props } = this.props;
+    const { datepicker, calendarIcon, ...props } = this.props;
     const id = `${(this.props.id || this.props.name).replace(
       /[^a-zA-Z0-9]/gi,
       ''
@@ -179,7 +185,7 @@ class AvDate extends Component {
               zIndex: 'auto',
             }}
           >
-            <span className="icon icon-calendar" />
+            {calendarIcon}
             <span className="sr-only">Toggle Calendar</span>
           </Button>
         </InputGroupAddon>

--- a/packages/reactstrap-validation-date/AvDateRange.js
+++ b/packages/reactstrap-validation-date/AvDateRange.js
@@ -9,6 +9,7 @@ import {
 } from 'availity-reactstrap-validation/lib/AvValidator/utils';
 import { AvInput } from 'availity-reactstrap-validation';
 import { DateRange } from 'react-date-range';
+import Icon from '@availity/icon';
 import AvDate from './AvDate';
 
 let count = 0;
@@ -88,11 +89,15 @@ export default class AvDateRange extends Component {
     ranges: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     defaultValues: PropTypes.object,
     theme: PropTypes.object,
+    calendarIcon: PropTypes.node,
   };
 
   static contextTypes = { FormCtrl: PropTypes.object.isRequired };
 
-  static defaultProps = { type: 'text' };
+  static defaultProps = {
+    type: 'text',
+    calendarIcon: <Icon name="calendar" />,
+  };
 
   constructor(props, context) {
     super(props, context);
@@ -385,7 +390,7 @@ export default class AvDateRange extends Component {
               zIndex: 'auto',
             }}
           >
-            <span className="icon icon-calendar" />
+            {this.props.calendarIcon}
             <span className="sr-only">Toggle Calendar</span>
           </Button>
         </InputGroupAddon>

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -115,6 +115,7 @@ See availity-reactstrap-validation for additional props, such as `name`, `valida
 *   **`start`**: Object. Required. and object which will be spread on the start date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 *   **`end`**: Object. Required. and object which will be spread on the end date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 *   **`distance`**: Object. Optional. Object containing the `min` and `max` distance the start and end dates are allowed to be apart from each other. See example below.
+*   **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 
 #### AvDateRange Example usage
 

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -55,6 +55,7 @@ This is the underlying date without the `AvGroup`, `Label` or `AvFeedback`
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
 
 *   **`datepicker`**: Boolean. Optional. Default: `true`. If `true`, the date picker button will be shown, clicking it activates the datepicker calendar. If `false`, only the date input field will be displayed (useful for date of birth fields).
+*   **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 
 #### AvDate Example usage
 

--- a/packages/reactstrap-validation-date/package.json
+++ b/packages/reactstrap-validation-date/package.json
@@ -37,6 +37,7 @@
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0"
   },
   "dependencies": {
+    "@availity/icon": "^0.4.0",
     "prop-types": "^15.5.8",
     "react-date-range": "^0.9.4"
   },

--- a/packages/reactstrap-validation-date/tests/__snapshots__/AvDate.test.js.snap
+++ b/packages/reactstrap-validation-date/tests/__snapshots__/AvDate.test.js.snap
@@ -31,8 +31,9 @@ exports[`AvDate should render 1`] = `
           style="z-index: auto;"
           type="button"
         >
-          <span
-            class="icon icon-calendar"
+          <i
+            aria-label="calendar"
+            class="icon icon-calendar undefined"
           />
           <span
             class="sr-only"


### PR DESCRIPTION
For anyone not using the `availity-uikit` you can pass in your own calendarIcon to the calendar component. Alternatively, we could just include the calendar icon font with the component.