### PR TITLE
docs: add missing package links in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ lerna publish -c
 
 ### Adding a New Package
 
+1. 
 ```bash
-npm run new
+$ npm run new
 ```
+
+2. Add link to new package in README

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ https://availity-react-preview.netlify.com
 
 * [app-icon](packages/app-icon/README.md) - Availity UI Kit application icon react component.
 * [authorize](packages/authorize/README.md) - Check user permissions to see if the current user is authorized to see your content.
-* [breadcrumbs](packages/breadcrumbs/README.md) - Breadscrumbs component for Spaces platform.
+* [avatar](packages/avatar/README.md) - Availity user avatar component
+* [breadcrumbs](packages/breadcrumbs/README.md) - Breadcrumbs component for Spaces platform.
+* [date](packages/date/README.md) - Wrapper for [react-dates](https://github.com/airbnb/react-dates) to work with [formik](https://github.com/jaredpalmer/formik)
 * [favorites](packages/favorites/README.md) - Favorite Heart for favoriting items such as resources/applications etc.
 * [feature](packages/feature/README.md) - Check environment features for the current environment to determine if a particular feature is enabled.
 * [feedback](packages/feedback/README.md) - Availity feedback with simley faces react component.
+* [form](packages/form/README.md) - Availity form components that are wired to be hooked up to [formik](https://github.com/jaredpalmer/formik)
 * [hooks](packages/hooks/README.md) - Custom Hooks that can be used in any projects.
 * [icon](packages/icon/README.md) - Icon Component using sizes and icons from availity-uikit.
 * [link](packages/link/README.md) - Availity Link component
@@ -35,17 +38,21 @@ https://availity-react-preview.netlify.com
 * [progress](packages/progress/README.md) - Availity Progress Bar
 * [reactstrap-validation-date](packages/reactstrap-validation-date/README.md) - Wrapper for react-date-range to work with availity-reactstrap-validation
 * [reactstrap-validation-select](packages/reactstrap-validation-select/README.md) - Wrapper for react-select to work with availity-reactstrap-validation
-* [upload](packages/upload/README.md) - Availity upload component for uploading files
+* [select](packages/select/README.md) - Wrapper for [react-select-async-paginate](https://github.com/vtaits/react-select-async-paginate) to work with [formik](https://github.com/jaredpalmer/formik)
 * [spaces](packages/spaces/README.md) - Easy to use spaces components
+* [step-wizard](packages/step-wizard/README.md) - Step Wizard - the Availity Way
 * [training-link](packages/training-link/README.md) - Component for allowing link out to training in the Header component.
 * [typography](packages/typography/README.md) - Availity typography components
 * [upload](packages/upload/README.md) - Availity upload component for uploading files.
 
 ## Adding a New Package
 
+1. 
 ```bash
 $ npm run new
 ```
+
+2. Add link to new package in README
 
 ## License
 

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,6 +1,6 @@
 # @availity/form
 
-> Availity form components that are wired to be hooked up to Formik
+> Availity form components that are wired to be hooked up to [formik](https://github.com/jaredpalmer/formik)
 
 [![Version](https://img.shields.io/npm/v/@availity/form.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form)
 


### PR DESCRIPTION
Also adds additional step in contributing guide to add link to new package. Ideally that would be automated but I don't think there's an easy way to do that with `plop` without sacrificing the packages being in alphabetical order (which is nice IMO)