### PR TITLE
refactor(spaces): catch error in effect and return error

### DIFF
--- a/packages/spaces/index.d.ts
+++ b/packages/spaces/index.d.ts
@@ -1,4 +1,4 @@
-import Spaces from './types/Spaces';
+import Spaces, { useSpace } from './types/Spaces';
 import SpacesImage from './types/SpacesImage';
 import SpacesDisclaimer from './types/SpacesDisclaimer';
 import SpacesAgreement from './types/SpacesAgreement';
@@ -11,6 +11,7 @@ export {
     SpacesImage as SpacesBillboard,
     SpacesImage as SpacesTile,
     SpacesDisclaimer,
-    SpacesAgreement
+    SpacesAgreement,
+    useSpace
 };
 

--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -67,69 +67,78 @@ const Spaces = ({
 }) => {
   const [spaces, setSpaces] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   // NOTE: we do not want to query slotmachine by payerIDs and spaceIDs at the same time
   // because slotmachine does an AND on those conditions. We want OR
   useEffectAsync(async () => {
-    setLoading(true);
-    // Filter out dupes and ids that we already have the space for
-    const filteredSpaceIDs = spaceIds
-      .filter((id, i) => spaceIds.indexOf(id) === i)
-      .filter(id => !spaces.some(spc => spc && spc.id === id))
-      .filter(id => !spacesFromProps.some(spc => spc && spc.id === id));
+    try {
+      setLoading(true);
+      // Filter out dupes and ids that we already have the space for
+      const filteredSpaceIDs = spaceIds
+        .filter((id, i) => spaceIds.indexOf(id) === i)
+        .filter(id => !spaces.some(spc => spc && spc.id === id))
+        .filter(id => !spacesFromProps.some(spc => spc && spc.id === id));
 
-    const filteredPayerIDs = payerIds
-      .filter((id, i) => payerIds.indexOf(id) === i)
-      .filter(
-        id =>
-          !spaces.some(
-            spc => spc && spc.payerIDs && spc.payerIDs.some(pId => pId === id)
-          )
-      )
-      .filter(
-        id =>
-          !spacesFromProps.some(
-            spc => spc && spc.payerIDs && spc.payerIDs.some(pId => pId === id)
-          )
-      );
+      const filteredPayerIDs = payerIds
+        .filter((id, i) => payerIds.indexOf(id) === i)
+        .filter(
+          id =>
+            !spaces.some(
+              spc => spc && spc.payerIDs && spc.payerIDs.some(pId => pId === id)
+            )
+        )
+        .filter(
+          id =>
+            !spacesFromProps.some(
+              spc => spc && spc.payerIDs && spc.payerIDs.some(pId => pId === id)
+            )
+        );
 
-    let _spaces = [];
-    if (filteredSpaceIDs.length > 0) {
-      const vars = { ...variables, ids: filteredSpaceIDs };
-      const spacesBySpaceIDs = await getAllSpaces(
-        query,
-        clientId,
-        vars,
-        spaces
-      );
-      _spaces = _spaces.concat(spacesBySpaceIDs);
+      let _spaces = [];
+      if (filteredSpaceIDs.length > 0) {
+        const vars = { ...variables, ids: filteredSpaceIDs };
+        const spacesBySpaceIDs = await getAllSpaces(
+          query,
+          clientId,
+          vars,
+          spaces
+        );
+        _spaces = _spaces.concat(spacesBySpaceIDs);
+      }
+
+      if (filteredPayerIDs.length > 0) {
+        const vars = { ...variables, payerIDs: filteredPayerIDs };
+        const spacesByPayerIDs = await getAllSpaces(
+          query,
+          clientId,
+          vars,
+          spaces
+        );
+        _spaces = _spaces.concat(spacesByPayerIDs);
+      }
+
+      if (_spaces.length > 0) setSpaces(_spaces);
+      setError(null);
+    } catch (error_) {
+      setError(error_.message);
+    } finally {
+      setLoading(false);
     }
-
-    if (filteredPayerIDs.length > 0) {
-      const vars = { ...variables, payerIDs: filteredPayerIDs };
-      const spacesByPayerIDs = await getAllSpaces(
-        query,
-        clientId,
-        vars,
-        spaces
-      );
-      _spaces = _spaces.concat(spacesByPayerIDs);
-    }
-
-    if (_spaces.length > 0) setSpaces(_spaces);
-    setLoading(false);
   }, [payerIds, spaceIds]);
 
   const spacesForProvider = sanitizeSpaces(spaces.concat(spacesFromProps));
   return (
-    <SpacesContext.Provider value={{ spaces: spacesForProvider, loading }}>
+    <SpacesContext.Provider
+      value={{ spaces: spacesForProvider, loading, error }}
+    >
       {children}
     </SpacesContext.Provider>
   );
 };
 
 export const useSpace = id => {
-  const { spaces = [], loading } = useContext(SpacesContext) || {};
+  const { spaces = [], loading, error } = useContext(SpacesContext) || {};
 
   // Try to match by space id first, else match by payer id
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -173,7 +182,7 @@ export const useSpace = id => {
     );
   });
 
-  return { space, isGhost, loading };
+  return { space, isGhost, loading, error };
 };
 
 Spaces.propTypes = {

--- a/packages/spaces/tests/Spaces.test.js
+++ b/packages/spaces/tests/Spaces.test.js
@@ -154,10 +154,10 @@ describe('Spaces', () => {
     const fn = jest.fn(() => {});
     // Create component to call mock function
     const SpaceComponent = ({ spaceId }) => {
-      const { loading, space } = useSpace(spaceId);
+      const { loading, space, error } = useSpace(spaceId);
 
       // Should be called when async effect to fetch spaces from slotmachine gets executed
-      if (space && !loading) fn();
+      if (space && !loading) fn(space, error);
       return loading ? null : (
         <span data-testid={`space-for-${spaceId}`}>
           {space ? `Space ${space.id}` : 'No Space '}
@@ -327,5 +327,32 @@ describe('Spaces', () => {
     expect(console.warn.mock.calls[0][0]).toBe(
       'You did not pass an ID in to find a space, and there is more than 1 space in the space array. Returning the first.'
     );
+  });
+
+  it('returns error when missing clientId', async () => {
+    // Create component that renders a SpaceComponent for the current space id
+    const fn = jest.fn(() => {});
+    // Create component to call mock function
+    const SpaceComponent = ({ spaceId }) => {
+      const { loading, space, error } = useSpace(spaceId);
+
+      // Should be called when async effect to fetch spaces from slotmachine gets executed
+      if (!loading) fn(space, error);
+      return loading ? null : (
+        <span data-testid={`space-for-${spaceId}`}>
+          {space ? `Space ${space.id}` : 'No Space '}
+        </span>
+      );
+    };
+
+    const { getByText } = render(
+      <Spaces spaceIds={['1']}>
+        <SpaceComponent />
+      </Spaces>
+    );
+
+    await waitForElement(() => getByText('No Space'));
+
+    expect(fn.mock.calls[0][1]).toBe('clientId is required');
   });
 });

--- a/packages/spaces/types/Spaces.d.ts
+++ b/packages/spaces/types/Spaces.d.ts
@@ -8,6 +8,20 @@ export interface SpacesProps {
     spaces: Array<Object>;
 }
 
+
+export interface SpaceType {
+    error?: string;
+    space: object;
+    isGhost: boolean;
+    loading: boolean;
+}
+
+declare function useSpace(id?: string): SpaceType;
+
 declare const Spaces: React.FunctionComponent<SpacesProps>;
+
+export {
+    useSpace
+};
 
 export default Spaces;


### PR DESCRIPTION
Since `useEffect` doesn't allow errors to be bubbled up to a `derivedStateFromErrors` we need to set the error and then return it in the spaces hook in the case someone needs to render an error.