### PR TITLE
refactor(page-header): updated default props to prevent wrong space

### DIFF
--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -128,6 +128,10 @@ PageHeader.propTypes = {
 
 PageHeader.defaultProps = {
   tag: 'h1',
+  // SpaceId and payerId are defaulted to null to prevent `useSpace` from
+  // returning a space we may not want
+  spaceId: null,
+  payerId: null,
 };
 
 export default PageHeader;

--- a/packages/page-header/tests/PageHeader.test.js
+++ b/packages/page-header/tests/PageHeader.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-// import TrainingLink from '@availity/training-link';
+import TrainingLink from '@availity/training-link';
 import PageHeader from '..';
 
 describe('PageHeader', () => {
@@ -56,8 +56,8 @@ describe('PageHeader', () => {
 
     expect(container).toMatchSnapshot();
   });
-  /* test('should render trainingLink', () => {
-    const { container } = render(
+  test('should render trainingLink', () => {
+    const { getByText } = render(
       <PageHeader
         appName="Payer Space"
         component={
@@ -71,6 +71,6 @@ describe('PageHeader', () => {
       </PageHeader>
     );
 
-    expect(container).toMatchSnapshot();
-  }); */
+    getByText('Watch a demo');
+  });
 });


### PR DESCRIPTION
The current behavior for `useSpace` is to return the first space in the `spaces` array if the value being passed into the hook is `undefined.

This would cause the `space` and `payer` objects to be defined regardless of a `spaceId or `payerId` being passed in. The check is `id === undefined` so defaulting them to null will prevent this from occurring.