### PR TITLE
Fix/wizard classname

### DIFF
--- a/packages/step-wizard/Wizard.d.ts
+++ b/packages/step-wizard/Wizard.d.ts
@@ -4,6 +4,7 @@ export interface WizardProps {
     progress?: boolean;
     children?: React.ReactType;
     tag?: React.ReactType | string;
+    className?: string;
 }
 
 declare const Wizard: React.FunctionComponent<WizardProps>;

--- a/packages/step-wizard/Wizard.js
+++ b/packages/step-wizard/Wizard.js
@@ -2,9 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Wizard = ({ tag: Tag, bar, stacked, children, progress, ...rest }) => (
+const Wizard = ({
+  tag: Tag,
+  bar,
+  stacked,
+  children,
+  progress,
+  className: classes,
+  ...rest
+}) => (
   <Tag
     className={classNames(
+      classes,
       'stepwizard',
       { 'stepwizard-bar': bar },
       { 'stepwizard-stacked': stacked },
@@ -27,6 +36,7 @@ Wizard.propTypes = {
   progress: PropTypes.bool,
   children: PropTypes.node,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.string,
 };
 
 export default Wizard;


### PR DESCRIPTION
Forgot to add a className prop to `<Wizard />`. 🤦‍♂ It's already present on `<WizardStep />`, `<WizardStepBadge />`, and `<WizardStepTitle />`