### PR TITLE
docs: added npm version shields to each package

### DIFF
--- a/packages/app-icon/README.md
+++ b/packages/app-icon/README.md
@@ -1,6 +1,7 @@
 # @availity/app-icon
-
 > Availity UI Kit application icon react component.
+
+[![Version](https://img.shields.io/npm/v/@availity/app-icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/app-icon)
 
 ## Installation
 

--- a/packages/authorize/README.md
+++ b/packages/authorize/README.md
@@ -2,6 +2,8 @@
 
 > Check user permissions to see if the current user is authorized to see your content.
 
+[![Version](https://img.shields.io/npm/v/@availity/authorize.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/authorize)
+
 ## Installation
 
 ```bash

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -2,6 +2,8 @@
 
 > Availity breadcrumbs
 
+[![Version](https://img.shields.io/npm/v/@availity/breadcrumbs.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/breadcrumbs)
+
 ## Installation
 
 ```bash

--- a/packages/favorites/README.md
+++ b/packages/favorites/README.md
@@ -2,6 +2,8 @@
 
 > Favorite Heart for favoriting items such as resources/applications etc.
 
+[![Version](https://img.shields.io/npm/v/@availity/favorites.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/favorites)
+
 ## Installation
 
 ```bash

--- a/packages/feature/README.md
+++ b/packages/feature/README.md
@@ -2,6 +2,8 @@
 
 > Check environment features for the current environment to determine if a particular feature is enabled.
 
+[![Version](https://img.shields.io/npm/v/@availity/feature.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feature)
+
 Note: Only works with OpenShift deployed applications using the standard pipeline
 
 ## Installation

--- a/packages/feedback/README.md
+++ b/packages/feedback/README.md
@@ -2,6 +2,8 @@
 
 > Availity feedback with simley faces react component.
 
+[![Version](https://img.shields.io/npm/v/@availity/feedback.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feedback)
+
 ## Installation
 
 ```bash

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -2,6 +2,8 @@
 
 > Re-usable hooks for components and apps.
 
+[![Version](https://img.shields.io/npm/v/@availity/hooks.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/hooks)
+
 ## Installation
 
 ```bash

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -2,6 +2,8 @@
 
 > Simple icon component that is a wrapper for the icons in the availity uikit. **[Icon List](http://availity.github.io/availity-uikit/v3/icons)**
 
+[![Version](https://img.shields.io/npm/v/@availity/icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/icon)
+
 ## Installation
 
 ```bash

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -2,6 +2,8 @@
 
 > Simple link component that renders an `<a>` tag with the `href` formatted to leverage loadApp so that when the link is opened in a new tab, it gets loaded inside the home page's iframe
 
+[![Version](https://img.shields.io/npm/v/@availity/link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/link)
+
 ## Installation
 
 ```bash

--- a/packages/list-group-item/README.md
+++ b/packages/list-group-item/README.md
@@ -2,6 +2,8 @@
 
 > List Group Item with some Availity flair
 
+[![Version](https://img.shields.io/npm/v/@availity/list-group-item.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group-item)
+
 ## Installation
 
 ```bash

--- a/packages/list-group/README.md
+++ b/packages/list-group/README.md
@@ -2,6 +2,8 @@
 
 > List Group with some Availity flair
 
+[![Version](https://img.shields.io/npm/v/@availity/list-group.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group)
+
 ## Installation
 
 ```bash

--- a/packages/page-header/README.md
+++ b/packages/page-header/README.md
@@ -2,6 +2,8 @@
 
 > The standard page header for Availity Portal Applications
 
+[![Version](https://img.shields.io/npm/v/@availity/page-header.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/page-header)
+
 ## Installation
 
 ```bash

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -2,6 +2,8 @@
 
 > Pagination, the Availity way.
 
+[![Version](https://img.shields.io/npm/v/@availity/pagination.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/pagination)
+
 ## Installation
 
 ```bash

--- a/packages/payer-logo/README.md
+++ b/packages/payer-logo/README.md
@@ -2,6 +2,8 @@
 
 > THIS PACKAGE HAS BEEN DEPRECATED IN FAVOR OF `@availity/spaces`
 
+[![Version](https://img.shields.io/npm/v/@availity/payer-logo.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/payer-logo)
+
 Easy to use component to display the payer&#x27;s logo given the payer&#x27;s ID
 
 ## Installation

--- a/packages/progress/README.md
+++ b/packages/progress/README.md
@@ -2,6 +2,8 @@
 
 > Availity Progress Bar
 
+[![Version](https://img.shields.io/npm/v/@availity/progress.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/progress)
+
 ## Installation
 
 ```bash

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -2,6 +2,8 @@
 
 > Wrapper for react-date-range to work with availity-reactstrap-validation.
 
+[![Version](https://img.shields.io/npm/v/@availity/reactstrap-validation-date.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-date)
+
 ## Installation
 
 ```bash

--- a/packages/reactstrap-validation-select/README.md
+++ b/packages/reactstrap-validation-select/README.md
@@ -2,6 +2,8 @@
 
 > Wrapper for react-select (with async pagination) to work with availity-reactstrap-validation.
 
+[![Version](https://img.shields.io/npm/v/@availity/reactstrap-validation-select.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-select)
+
 ## Installation
 
 ```bash

--- a/packages/spaces/README.md
+++ b/packages/spaces/README.md
@@ -2,6 +2,8 @@
 
 > Easy to use spaces components
 
+[![Version](https://img.shields.io/npm/v/@availity/spaces.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/spaces)
+
 ## Installation
 
 ```bash

--- a/packages/step-wizard/README.md
+++ b/packages/step-wizard/README.md
@@ -2,6 +2,8 @@
 
 > Step Wizard - the Availity Way
 
+[![Version](https://img.shields.io/npm/v/@availity/step-wizard.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/step-wizard)
+
 ## Installation
 
 ```bash

--- a/packages/training-link/README.md
+++ b/packages/training-link/README.md
@@ -2,6 +2,8 @@
 
 > Component for allowing link out to training in the Header component
 
+[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/training-link)
+
 ## Installation
 
 ```bash

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -2,6 +2,8 @@
 
 > Availity typography components
 
+[![Version](https://img.shields.io/npm/v/@availity/typography.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/typography)
+
 ## Installation
 
 ```bash

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -2,6 +2,8 @@
 
 > Availity component for uploading files
 
+[![Version](https://img.shields.io/npm/v/@availity/upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/upload)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
When you are too lazy to click into the package.json file for each of the components to check their version, we use shields