### PR TITLE
feat(link): add loadApp prop

### DIFF
--- a/packages/link/Link.d.ts
+++ b/packages/link/Link.d.ts
@@ -4,6 +4,7 @@ export interface AvLinkProps {
     tag?: React.ReactType | string;
     children?: any;
     onClick?: Function;
+    loadApp?: boolean;
 }
 
 declare const AvLink: React.FunctionComponent<AvLinkProps>;

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -2,19 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isAbsoluteUrl } from '@availity/resolve-url';
 
-// if absolute, return url. otherwise loadappify the url
-export const getUrl = (url = '') => {
+// if absolute or loadApp is disabled, return url. otherwise loadappify the url
+export const getUrl = (url = '', loadApp) => {
   const absolute = isAbsoluteUrl(url);
-  if (absolute) return url;
+  if (absolute || !loadApp) return url;
 
   return `/public/apps/home/#!/loadApp?appUrl=${encodeURIComponent(url)}`;
 };
 
-const AvLink = ({ tag: Tag, url, target, children, onClick, ...props }) => (
+const AvLink = ({
+  tag: Tag,
+  url,
+  target,
+  children,
+  onClick,
+  loadApp,
+  ...props
+}) => (
   <Tag
-    href={getUrl(url)}
+    href={getUrl(url, loadApp)}
     target={target}
-    onClick={event => onClick && onClick(event, getUrl(url))}
+    onClick={event => onClick && onClick(event, getUrl(url, loadApp))}
     data-testid="av-link-tag"
     {...props}
   >
@@ -24,6 +32,7 @@ const AvLink = ({ tag: Tag, url, target, children, onClick, ...props }) => (
 
 AvLink.defaultProps = {
   tag: 'a',
+  loadApp: true,
 };
 
 AvLink.propTypes = {
@@ -32,6 +41,7 @@ AvLink.propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.node,
   onClick: PropTypes.func,
+  loadApp: PropTypes.bool,
 };
 
 export default AvLink;

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -28,3 +28,4 @@ import AvLink from '@availity/link';
 - **`target`**: String. Optional. Where to open the linked document
 - **`tag`**: React component. Optional. The tag to use in the link that gets rendered. Defaults to an `<a>` tag
 - **`onClick`**: Function. Optional. Function to run onClick of the tag. The first argument that gets passed to `onClick` is the event. The second is the processed `url`.
+- **`loadApp`**: Boolean. Optional. Default `true`. When `false`, the `url` prop to `AvLink` _will not_ be formatted to leverage loadApp.

--- a/packages/link/test/Link.test.js
+++ b/packages/link/test/Link.test.js
@@ -26,4 +26,17 @@ describe('AvLink', () => {
 
     expect(tag.getAttribute('href')).toBe(expected);
   });
+
+  test('should render url prop as is when loadApp is false', () => {
+    const { getByTestId } = render(
+      <AvLink loadApp={false} url="/public/apps/my-app">
+        My App
+      </AvLink>
+    );
+
+    const tag = getByTestId('av-link-tag');
+    const expected = '/public/apps/my-app';
+
+    expect(tag.getAttribute('href')).toBe(expected);
+  });
 });


### PR DESCRIPTION
closes #163 

When `loadApp` is "true", (the default), the `url` prop will be formatted
to leverage "loadApp". When `loadApp` is "false", the `url` prop _will
not_ be formatted to leverage "loadApp".