### PR TITLE
refactor(reactstrap-validation-date): fixed datepicker prop for hiding

### DIFF
--- a/packages/docs/stories/avdate.stories.js
+++ b/packages/docs/stories/avdate.stories.js
@@ -35,7 +35,6 @@ storiesOf('Components|AvDate', module)
         required={boolean('Required', false)}
         disabled={boolean('Disabled', false)}
         datepicker={boolean('Has DatePicker', true)}
-        hideIcon={boolean('Hide Calendar Icon', false)}
       />
       <Button className="mt-3" color="primary">
         Submit
@@ -55,7 +54,6 @@ storiesOf('Components|AvDate', module)
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           datepicker={boolean('Has DatePicker', true)}
-          hideIcon={boolean('Hide Calendar Icon', false)}
         />
         <AvFeedback>
           {text('Error Message', 'This field is invalid')}
@@ -86,7 +84,6 @@ storiesOf('Components|AvDate', module)
                 text('Required Error Message', 'This field is required'),
             },
           }}
-          hideIcon={boolean('Hide Calendar Icon', false)}
         />
         <Button color="primary">Submit</Button>
       </AvFormResults>
@@ -114,7 +111,7 @@ storiesOf('Components|AvDate', module)
                 text('Required Error Message', 'This field is required'),
             },
           }}
-          hideIcon={boolean('Hide Calendar Icon', false)}
+          datepicker={boolean('Has DatePicker', true)}
         />
         <Button color="primary">Submit</Button>
       </AvFormResults>
@@ -143,7 +140,7 @@ storiesOf('Components|AvDate', module)
                 text('Required Error Message', 'This field is required'),
             },
           }}
-          hideIcon={boolean('Hide Calendar Icon', false)}
+          datepicker={boolean('Has DatePicker', true)}
         />
         <Button color="primary">Submit</Button>
       </AvFormResults>

--- a/packages/reactstrap-validation-date/AvDate.js
+++ b/packages/reactstrap-validation-date/AvDate.js
@@ -56,7 +56,6 @@ class AvDate extends Component {
   static propTypes = {
     ...AvInput.propTypes,
     calendarIcon: PropTypes.node,
-    hideIcon: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -67,7 +66,6 @@ class AvDate extends Component {
     type: 'text',
     datepicker: true,
     calendarIcon: <Icon name="calendar" />,
-    hideIcon: false,
   };
 
   static getDerivedStateFromProps = ({ value }, prevState) => {
@@ -186,23 +184,21 @@ class AvDate extends Component {
     return (
       <div className="input-group">
         {input}
-        {!hideIcon && (
-          <InputGroupAddon addonType="append">
-            <Button
-              id={id}
-              color="light"
-              type="button"
-              onClick={this.togglePicker}
-              disabled={props.disabled}
-              style={{
-                zIndex: 'auto',
-              }}
-            >
-              {calendarIcon}
-              <span className="sr-only">Toggle Calendar</span>
-            </Button>
-          </InputGroupAddon>
-        )}
+        <InputGroupAddon addonType="append">
+          <Button
+            id={id}
+            color="light"
+            type="button"
+            onClick={this.togglePicker}
+            disabled={props.disabled}
+            style={{
+              zIndex: 'auto',
+            }}
+          >
+            {calendarIcon}
+            <span className="sr-only">Toggle Calendar</span>
+          </Button>
+        </InputGroupAddon>
         <Popover
           placement="top"
           target={id}

--- a/packages/reactstrap-validation-date/AvDateRange.js
+++ b/packages/reactstrap-validation-date/AvDateRange.js
@@ -95,7 +95,7 @@ export default class AvDateRange extends Component {
     defaultValues: PropTypes.object,
     theme: PropTypes.object,
     calendarIcon: PropTypes.node,
-    hideIcon: PropTypes.bool,
+    datepicker: PropTypes.bool,
   };
 
   static contextTypes = { FormCtrl: PropTypes.object.isRequired };
@@ -103,7 +103,7 @@ export default class AvDateRange extends Component {
   static defaultProps = {
     type: 'text',
     calendarIcon: <Icon name="calendar" />,
-    hideIcon: false,
+    datepicker: true,
   };
 
   constructor(props, context) {
@@ -384,56 +384,59 @@ export default class AvDateRange extends Component {
           aria-label="To Date"
           datepicker={false}
         />
-        {!this.props.hideIcon && (
-          <InputGroupAddon addonType="append">
-            <Button
-              id={this.guid}
-              color="light"
-              type="button"
-              disabled={this.props.disabled}
-              onClick={this.togglePicker}
-              style={{
-                lineHeight:
-                  this.state.format === isoDateFormat ? '1.4' : undefined,
-                zIndex: 'auto',
-              }}
+        {this.props.datepicker && (
+          <>
+            <InputGroupAddon addonType="append">
+              <Button
+                id={this.guid}
+                color="light"
+                type="button"
+                disabled={this.props.disabled}
+                onClick={this.togglePicker}
+                style={{
+                  lineHeight:
+                    this.state.format === isoDateFormat ? '1.4' : undefined,
+                  zIndex: 'auto',
+                }}
+              >
+                {this.props.calendarIcon}
+                <span className="sr-only">Toggle Calendar</span>
+              </Button>
+            </InputGroupAddon>
+
+            <Popover
+              placement="top"
+              target={this.guid}
+              isOpen={this.state.open}
+              toggle={this.toggle}
+              className="popover-calendar-range"
             >
-              {this.props.calendarIcon}
-              <span className="sr-only">Toggle Calendar</span>
-            </Button>
-          </InputGroupAddon>
+              <DateRange
+                startDate={this.state.startValue}
+                endDate={
+                  dayjs(new Date(this.state.endValue)).isValid()
+                    ? this.state.endValue
+                    : null
+                }
+                maxDate={this.props.max}
+                minDate={this.props.min}
+                ranges={
+                  // eslint-disable-next-line no-nested-ternary
+                  this.props.ranges !== undefined
+                    ? Array.isArray(this.props.ranges)
+                      ? pick(relativeRanges, this.props.ranges)
+                      : this.props.ranges
+                    : relativeRanges
+                }
+                onChange={this.onPickerChange}
+                format={this.state.format}
+                theme={this.props.theme || theme}
+                twoStepChange
+                linkedCalendars
+              />
+            </Popover>
+          </>
         )}
-        <Popover
-          placement="top"
-          target={this.guid}
-          isOpen={this.state.open}
-          toggle={this.toggle}
-          className="popover-calendar-range"
-        >
-          <DateRange
-            startDate={this.state.startValue}
-            endDate={
-              dayjs(new Date(this.state.endValue)).isValid()
-                ? this.state.endValue
-                : null
-            }
-            maxDate={this.props.max}
-            minDate={this.props.min}
-            ranges={
-              // eslint-disable-next-line no-nested-ternary
-              this.props.ranges !== undefined
-                ? Array.isArray(this.props.ranges)
-                  ? pick(relativeRanges, this.props.ranges)
-                  : this.props.ranges
-                : relativeRanges
-            }
-            onChange={this.onPickerChange}
-            format={this.state.format}
-            theme={this.props.theme || theme}
-            twoStepChange
-            linkedCalendars
-          />
-        </Popover>
       </div>
     );
   }


### PR DESCRIPTION
BREAKING CHANGE: removed the hideIcon prop in favor of the datepicker prop from the standard date picker to keep the same high level API for showing and hiding the calendar