### PR TITLE
fix(reactstrap-validation-date): fixed date auto filling on first type

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,3 +5,5 @@ rules:
   react/destructuring-assignment: 0
   react/forbid-foreign-prop-types: 0
   react/no-access-state-in-setstate: 0
+  guard-for-in: 0
+  no-restricted-syntax: 0

--- a/packages/reactstrap-validation-date/AvDate.js
+++ b/packages/reactstrap-validation-date/AvDate.js
@@ -93,22 +93,26 @@ class AvDate extends Component {
 
   valueParser(value) {
     if (this.state.format === isoDateFormat) return value;
-    const date = dayjs(
-      value,
-      [this.state.format, 'MMDDYYYY', 'YYYYMMDD'],
-      true
-    );
-    if (date.isValid()) return date.format(isoDateFormat);
+
+    const formats = [this.state.format, 'MMDDYYYY', 'YYYYMMDD'];
+
+    for (const i in formats) {
+      const date = dayjs(value, formats[i]);
+
+      if (date.isValid()) return date.format(isoDateFormat);
+    }
     return value;
   }
 
   valueFormatter(value) {
-    const date = dayjs(
-      value,
-      [isoDateFormat, this.state.format, 'MMDDYYYY', 'YYYYMMDD'],
-      true
-    );
-    if (date.isValid()) return date.format(this.state.format);
+    const formats = [isoDateFormat, this.state.format, 'MMDDYYYY', 'YYYYMMDD'];
+
+    for (const i in formats) {
+      const date = dayjs(value, formats[i]);
+
+      if (date.isValid()) return date.format(this.state.format);
+    }
+
     return value;
   }
 
@@ -162,7 +166,6 @@ class AvDate extends Component {
       ''
     )}-btn`;
 
-    console.log('State value;', this.state.value);
     const input = (
       <AvInput
         placeholder={this.state.format.toLowerCase()}


### PR DESCRIPTION
Fixed issue where formatter would think the first inputted value is valid. `dayjs` doesn't accept arrays as formats so we have to iterate.