### PR TITLE
feat(reactstrap-validation-date): Adding in buttonColorOnChange props

### DIFF
--- a/packages/reactstrap-validation-date/AvDateRange.js
+++ b/packages/reactstrap-validation-date/AvDateRange.js
@@ -234,7 +234,9 @@ export default class AvDateRange extends Component {
         if (!mEnd.isBefore(mStart.add(max.value, max.units), 'day')) {
           return (
             max.errorMessage ||
-            `The end date must be within ${max.value} ${max.units} of the start date`
+            `The end date must be within ${max.value} ${
+              max.units
+            } of the start date`
           );
         }
       }
@@ -242,7 +244,9 @@ export default class AvDateRange extends Component {
         if (mEnd.isAfter(mStart.add(min.value, min.units), 'day')) {
           return (
             min.errorMessage ||
-            `The end date must be greater than ${min.value} ${min.units} of the start date`
+            `The end date must be greater than ${min.value} ${
+              min.units
+            } of the start date`
           );
         }
       }
@@ -318,7 +322,6 @@ export default class AvDateRange extends Component {
     }
     const startValue = range.startDate.format(this.state.format);
     const endValue = range.endDate.format(this.state.format);
-    console.log(this.state.buttonColor, this.props.buttonColorOnChange);
 
     this.setState(
       {
@@ -336,8 +339,6 @@ export default class AvDateRange extends Component {
             end: endValue,
           });
         }
-
-        console.log(this.state.buttonColor, this.props.buttonColorOnChange);
 
         this.checkDistanceValidation(endValue, {
           [this.props.start.name]: startValue,

--- a/packages/reactstrap-validation-date/AvDateRange.js
+++ b/packages/reactstrap-validation-date/AvDateRange.js
@@ -96,6 +96,7 @@ export default class AvDateRange extends Component {
     theme: PropTypes.object,
     calendarIcon: PropTypes.node,
     datepicker: PropTypes.bool,
+    buttonColorOnChange: PropTypes.string,
   };
 
   static contextTypes = { FormCtrl: PropTypes.object.isRequired };
@@ -113,6 +114,7 @@ export default class AvDateRange extends Component {
       open: false,
       startValue: props.start.value,
       endValue: props.end.value,
+      buttonColor: 'light',
     };
     if (props.type.toLowerCase() === 'date' && inputType.date) {
       this.state.format = isoDateFormat;
@@ -232,9 +234,7 @@ export default class AvDateRange extends Component {
         if (!mEnd.isBefore(mStart.add(max.value, max.units), 'day')) {
           return (
             max.errorMessage ||
-            `The end date must be within ${max.value} ${
-              max.units
-            } of the start date`
+            `The end date must be within ${max.value} ${max.units} of the start date`
           );
         }
       }
@@ -242,9 +242,7 @@ export default class AvDateRange extends Component {
         if (mEnd.isAfter(mStart.add(min.value, min.units), 'day')) {
           return (
             min.errorMessage ||
-            `The end date must be greater than ${min.value} ${
-              min.units
-            } of the start date`
+            `The end date must be greater than ${min.value} ${min.units} of the start date`
           );
         }
       }
@@ -320,11 +318,16 @@ export default class AvDateRange extends Component {
     }
     const startValue = range.startDate.format(this.state.format);
     const endValue = range.endDate.format(this.state.format);
+    console.log(this.state.buttonColor, this.props.buttonColorOnChange);
+
     this.setState(
       {
         startValue,
         endValue,
         open: false,
+        buttonColor: this.props.buttonColorOnChange
+          ? this.props.buttonColorOnChange
+          : 'light',
       },
       () => {
         if (this.props.onChange) {
@@ -333,6 +336,9 @@ export default class AvDateRange extends Component {
             end: endValue,
           });
         }
+
+        console.log(this.state.buttonColor, this.props.buttonColorOnChange);
+
         this.checkDistanceValidation(endValue, {
           [this.props.start.name]: startValue,
         });
@@ -389,7 +395,7 @@ export default class AvDateRange extends Component {
             <InputGroupAddon addonType="append">
               <Button
                 id={this.guid}
-                color="light"
+                color={this.state.buttonColor}
                 type="button"
                 disabled={this.props.disabled}
                 onClick={this.togglePicker}

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -120,7 +120,7 @@ See availity-reactstrap-validation for additional props, such as `name`, `valida
 *   **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 *    **`buttonColorOnChange`**: String. Optional. Default: `light`. You can optionally change the buttonColor when the DatePicker Changes
 
-#### AvDateRange Example  
+#### AvDateRange Example usage
 
 ```javascript
 import React from 'react';

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @availity/reactstrap-validation-date availity-reactstrap-validation reactstrap react --save
+    npm install @availity/reactstrap-validation-date availity-reactstrap-validation reactstrap react --save
 ```
 
 ### Usage
@@ -113,13 +113,14 @@ This is the underlying date-range without the `AvGroup`, `Label` or `AvFeedback`
 
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
 
-*   **`ranges`**: Object or Array. Optional. Default: `['Last 7 Days','Last 30 Days','Last Calendar Month','Last 120 Days','Last 6 Months','Last 12 Months']`. Controls the preset range options which allows the user to easily select predefined ranges. If an array, the array *must* be a subset of the default array, any string not in the array will be omitted. If an object, the keys will be the display text and the value will be an object containing `startDate` and `endDate` *function* which will be called with the current date `dayjs` object and are expected to return the start and end dates respectfully.
+* **`ranges`**: Object or Array. Optional. Default: `['Last 7 Days','Last 30 Days','Last Calendar Month','Last 120 Days','Last 6 Months','Last 12 Months']`. Controls the preset range options which allows the user to easily select predefined ranges. If an array, the array *must* be a subset of the default array, any string not in the array will be omitted. If an object, the keys will be the display text and the value will be an object containing `startDate` and `endDate` *function* which will be called with the current date `dayjs` object and are expected to return the start and end dates respectfully.
 *   **`start`**: Object. Required. and object which will be spread on the start date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 *   **`end`**: Object. Required. and object which will be spread on the end date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 *   **`distance`**: Object. Optional. Object containing the `min` and `max` distance the start and end dates are allowed to be apart from each other. See example below.
 *   **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
+*    **`buttonColorOnChange`**: String. Optional. Default: `light`. You can optionally change the buttonColor when the DatePicker Changes
 
-#### AvDateRange Example usage
+#### AvDateRange Example  
 
 ```javascript
 import React from 'react';


### PR DESCRIPTION
Adding in `buttonColorOnChange props` to `AvDateRange`. This is **optional**. The default `buttonColor` is still `light`

![ChangeButtonColor](https://user-images.githubusercontent.com/17089609/60618123-54d53600-9da3-11e9-803c-446be7a58e23.gif)


 #[190](https://github.com/Availity/availity-react/issues/190)