### PR TITLE
refactor(reactstrap-validation-date): single dateRange field filled without other should cause error

### DIFF
--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/Availity/availity-react/tree/master/packages/date#readme",
   "devDependencies": {
     "@availity/form": "^0.2.2",
-    "@availity/yup": "^1.1.0",
+    "@availity/yup": "^1.1.1",
     "@types/react-dates": "^17.1.5",
     "formik": "^2.0.1-rc.12",
     "react": "^16.8.3",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -55,7 +55,7 @@
     "@availity/typography": "^1.1.2",
     "@availity/upload": "^2.0.6",
     "@availity/upload-core": "^3.0.4",
-    "@availity/yup": "^1.1.0",
+    "@availity/yup": "^1.1.1",
     "@babel/core": "^7.2.2",
     "@storybook/addon-a11y": "^5.1.3",
     "@storybook/addon-actions": "^5.1.3",

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -302,6 +302,17 @@ export default class AvDateRange extends Component {
     return true;
   };
 
+  getInputState = () => {
+    const startValidation = this.context.FormCtrl.getInputState(
+      this.props.start.name
+    );
+    if (startValidation.errorMessage) return startValidation;
+    const endValidation = this.context.FormCtrl.getInputState(
+      this.props.end.name
+    );
+    return endValidation;
+  };
+
   render() {
     const {
       name,
@@ -345,13 +356,15 @@ export default class AvDateRange extends Component {
       this.context.FormCtrl.isBad(this.props.start.name) ||
       this.context.FormCtrl.isBad(this.props.end.name);
 
+    const validation = this.getInputState();
+
     const classes = classNames(
       className,
       touched ? 'is-touched' : 'is-untouched',
       isDirty ? 'is-dirty' : 'is-pristine',
       isBad ? 'is-bad-input' : null,
       hasError ? 'av-invalid' : 'av-valid',
-      touched && hasError && 'is-invalid',
+      validation.error && 'is-invalid',
       !startValue && !endValue && 'current-day-highlight',
       datepicker && 'av-calendar-show'
     );

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -332,7 +332,7 @@ export default class AvDateRange extends Component {
       this.context.FormCtrl.getInput(this.props.end.name).getViewValue();
 
     if (!start && end) {
-      return 'Both start and end date are required';
+      return 'Both start and end date are required.';
     }
 
     return true;

--- a/packages/reactstrap-validation-date/tests/AvDateRangeField.test.js
+++ b/packages/reactstrap-validation-date/tests/AvDateRangeField.test.js
@@ -48,6 +48,70 @@ describe('AvDateRange', () => {
     await waitForElement(() => getByText('Date must come after value'));
   });
 
+  test('start date and no end date', async () => {
+    const { getByText } = render(
+      <DateRange
+        name="standAlone"
+        start={{
+          name: 'date.start',
+          value: '01/01/2001',
+        }}
+        end={{
+          name: 'date.end',
+        }}
+      />
+    );
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitForElement(() =>
+      getByText('Both start and end date are required.')
+    );
+  });
+
+  test('end date after start date', async () => {
+    const { getByText } = render(
+      <DateRange
+        name="standAlone"
+        start={{
+          name: 'date.start',
+          value: '01/04/2001',
+        }}
+        end={{
+          name: 'date.end',
+          value: '01/01/2001',
+        }}
+      />
+    );
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitForElement(() =>
+      getByText('Start Date must come before End Date.')
+    );
+  });
+
+  test('end date and no start date', async () => {
+    const { getByText } = render(
+      <DateRange
+        name="standAlone"
+        start={{
+          name: 'date.start',
+        }}
+        end={{
+          name: 'date.end',
+          value: '01/01/2001',
+        }}
+      />
+    );
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitForElement(() =>
+      getByText('Both start and end date are required.')
+    );
+  });
+
   test('display label with grid', async () => {
     const { getByText } = render(
       <DateRange


### PR DESCRIPTION
Currently if we had filled out one of the date range fields but not the other it would not error out. The previous datepicker had it to where it would just put the current date of the opposite field into there and call it a day.

I don't think putting the original logic back is good for 508 as its autofilling without the user's consent and without proper reading. Instead we can just display a required message if one of the fields is filled out but not the other.