### PR TITLE
feat(pagination): adding defaultPage prop

### DIFF
--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -30,6 +30,7 @@ This is the provider component for pagination to work. All the inner components 
 - **`itemsPerPage`**: number. default `10`. The total amount of items to render at a time. ( After all the filtering )
 - **`onPageChange`**: function. optional. When the user changes the page, this will be called after the new page has been set.
 - **`watchList`**: Array. optional. Array of data points you want pagination to re-render if changed. This is helpful for when the function is passed in the `items` prop and you want to force call the pagination update.
+- **`defaultPage`**: number. optional. The starting page to use when the component mounts.
 
 #### Example usage
 

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -27,7 +27,7 @@ const Pagination = ({
   watchList,
   defaultPage,
 }) => {
-  const [currentPage, setPage] = useState(defaultPage || 1);
+  const [currentPage, setPage] = useState(defaultPage);
   const [pageData, setPageData] = useState({
     total: theItems != null && !isFunction(theItems) ? theItems.totalCount : 0,
     pageCount: 0,
@@ -122,6 +122,7 @@ Pagination.defaultProps = {
   itemsPerPage: 10,
   items: [],
   watchList: [],
+  defaultPage: 1,
 };
 
 export default Pagination;

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -25,8 +25,9 @@ const Pagination = ({
   onPageChange,
   children,
   watchList,
+  defaultPage,
 }) => {
-  const [currentPage, setPage] = useState(1);
+  const [currentPage, setPage] = useState(defaultPage || 1);
   const [pageData, setPageData] = useState({
     total: theItems != null && !isFunction(theItems) ? theItems.totalCount : 0,
     pageCount: 0,
@@ -114,6 +115,7 @@ Pagination.propTypes = {
   onPageChange: PropTypes.func,
   children: PropTypes.node,
   watchList: PropTypes.array,
+  defaultPage: PropTypes.number,
 };
 
 Pagination.defaultProps = {

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -205,4 +205,46 @@ describe('Pagination', () => {
 
     expect(mockFunc).toHaveBeenCalledTimes(3);
   });
+
+  test('show correct page when given defaultPage', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1} defaultPage={2}>
+        <PaginationJson />
+        <PaginationControls directionLinks />
+      </Pagination>
+    );
+
+    let paginationCon = await waitForElement(() =>
+      getByTestId('pagination-con')
+    );
+
+    expect(paginationCon).toBeDefined();
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: [items[1]],
+      })
+    );
+
+    // Testing that clicking next still works with a defaultPage
+    fireEvent.click(getByTestId('pagination-control-next-link'));
+
+    // Wait for component to render nothing
+    waitForDomChange(() => getByTestId('pagination-con'));
+
+    // Get the component now with the new page data
+    paginationCon = await waitForElement(() => getByTestId('pagination-con'));
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: [items[2]],
+      })
+    );
+  });
 });

--- a/packages/pagination/types/Pagination.d.ts
+++ b/packages/pagination/types/Pagination.d.ts
@@ -4,6 +4,7 @@ export interface PaginationProps {
     children?: React.ReactType;
     onPageChange?: Function;
     watchList?: Array<any>;
+    defaultPage?: number;
 }
 
 declare const Pagination: React.FunctionComponent<PaginationProps>;


### PR DESCRIPTION
For the story I'm working on, I'm replacing some legacy pagination with this newer one, and one of the requirements is that if the user clicks on an item on the page and gets taken to a different page in the same app, then goes back, it needs to be on the same page. Since the component unmounts when we show the other page it loses its state, so with this prop, we can store the current page at a higher level and pass it into the defaultPage prop when we want to show the Pagination again.

Thanks!