### PR TITLE
feat: add spaces package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * [app-icon](packages/app-icon/README.md) - Availity UI Kit application icon react component.
 * [authorize](packages/authorize/README.md) - Check user permissions to see if the current user is authorized to see your content.
 * [breadcrumbs](packages/breadcrumbs/README.md) - Breadscrumbs component for Spaces platform.
+* [favorites](packages/favorites/README.md) - Favorite Heart for favoriting items such as resources/applications etc.
 * [feature](packages/feature/README.md) - Check environment features for the current environment to determine if a particular feature is enabled.
 * [feedback](packages/feedback/README.md) - Availity feedback with simley faces react component.
 * [hooks](packages/hooks/README.md) - Custom Hooks that can be used in any projects.
@@ -30,6 +31,7 @@
 * [reactstrap-validation-date](packages/reactstrap-validation-date/README.md) - Wrapper for react-date-range to work with availity-reactstrap-validation
 * [reactstrap-validation-select](packages/reactstrap-validation-select/README.md) - Wrapper for react-select to work with availity-reactstrap-validation
 * [upload](packages/upload/README.md) - Availity upload component for uploading files
+* [spaces](packages/spaces/README.md) - Easy to use spaces components
 * [training-link](packages/training-link/README.md) - Component for allowing link out to training in the Header component.
 * [upload](packages/upload/README.md) - Availity upload component for uploading files.
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -44,6 +44,7 @@
     "@availity/payer-logo": "^3.0.0",
     "@availity/reactstrap-validation-date": "^1.7.10",
     "@availity/reactstrap-validation-select": "^3.0.5",
+    "@availity/spaces": "^1.0.0",
     "@availity/step-wizard": "^1.2.1",
     "@availity/training-link": "^1.1.4",
     "@availity/upload": "^1.8.1",

--- a/packages/docs/stories/data/availity-spaces-response.json
+++ b/packages/docs/stories/data/availity-spaces-response.json
@@ -1,0 +1,71 @@
+{
+  "data": {
+    "spaces": {
+      "spaces": [
+        {
+          "id": "space1",
+          "images": [
+            {
+              "name": "logo",
+              "value": "/static/spaces/space1/banner.png"
+            }
+          ]
+        },
+        {
+          "id": "a",
+          "payerIDs": [
+            "availity1"
+          ],
+          "images": [
+            {
+              "name": "logo",
+              "value": "/static/spaces/a/banner.png"
+            }
+          ]
+        },
+        {
+          "id": "space2",
+          "images": [
+            {
+              "name": "tile",
+              "value": "/static/spaces/space2/tile.png"
+            }
+          ]
+        },
+        {
+          "id": "b",
+          "payerIDs": [
+            "availity2"
+          ],
+          "images": [
+            {
+              "name": "tile",
+              "value": "/static/spaces/b/tile.png"
+            }
+          ]
+        },
+        {
+          "id": "space3",
+          "images": [
+            {
+              "name": "billboard",
+              "value": "/static/spaces/space3/billboard.png"
+            }
+          ]
+        },
+        {
+          "id": "c",
+          "payerIDs": [
+            "availity3"
+          ],
+          "images": [
+            {
+              "name": "billboard",
+              "value": "/static/spaces/b/billboard.png"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/docs/stories/mock-requests/slotmachine.js
+++ b/packages/docs/stories/mock-requests/slotmachine.js
@@ -1,19 +1,28 @@
 import space1 from '../data/space-73162546201440710195134200002269.json';
 import space2 from '../data/space-73162546201441126239486200007187.json';
+import availitySpacesResponse from '../data/availity-spaces-response.json';
 
 export default mock => {
   mock.post(
     '/ms/api/availity/internal/platform/slotmachine/graphql',
     (req, res) => {
-      let space;
+      let resp;
       const body = JSON.parse(req._body);
-      if (body.variables && body.variables.payerIDs) {
-        space = space1;
+      if (
+        body.variables &&
+        ((body.variables.ids &&
+          body.variables.ids.some(id => id === 'space1')) ||
+          (body.variables.payerIDs &&
+            body.variables.payerIDs.some(id => id === 'availity1')))
+      ) {
+        resp = availitySpacesResponse;
+      } else if (body.variables && body.variables.payerIDs) {
+        resp = space1;
       } else if (body.variables && body.variables.id) {
-        space = space2;
+        resp = space2;
       }
 
-      return res.status(200).body(window.JSON.stringify(space));
+      return res.status(200).body(window.JSON.stringify(resp));
     }
   );
 };

--- a/packages/docs/stories/spaces.stories.js
+++ b/packages/docs/stories/spaces.stories.js
@@ -20,7 +20,11 @@ storiesOf('Spaces|Spaces', module)
   })
   .add('Images', () => (
     <div>
-      <Spaces clientId="my-client-id">
+      <Spaces
+        spaceIds={['space1', 'space2', 'space3']}
+        payerIds={['availity1', 'availity2', 'availity3']}
+        clientId="my-client-id"
+      >
         <Row className="mb-3">
           <Col sm={6}>
             <SpacesLogo spaceId="space1" />

--- a/packages/docs/stories/spaces.stories.js
+++ b/packages/docs/stories/spaces.stories.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Row, Col } from 'reactstrap';
+
+import Spaces, {
+  SpacesLogo,
+  SpacesTile,
+  SpacesBillboard,
+} from '@availity/spaces';
+import README from '@availity/spaces/README.md';
+
+storiesOf('Spaces|Spaces', module)
+  .addParameters({
+    readme: {
+      // Show readme at the addons panel
+      sidebar: README,
+      // eslint-disable-next-line react/prop-types
+      StoryPreview: ({ children }) => <div>{children}</div>,
+    },
+  })
+  .add('Images', () => (
+    <div>
+      <Spaces clientId="my-client-id">
+        <Row className="mb-3">
+          <Col sm={6}>
+            <SpacesLogo spaceId="space1" />
+          </Col>
+          <Col sm={6}>
+            <SpacesLogo payerId="availity1" />
+          </Col>
+        </Row>
+
+        <Row className="mb-3">
+          <Col sm={6}>
+            <SpacesTile spaceId="space2" />
+          </Col>
+          <Col sm={6}>
+            <SpacesTile payerId="availity2" />
+          </Col>
+        </Row>
+
+        <Row className="mb-3">
+          <Col sm={6}>
+            <SpacesBillboard spaceId="space3" />
+          </Col>
+          <Col sm={6}>
+            <SpacesBillboard payerId="availity3" />
+          </Col>
+        </Row>
+      </Spaces>
+
+      <div>
+        <p>
+          Note: these spaces images use a relative URL which will only work on
+          the Availity Portal
+        </p>
+      </div>
+    </div>
+  ));

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Breadcrumbs from '@availity/breadcrumbs';
 import AppIcon from '@availity/app-icon';
 import Feedback from '@availity/feedback';
-import Spaces, { SpacesLogo } from '@availity/spaces';
+import Spaces, { SpacesLogo, useSpace } from '@availity/spaces';
 
 const PageHeader = ({
   payerId,
@@ -24,9 +24,13 @@ const PageHeader = ({
   iconAlt,
   ...props
 }) => {
+  const id = spaceId || payerId;
+  const space = useSpace(id);
+
+  const _spaceName = spaceName || (space && space.name);
   if (spaceId || spaceName) {
     crumbs = [
-      { name: spaceName, url: spaceId && `/web/spaces/spaces/#/${spaceId}` },
+      { name: _spaceName, url: spaceId && `/web/spaces/spaces/#/${spaceId}` },
     ];
   }
   return (
@@ -55,7 +59,11 @@ const PageHeader = ({
           {children || appName}
         </div>
         {payerId && (
-          <Spaces clientId={clientId}>
+          <Spaces
+            spaceIds={spaceId ? [spaceId] : undefined}
+            payerIds={[payerId]}
+            clientId={clientId}
+          >
             <SpacesLogo
               spaceId={spaceId}
               payerId={payerId}

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Breadcrumbs from '@availity/breadcrumbs';
 import AppIcon from '@availity/app-icon';
 import Feedback from '@availity/feedback';
-import PayerLogo from '@availity/payer-logo';
+import Spaces, { SpacesLogo } from '@availity/spaces';
 
 const PageHeader = ({
   payerId,
@@ -55,12 +55,13 @@ const PageHeader = ({
           {children || appName}
         </div>
         {payerId && (
-          <PayerLogo
-            spaceId={spaceId}
-            payerId={payerId}
-            clientId={clientId}
-            className="float-md-right d-inline-block"
-          />
+          <Spaces clientId={clientId}>
+            <SpacesLogo
+              spaceId={spaceId}
+              payerId={payerId}
+              className="float-md-right d-inline-block"
+            />
+          </Spaces>
         )}
         {feedback && (
           <Feedback

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -24,15 +24,39 @@ const PageHeader = ({
   iconAlt,
   ...props
 }) => {
-  const id = spaceId || payerId;
-  const space = useSpace(id);
+  const spaceForSpaceID = useSpace(spaceId);
+  const spaceForPayerID = useSpace(payerId);
+  const _space = spaceForSpaceID || spaceForPayerID;
 
-  const _spaceName = spaceName || (space && space.name);
+  let payerLogo = null;
+  if (payerId) {
+    const logo = (
+      <SpacesLogo
+        spaceId={spaceId}
+        payerId={payerId}
+        className="float-md-right d-inline-block"
+      />
+    );
+    payerLogo = spaceForPayerID ? (
+      logo
+    ) : (
+      <Spaces
+        spaceIds={spaceId ? [spaceId] : undefined}
+        payerIds={[payerId]}
+        clientId={clientId}
+      >
+        {logo}
+      </Spaces>
+    );
+  }
+
+  const _spaceName = spaceName || (_space && _space.name);
   if (spaceId || spaceName) {
     crumbs = [
       { name: _spaceName, url: spaceId && `/web/spaces/spaces/#/${spaceId}` },
     ];
   }
+
   return (
     <React.Fragment>
       <div className="d-flex align-items-start">
@@ -58,19 +82,9 @@ const PageHeader = ({
           )}{' '}
           {children || appName}
         </div>
-        {payerId && (
-          <Spaces
-            spaceIds={spaceId ? [spaceId] : undefined}
-            payerIds={[payerId]}
-            clientId={clientId}
-          >
-            <SpacesLogo
-              spaceId={spaceId}
-              payerId={payerId}
-              className="float-md-right d-inline-block"
-            />
-          </Spaces>
-        )}
+
+        {payerLogo}
+
         {feedback && (
           <Feedback
             appName={appName}

--- a/packages/page-header/README.md
+++ b/packages/page-header/README.md
@@ -35,9 +35,9 @@ The standard Availity application header which appears at the top of the page. I
 - **`feedbackProps`**: See [Feedback](../feedback/README.md). Props to send to `<Feedback />` component
 - **`crumbs`**: Array(Object) or [BreadCrumbs](../breadcrumbs/README.md) . Optional. Array of Objects contains `name` (String) and `url` (string) properties. Optional. The ancestor pages which gets passed to the `Breadcrumbs` component. See the children props sections of the @availity/Breadcrumbs documentation
 - **`component`**: Component. Optional. Allow rendering of an optional component in the top right of the header.
-- **`clientId`**: String. Optional. client id to use in [PayerLogo](../payer-logo/README.md)
+- **`clientId`**: String. Optional. client id to use in [spaces](../spaces/README.md) to fetch the payer's logo
 - **`iconSrc`**: String. Optional. Image source for `AppIcon` instead of `appAbbr`
--**`iconAlt`**: String. Required if `iconSrc`. Image alt property of `AppIcon`
+- **`iconAlt`**: String. Required if `iconSrc`. Image alt property of `AppIcon`
 
 ##### PageHeader Usage
 

--- a/packages/page-header/package.json
+++ b/packages/page-header/package.json
@@ -24,6 +24,7 @@
     "@availity/breadcrumbs": "^3.0.1",
     "@availity/feedback": "^4.1.6",
     "@availity/payer-logo": "^3.0.0",
+    "@availity/spaces": "^1.0.0",
     "@availity/training-link": "^1.1.4",
     "prop-types": "^15.5.8"
   },

--- a/packages/payer-logo/README.md
+++ b/packages/payer-logo/README.md
@@ -1,3 +1,5 @@
+# THIS PACKAGE HAS BEEN DEPRECATED IN FAVOR OF [spaces](../spaces)
+
 # @availity/payer-logo
 
 > Easy to use component to display the payer&#x27;s logo given the payer&#x27;s ID

--- a/packages/spaces/CHANGELOG.md
+++ b/packages/spaces/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+

--- a/packages/spaces/README.md
+++ b/packages/spaces/README.md
@@ -1,0 +1,87 @@
+# @availity/spaces
+
+> Easy to use spaces components
+
+## Installation
+
+```bash
+npm install @availity/spaces --save
+```
+
+## Spaces (Default export)
+This is the provider component needed for `@availity/spaces` components to work. All `@availity/spaces` components must be children of a Spaces provider.
+
+### Props
+
+- **`clientId`**: String. **Required** clientId to use in slotmachine request
+- **`query`**: String. Optional. Override the default slotmachine query
+- **`variables`**: Object. Override the default variables used in the slotmachine query
+
+
+### Images
+
+#### Usage
+```javascript
+import React from 'react';
+import Spaces, { SpacesLogo, SpacesBillboard, SpacesTile } from '@availity/spaces';
+// ... 
+<Spaces clientId="my-client-id">
+  <SpacesLogo spaceId="73162546201441126239486200007187" />
+  <SpacesBillboard payerId="PayerID" />
+  <SpacesTile payerId="PayerID" />
+</Spaces>
+// ...
+```
+
+#### SpacesLogo (Named export)
+Display the Space's logo
+
+#### SpacesTile (Named export)
+Display the Space's tile
+
+#### SpacesBillboard (Named export)
+Display the Space's billboard
+
+##### Props
+
+At least one of the following props must be provided:
+
+- **`spaceId`**: String. Optional, required if `payerId` is not provided. The payer spaces ID for the payer for which you want a image.
+- **`payerId`**: String. Optional, required if `spaceId` is not provided. The payer ID for the payer for which you want a image.
+
+### useSpaces
+
+This is a custom hook for grabbing any Spaces data you may need from the `Spaces` provider.
+
+#### Example usage
+
+```javascript
+import React from 'react';
+import { useSpaces } from '@availity/spaces';
+// ...
+const SpacesComponent = () => {
+    const [space, images] = useSpaces(spaceId, payerId);
+    // Returns space and images for spaceId, if available. Otherwise returns space and images for payerId
+};
+```
+
+### SpacesContext
+
+If you are using a class component, you can subscribe to the spaces by using this context.
+
+
+#### Example usage
+
+```javascript
+import React from 'react';
+import { SpacesContext } from '@availity/spaces';
+// ...
+class SpacesComponent extends React.Component {
+  render() { 
+    const [space, images] = useSpaces(spaceId, payerId);
+    // Returns space and images for spaceId, if available. Otherwise returns space and images for payerId
+  }
+}
+
+SpacesComponent.contextType = SpacesContext;
+```

--- a/packages/spaces/README.md
+++ b/packages/spaces/README.md
@@ -17,6 +17,9 @@ This is the provider component needed for `@availity/spaces` components to work.
 - **`query`**: String. Optional. Override the default slotmachine query
 - **`variables`**: Object. Override the default variables used in the slotmachine query
 
+At least one of the following props must be provided (and not empty)
+- **`spaceIds`**: String array. Array of spaceIds the Spaces provider should fetch the spaces for
+- **`payerIds`**: String array. Array of payerIds the Spaces provider should fetch the spaces for
 
 ### Images
 
@@ -25,7 +28,11 @@ This is the provider component needed for `@availity/spaces` components to work.
 import React from 'react';
 import Spaces, { SpacesLogo, SpacesBillboard, SpacesTile } from '@availity/spaces';
 // ... 
-<Spaces clientId="my-client-id">
+<Spaces
+  spaceIds={['73162546201441126239486200007187']}
+  payerIds={['PayerID']}
+  clientId="my-client-id"
+>
   <SpacesLogo spaceId="73162546201441126239486200007187" />
   <SpacesBillboard payerId="PayerID" />
   <SpacesTile payerId="PayerID" />
@@ -49,7 +56,7 @@ At least one of the following props must be provided:
 - **`spaceId`**: String. Optional, required if `payerId` is not provided. The payer spaces ID for the payer for which you want a image.
 - **`payerId`**: String. Optional, required if `spaceId` is not provided. The payer ID for the payer for which you want a image.
 
-### useSpaces
+### useSpace
 
 This is a custom hook for grabbing any Spaces data you may need from the `Spaces` provider.
 
@@ -57,11 +64,12 @@ This is a custom hook for grabbing any Spaces data you may need from the `Spaces
 
 ```javascript
 import React from 'react';
-import { useSpaces } from '@availity/spaces';
+import { useSpace } from '@availity/spaces';
 // ...
 const SpacesComponent = () => {
-    const [space, images] = useSpaces(spaceId, payerId);
-    // Returns space and images for spaceId, if available. Otherwise returns space and images for payerId
+    // id can be a space or a payer id
+    const {space, images} = useSpace(id);
+    // Returns space and images for id
 };
 ```
 
@@ -78,8 +86,9 @@ import { SpacesContext } from '@availity/spaces';
 // ...
 class SpacesComponent extends React.Component {
   render() { 
-    const [space, images] = useSpaces(spaceId, payerId);
-    // Returns space and images for spaceId, if available. Otherwise returns space and images for payerId
+    // id can be a space or a payer id
+    const {space, images} = this.context;
+    // Returns space and images for id
   }
 }
 

--- a/packages/spaces/index.d.ts
+++ b/packages/spaces/index.d.ts
@@ -1,0 +1,9 @@
+import Spaces from './types/Spaces';
+import SpacesImage from './types/SpacesImage';
+
+export default Spaces;
+
+export {
+    SpacesImage
+};
+

--- a/packages/spaces/index.js
+++ b/packages/spaces/index.js
@@ -1,4 +1,4 @@
-import Spaces from './src/Spaces';
+import Spaces, { useSpace, SpacesContext } from './src/Spaces';
 import SpacesImage from './src/SpacesImage';
 
 const SpacesLogo = SpacesImage.create({
@@ -15,4 +15,4 @@ const SpacesBillboard = SpacesImage.create({
 
 export default Spaces;
 
-export { SpacesLogo, SpacesTile, SpacesBillboard };
+export { SpacesLogo, SpacesTile, SpacesBillboard, useSpace, SpacesContext };

--- a/packages/spaces/index.js
+++ b/packages/spaces/index.js
@@ -1,0 +1,18 @@
+import Spaces from './src/Spaces';
+import SpacesImage from './src/SpacesImage';
+
+const SpacesLogo = SpacesImage.create({
+  imageType: 'logo',
+});
+
+const SpacesTile = SpacesImage.create({
+  imageType: 'tile',
+});
+
+const SpacesBillboard = SpacesImage.create({
+  imageType: 'billboard',
+});
+
+export default Spaces;
+
+export { SpacesLogo, SpacesTile, SpacesBillboard };

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@availity/spaces",
+  "version": "1.0.0",
+  "author": "Tyson Warner <tyson.warner@availity.com>",
+  "description": "Easy to use spaces components",
+  "main": "index.js",
+  "keywords": [
+    "react",
+    "availity"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@availity/api-axios": "^5.1.5",
+    "@availity/api-core": "^5.1.5",
+    "@availity/hooks": "^1.3.0",
+    "@availity/localstorage-core": "^2.6.1",
+    "axios": "^0.17.0",
+    "lodash.get": "^4.4.2",
+    "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "react-dom": "^16.8.6"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6"
+  }
+}

--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -92,6 +92,22 @@ const Spaces = ({
       _spaces = _spaces.concat(spacesByPayerIDs);
     }
 
+    // Normalize space pairs ( [{ name, value }} => { name: value } )
+    const pairFields = ['images', 'metadata', 'colors', 'icons', 'mapping'];
+    _spaces = _spaces.reduce((accum, spc) => {
+      pairFields.forEach(field => {
+        if (spc[field]) {
+          spc[field] = spc[field].reduce((_accum, { name, value }) => {
+            _accum[name] = value;
+            return _accum;
+          }, {});
+        }
+      });
+
+      accum.push(spc);
+      return accum;
+    }, []);
+
     if (_spaces.length > 0) setSpaces(_spaces);
   }, [payerIds, spaceIds]);
 
@@ -116,16 +132,7 @@ export const useSpace = id => {
     return spc;
   });
 
-  const images = useMemo(() => {
-    if (!space) return {};
-
-    return (space.images || []).reduce((accum, { name, value }) => {
-      accum[name] = value;
-      return accum;
-    }, {});
-  });
-
-  return { space, images };
+  return { space };
 };
 
 Spaces.propTypes = {

--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -1,0 +1,173 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+} from 'react';
+import PropTypes from 'prop-types';
+import { avSlotMachineApi } from '@availity/api-axios';
+import { useEffectAsync } from '@availity/hooks';
+
+export const getAllSpaces = async (
+  query,
+  clientId,
+  variables,
+  _spaces = []
+) => {
+  if (!clientId) {
+    throw new Error('clientId is required');
+  }
+
+  try {
+    const {
+      data: {
+        data: { spaces },
+      },
+    } = await avSlotMachineApi.create(
+      {
+        query,
+        variables,
+      },
+      { headers: { 'X-Client-ID': clientId } }
+    );
+
+    const { totalCount, page, perPage } = spaces;
+    const unionedSpaces = _spaces.concat(spaces.spaces);
+
+    if (totalCount > page * perPage) {
+      const vars = { ...variables, page: page + 1 };
+      return getAllSpaces(query, clientId, vars, unionedSpaces);
+    }
+
+    return unionedSpaces;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const SpacesContext = createContext();
+
+// getIDsFromChildren returns all the payer and space ids from the props of all the Spaces children in the Spaces provider
+export const getIDsFromChildren = (children, payerIDs = [], spaceIDs = []) => {
+  React.Children.forEach(children, child => {
+    if (React.isValidElement(child)) {
+      const { payerId, spaceId, children: grandChildren } = child.props;
+      // Check child is a spaces component
+      if (/^Spaces.*/.test(child.type.displayName)) {
+        if (payerId !== undefined) payerIDs.push(payerId);
+        if (spaceId !== undefined) spaceIDs.push(spaceId);
+      } else if (grandChildren) {
+        getIDsFromChildren(grandChildren, payerIDs, spaceIDs);
+      }
+    }
+  });
+
+  // Filter out dupes and order ids. We don't want to query slotmachine again just because the ids change order
+  spaceIDs = spaceIDs
+    .filter((id, i) => spaceIDs.indexOf(id) === i)
+    .sort((a, b) => (a > b ? 1 : -1));
+  payerIDs = payerIDs
+    .filter((id, i) => payerIDs.indexOf(id) === i)
+    .sort((a, b) => (a > b ? 1 : -1));
+
+  return { payerIDs, spaceIDs };
+};
+
+const Spaces = ({ query, variables, clientId, children }) => {
+  const [spaces, setSpaces] = useState([]);
+  const [payerIDs, setPayerIDs] = useState([]);
+  const [spaceIDs, setSpaceIDs] = useState([]);
+
+  useEffect(() => {
+    const { payerIDs: _payerIDs, spaceIDs: _spaceIDs } = getIDsFromChildren(
+      children
+    );
+    setSpaceIDs(_spaceIDs);
+    setPayerIDs(_payerIDs);
+  }, [children]);
+
+  // Gather all of the spaces given the space and payer ids in the Spaces Provider
+  useEffectAsync(async () => {
+    // NOTE: we do not want to query slotmachine by payerIDs and spaceIDs at the same time
+    // because slotmachine does an AND on those conditions. We want OR
+    let _spaces = [];
+    if (spaceIDs.length > 0) {
+      const vars = { ...variables, ids: spaceIDs };
+      const spacesBySpaceIDs = await getAllSpaces(query, clientId, vars);
+      _spaces = _spaces.concat(spacesBySpaceIDs);
+    }
+
+    if (payerIDs.length > 0) {
+      const vars = { ...variables, payerIDs };
+      const spacesByPayerIDs = await getAllSpaces(query, clientId, vars);
+      _spaces = _spaces.concat(spacesByPayerIDs);
+    }
+
+    if (_spaces.length > 0) setSpaces(_spaces);
+  }, [payerIDs, spaceIDs]);
+
+  return (
+    <SpacesContext.Provider value={{ spaces }}>
+      {children}
+    </SpacesContext.Provider>
+  );
+};
+
+export const useSpaces = (spaceId, payerId) => {
+  const { spaces = [] } = useContext(SpacesContext);
+
+  // Try to match by space id first, else match by payer id
+  const space = useMemo(() => {
+    let [spc] = spaces.filter(s => s.id === spaceId);
+
+    if (!spc) {
+      [spc] = spaces.filter(s => (s.payerIDs || []).some(p => p === payerId));
+    }
+
+    return spc;
+  });
+
+  const images = useMemo(() => {
+    if (!space) return {};
+
+    return (space.images || []).reduce((accum, { name, value }) => {
+      accum[name] = value;
+      return accum;
+    }, {});
+  });
+
+  return [space, images];
+};
+
+Spaces.propTypes = {
+  clientId: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  query: PropTypes.string,
+  variables: PropTypes.object,
+};
+
+Spaces.defaultProps = {
+  query: `
+    query($ids: [String!], $payerIDs: [String!], $types: [String!], $page: Int){
+      spaces(ids: $ids, payerIDs: $payerIDs, types: $types, page: $page){
+        totalCount
+        perPage
+        page
+        spaces{
+          id
+          name
+          description
+          payerIDs
+          images{
+            name
+            value
+          }
+        }
+      }
+    }
+  `,
+  variables: { types: ['space'] },
+};
+
+export default Spaces;

--- a/packages/spaces/src/SpacesImage.js
+++ b/packages/spaces/src/SpacesImage.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSpaces } from './Spaces';
+
+const SpacesImage = ({ spaceId, payerId, imageType, ...props }) => {
+  const [, images] = useSpaces(spaceId, payerId);
+
+  let url = images[imageType];
+
+  // We can probably remove this at some point once our spaces data is complete
+  if (!url && payerId && imageType === 'logo') {
+    url = `/public/apps/eligibility/images/value-add-logos/${payerId.replace(
+      /\s/g,
+      ''
+    )}.gif`;
+  }
+
+  if (!url || (!payerId && !spaceId)) return null;
+
+  return (
+    <img
+      data-testid={`space-${imageType}-${spaceId || payerId}`}
+      src={url}
+      alt={`Space ${imageType}`}
+      {...props}
+    />
+  );
+};
+
+SpacesImage.propTypes = {
+  spaceId: PropTypes.string,
+  payerId: PropTypes.string,
+  imageType: PropTypes.string.isRequired,
+};
+
+// Adapted from https://github.com/Availity/availity-react/blob/master/packages/reactstrap-validation-select/AvResourceSelect.js
+const ucFirst = str => str && str.charAt(0).toUpperCase() + str.slice(1);
+
+SpacesImage.create = defaults => {
+  const SpecificSpacesImage = props => <SpacesImage {...defaults} {...props} />;
+
+  SpecificSpacesImage.displayName = `Spaces${ucFirst(defaults.imageType)}`;
+  return SpecificSpacesImage;
+};
+
+export default SpacesImage;

--- a/packages/spaces/src/SpacesImage.js
+++ b/packages/spaces/src/SpacesImage.js
@@ -4,9 +4,9 @@ import { useSpace } from './Spaces';
 
 const SpacesImage = ({ spaceId, payerId, imageType, ...props }) => {
   const id = spaceId || payerId;
-  const { images } = useSpace(id);
+  const { space = {} } = useSpace(id);
 
-  let url = images[imageType];
+  let url = space.images && space.images[imageType];
 
   // We can probably remove this at some point once our spaces data is complete
   if (!url && payerId && imageType === 'logo') {

--- a/packages/spaces/src/SpacesImage.js
+++ b/packages/spaces/src/SpacesImage.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSpaces } from './Spaces';
+import { useSpace } from './Spaces';
 
 const SpacesImage = ({ spaceId, payerId, imageType, ...props }) => {
-  const [, images] = useSpaces(spaceId, payerId);
+  const id = spaceId || payerId;
+  const { images } = useSpace(id);
 
   let url = images[imageType];
 

--- a/packages/spaces/tests/Spaces.test.js
+++ b/packages/spaces/tests/Spaces.test.js
@@ -1,0 +1,53 @@
+import { avSlotMachineApi } from '@availity/api-axios';
+import { getAllSpaces } from '../src/Spaces';
+
+jest.mock('@availity/api-axios');
+
+describe('Spaces', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllSpaces', () => {
+    it('gets all spaces', async () => {
+      avSlotMachineApi.create
+        .mockResolvedValueOnce({
+          data: {
+            data: {
+              spaces: {
+                totalCount: 10,
+                page: 1,
+                perPage: 5,
+                spaces: [{ id: '1' }, {}, {}, {}, {}],
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: {
+              spaces: {
+                totalCount: 10,
+                page: 2,
+                perPage: 5,
+                spaces: [{}, {}, {}, {}, { id: '10' }],
+              },
+            },
+          },
+        });
+
+      const spaces = await getAllSpaces('query', 'clientId', {
+        types: ['space'],
+      });
+
+      // Check correct spaces get returned
+      expect(spaces.length).toBe(10);
+      expect(spaces[0].id).toBe('1');
+      expect(spaces[spaces.length - 1].id).toBe('10');
+
+      // Check correct slotmachine calls were made
+      expect(avSlotMachineApi.create).toHaveBeenCalledTimes(2);
+      expect(avSlotMachineApi.create.mock.calls[1][0].variables.page).toBe(2);
+    });
+  });
+});

--- a/packages/spaces/tests/SpacesImage.test.js
+++ b/packages/spaces/tests/SpacesImage.test.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, waitForElement, cleanup } from 'react-testing-library';
+import { avSlotMachineApi } from '@availity/api-axios';
+import Spaces, { SpacesLogo, SpacesTile, SpacesBillboard } from '..';
+
+jest.mock('@availity/api-axios');
+
+avSlotMachineApi.create
+  .mockResolvedValueOnce({
+    data: {
+      data: {
+        spaces: {
+          totalCount: 2,
+          page: 1,
+          perPage: 50,
+          spaces: [
+            {
+              id: '1',
+              images: [
+                {
+                  name: 'logo',
+                  value: '/static/spaces/1/banner.png',
+                },
+              ],
+            },
+            {
+              id: '2',
+              payerIDs: ['payer1'],
+              images: [
+                {
+                  name: 'tile',
+                  value: '/static/spaces/2/tile.png',
+                },
+                {
+                  name: 'billboard',
+                  value: '/static/spaces/2/billboard.png',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  })
+  .mockResolvedValueOnce({
+    data: {
+      data: {
+        spaces: {
+          totalCount: 1,
+          page: 1,
+          perPage: 50,
+          spaces: [
+            {
+              id: '2',
+              payerIDs: ['payer1'],
+              images: [
+                {
+                  name: 'tile',
+                  value: '/static/spaces/2/tile.png',
+                },
+                {
+                  name: 'billboard',
+                  value: '/static/spaces/2/billboard.png',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  });
+
+describe('SpacesImage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  it('renders the spaces images in the spaces provider', async () => {
+    const { getByTestId } = render(
+      <Spaces clientId="my-client-id">
+        {/* wrap SpacesImages in divs to test deeply nested spaces images still get rendered */}
+        <div>
+          <SpacesLogo spaceId="1" />
+        </div>
+        <div>
+          <SpacesTile payerId="payer1" />
+        </div>
+        <div>
+          <SpacesBillboard spaceId="2" />
+        </div>
+      </Spaces>
+    );
+
+    // Check logo rendered
+    await waitForElement(() => getByTestId('space-logo-1'));
+
+    // Check tile rendered
+    await waitForElement(() => getByTestId('space-tile-payer1'));
+
+    // Check billboard rendered
+    await waitForElement(() => getByTestId('space-billboard-2'));
+
+    expect(avSlotMachineApi.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/spaces/tests/SpacesImage.test.js
+++ b/packages/spaces/tests/SpacesImage.test.js
@@ -77,30 +77,39 @@ describe('SpacesImage', () => {
   });
 
   it('renders the spaces images in the spaces provider', async () => {
-    const { getByTestId } = render(
-      <Spaces clientId="my-client-id">
-        {/* wrap SpacesImages in divs to test deeply nested spaces images still get rendered */}
-        <div>
-          <SpacesLogo spaceId="1" />
-        </div>
-        <div>
-          <SpacesTile payerId="payer1" />
-        </div>
-        <div>
-          <SpacesBillboard spaceId="2" />
-        </div>
+    const MyComponent = () => (
+      <Spaces
+        spaceIds={['1', '1', '2', '2']}
+        payerIds={['payer1', 'payer1']}
+        clientId="my-client-id"
+      >
+        <SpacesLogo spaceId="1" />
+        <SpacesTile payerId="payer1" />
+        <SpacesBillboard spaceId="2" />
+        <SpacesLogo spaceId="1" />
+        <SpacesTile payerId="payer1" />
+        <SpacesBillboard spaceId="2" />
       </Spaces>
     );
+    const { getAllByTestId } = render(<MyComponent />);
 
     // Check logo rendered
-    await waitForElement(() => getByTestId('space-logo-1'));
+    await waitForElement(() => getAllByTestId('space-logo-1'));
 
     // Check tile rendered
-    await waitForElement(() => getByTestId('space-tile-payer1'));
+    await waitForElement(() => getAllByTestId('space-tile-payer1'));
 
     // Check billboard rendered
-    await waitForElement(() => getByTestId('space-billboard-2'));
+    await waitForElement(() => getAllByTestId('space-billboard-2'));
 
+    // Check that we did not query for duplicate ids
     expect(avSlotMachineApi.create).toHaveBeenCalledTimes(2);
+    expect(avSlotMachineApi.create.mock.calls[0][0].variables.ids).toEqual([
+      '1',
+      '2',
+    ]);
+    expect(avSlotMachineApi.create.mock.calls[1][0].variables.payerIDs).toEqual(
+      ['payer1']
+    );
   });
 });

--- a/packages/spaces/types/Spaces.d.ts
+++ b/packages/spaces/types/Spaces.d.ts
@@ -2,7 +2,9 @@ export interface SpacesProps {
     clientId: string;
     children?: React.ReactType;
     query?: string;
-    variables?: Object
+    variables?: Object;
+    spaceIds: Array<string>;
+    payerIds: Array<string>;
 }
 
 declare const Spaces: React.FunctionComponent<SpacesProps>;

--- a/packages/spaces/types/Spaces.d.ts
+++ b/packages/spaces/types/Spaces.d.ts
@@ -1,0 +1,10 @@
+export interface SpacesProps {
+    clientId: string;
+    children?: React.ReactType;
+    query?: string;
+    variables?: Object
+}
+
+declare const Spaces: React.FunctionComponent<SpacesProps>;
+
+export default Spaces;

--- a/packages/spaces/types/SpacesImage.d.ts
+++ b/packages/spaces/types/SpacesImage.d.ts
@@ -1,0 +1,9 @@
+export interface SpacesImageProps {
+    spaceId?: string;
+    payerId?: string;
+    imageType: string;
+}
+
+declare const SpacesImage: React.FunctionComponent<SpacesImageProps>;
+
+export default SpacesImage;


### PR DESCRIPTION
This a follow up PR to this PR that I declined: https://github.com/Availity/availity-react/pull/118

The main difference in this PR and the previous one is this one uses React context to expose a Spaces provider. This way, several spaces images can be rendered under a Spaces Provider and we only have to make one ajax request to get the spaces. Another change is this package is no longer intended strictly for images.

As part of this change, I'm proposing:

1. Deprecating the existing @availity/payer-logo package on npm
2. Switching page-header to use `spaces` instead of `payer-logo`

Notes:

I added a deprecation notice to the README of the `payer-logo` package. If it would be preferred to remove it from source control entirely, please let me know.