### PR TITLE
docs(hooks): fixed react-hooks doc format

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -59,13 +59,13 @@ const Component = () => {
     const [isToggled,toggle] = useToggle(true);
 
     return <div onClick={() => toggle(true)}>{isToggled ? 'Hello' : 'World'</div>;
-}```
+}
+```
 
 #### useEffectAsync
 Hook that will allow asynchronous functions to be called in the standard `useEffect` React hook.
 
 ##### Arguments
-
 - **`effect`**: The effect to be called just like the function given to `useEffect`.
 - **`inputs`**: The watch params for the effect just like the second arg in `useEffect`.
 


### PR DESCRIPTION
Documentation had a wrong codeblock closing line