### PR TITLE
Fix/doc fixes

### DIFF
--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-npm install @availity/date @availity/form formik react reactstrap --save
+npm install @availity/date @availity/form formik@^2.0.1-rc.5 react reactstrap --save
 ```
 
 ## Validation

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @availity/form formik react reactstrap --save
+npm install @availity/form formik@^2.0.1-rc.5 react reactstrap --save
 ```
 
 ## Validation

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-npm install @availity/select @availity/api-axios @availity/api-core @availity/form formik react reactstrap --save
+npm install @availity/select @availity/api-axios @availity/api-core @availity/form formik@^2.0.1-rc.5 react reactstrap --save
 ```
 
 ## Validation


### PR DESCRIPTION
Necessary because formik v2 is still a release candidate. If you run the installation command as is v1 gets installed. 