### PR TITLE
Fix spaces and page-header prop types

### DIFF
--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -35,7 +35,7 @@ const PageHeader = ({
       payerId,
       className: 'float-md-right d-inline-block',
       skeletonProps: {
-        width: '180',
+        width: 180,
         height: '100%',
       },
     };

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -35,7 +35,7 @@ const PageHeader = ({
       payerId,
       className: 'float-md-right d-inline-block',
       skeletonProps: {
-        width: 180,
+        width: '180',
         height: '100%',
       },
     };

--- a/packages/spaces/src/SpacesImage.js
+++ b/packages/spaces/src/SpacesImage.js
@@ -5,8 +5,8 @@ import Img from 'react-image';
 import { useSpace } from './Spaces';
 
 const skeletonPropType = PropTypes.shape({
-  width: PropTypes.string,
-  height: PropTypes.string,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 });
 
 const Loader = ({ skeletonProps, ...rest }) => (

--- a/packages/spaces/src/SpacesImage.js
+++ b/packages/spaces/src/SpacesImage.js
@@ -23,7 +23,14 @@ Loader.defaultProps = {
   },
 };
 
-const SpacesImage = ({ spaceId, payerId, imageType, fallback, ...props }) => {
+const SpacesImage = ({
+  spaceId,
+  payerId,
+  imageType,
+  fallback,
+  skeletonProps,
+  ...props
+}) => {
   const { space = {}, loading } = useSpace(spaceId || payerId);
 
   const id = spaceId || payerId || space.id;
@@ -34,6 +41,7 @@ const SpacesImage = ({ spaceId, payerId, imageType, fallback, ...props }) => {
     return (
       <Loader
         data-testid={`space-${imageType}-${id}-loading`}
+        skeletonProps={skeletonProps}
         {...props}
       />
     );
@@ -44,7 +52,7 @@ const SpacesImage = ({ spaceId, payerId, imageType, fallback, ...props }) => {
     url = fallback;
   }
 
-  if (!url || (!id)) return null;
+  if (!url || !id) return null;
 
   return (
     <Img
@@ -54,6 +62,7 @@ const SpacesImage = ({ spaceId, payerId, imageType, fallback, ...props }) => {
       loader={
         <Loader
           data-testid={`space-${imageType}-${id}`}
+          skeletonProps={skeletonProps}
           {...props}
         />
       }

--- a/packages/spaces/types/SpacesImage.d.ts
+++ b/packages/spaces/types/SpacesImage.d.ts
@@ -1,6 +1,6 @@
 type SkeletonType = {
-    width?: string;
-    height?: string;
+    width?: string | number;
+    height?: string | number;
 };
 
 export interface SpacesImageProps {


### PR DESCRIPTION
fix(page-header): make skeletonProps.width a string
fix(spaces): only spread skeletonProps onto Loader

resolves prop type warnings