### PR TITLE
Fix/autofill default value

### DIFF
--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -209,9 +209,13 @@ class AvSelect extends AvBaseInput {
 
             let val;
             if (typeof this.props.autofill === 'object') {
-              val = get(rawValue, `${this.props.autofill[fieldName]}`);
+              val = get(
+                rawValue,
+                `${this.props.autofill[fieldName]}`,
+                input.getDefaultValue()
+              );
             } else {
-              val = rawValue[fieldName];
+              val = get(rawValue, fieldName, input.getDefaultValue());
             }
 
             input.onChangeHandler(val);

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -50,7 +50,8 @@ const Select = ({
     { onChange, value: fieldValue, ...field },
     { touched, error: hasError },
   ] = useField(name);
-  const { values, setFieldValue } = useFormikContext();
+  const { values, setFieldValue, initialValues } = useFormikContext();
+
   const [newOptions, setNewOptions] = useState([]);
 
   const getOptionLabel = option => {
@@ -148,9 +149,13 @@ const Select = ({
           if (shouldAutofillField) {
             let val;
             if (typeof autofill === 'object') {
-              val = get(rawValue, `${autofill[fieldName]}`);
+              val = get(
+                rawValue,
+                `${autofill[fieldName]}`,
+                initialValues[fieldName]
+              );
             } else {
-              val = rawValue[fieldName];
+              val = get(rawValue, fieldName, initialValues[fieldName]);
             }
             valuesToSet[fieldName] = true;
             await setFieldValue(fieldName, val);


### PR DESCRIPTION
Resolves React warning that a controlled input is changing from controlled to uncontrolled by preventing field values from being set to `undefined` when auto-filling. Instead of `undefined`, sets the field value to the default/initial value