### PR TITLE
Refactor/187

### DIFF
--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -5,7 +5,6 @@ import { AvBaseInput } from 'availity-reactstrap-validation';
 import Select, { components as reactSelectComponents } from 'react-select';
 import get from 'lodash.get';
 import isEqual from 'lodash.isEqual';
-import find from 'lodash/find';
 
 import AsyncPaginate from 'react-select-async-paginate';
 
@@ -44,7 +43,10 @@ class AvSelect extends AvBaseInput {
 
   optionsContainsValue = (props, value) => {
     const valueKey = this.getValueKey(props);
-    return !!find(props.options, [valueKey, value]);
+    const matchingValues = props.options.filter(
+      option => option.value === valueKey
+    );
+    return matchingValues.length > 0;
   };
 
   componentWillReceiveProps(nextProps) {

--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { AvBaseInput } from 'availity-reactstrap-validation';
 import Select, { components as reactSelectComponents } from 'react-select';
-import get from 'lodash/get';
+import { get } from 'lodash.get';
 import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
 

--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { AvBaseInput } from 'availity-reactstrap-validation';
 import Select, { components as reactSelectComponents } from 'react-select';
-import { get } from 'lodash.get';
+import get from 'lodash.get';
+import isEqual from 'lodash.isEqual';
 import find from 'lodash/find';
-import isEqual from 'lodash/isEqual';
 
 import AsyncPaginate from 'react-select-async-paginate';
 

--- a/packages/reactstrap-validation-select/package.json
+++ b/packages/reactstrap-validation-select/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "lodash": "^4.17.10",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.5.8",

--- a/packages/reactstrap-validation-select/package.json
+++ b/packages/reactstrap-validation-select/package.json
@@ -43,6 +43,7 @@
     "classnames": "^2.2.5",
     "lodash": "^4.17.10",
     "lodash.get": "^4.4.2",
+    "lodash.isequal": "^4.5.0",
     "prop-types": "^15.5.8",
     "qs": "^6.5.2",
     "react-select": "^3.0.3",

--- a/packages/reactstrap-validation-select/package.json
+++ b/packages/reactstrap-validation-select/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash": "^4.17.10",
+    "lodash.get": "^4.4.2",
     "prop-types": "^15.5.8",
     "qs": "^6.5.2",
     "react-select": "^3.0.3",


### PR DESCRIPTION
Removed lodash package, keeping only the `get` and `isEqual` modules. Kept `isEqual` because it can be quicker than other ways of comparing objects. It also avoids the case of calling `this.updateValidations(nextProps)` when the objects are the same but the order of their keys are different.

closes #187 