### PR TITLE
feat(reactstrap-validation-date): added back ranges prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "link": "lerna link",
     "clean": "lerna clean --yes",
     "test": "jest",
-    "test:commit": "jest --onlyChanged",
     "test:ci": "jest --runInBand --collectCoverage",
     "postinstall": "npm run bootstrap",
     "start": "npm start --prefix packages/docs",
@@ -143,7 +142,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
-      "pre-commit": "npm run test:commit && lint-staged"
+      "pre-commit": "npm test && lint-staged"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "link": "lerna link",
     "clean": "lerna clean --yes",
     "test": "jest",
+    "test:commit": "jest --onlyChanged",
     "test:ci": "jest --runInBand --collectCoverage",
     "postinstall": "npm run bootstrap",
     "start": "npm start --prefix packages/docs",
@@ -142,7 +143,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
-      "pre-commit": "npm test && lint-staged"
+      "pre-commit": "npm run test:commit && lint-staged"
     }
   }
 }

--- a/packages/docs/stories/avdate.stories.js
+++ b/packages/docs/stories/avdate.stories.js
@@ -138,7 +138,7 @@ storiesOf('Components|AvDate', module)
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           distance={distance}
-          ranges
+          ranges={boolean('ranges', false)}
           errorMessage={text('Generic Error Message', 'This field is invalid')}
           validate={{
             required: {
@@ -195,7 +195,7 @@ storiesOf('Components|AvDate', module)
           min={text('Min Date (yyyy-mm-dd)')}
           max={text('Max Date (yyyy-mm-dd)')}
           distance={distance}
-          ranges
+          ranges={boolean('ranges', false)}
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           errorMessage={text('Generic Error Message', 'This field is invalid')}

--- a/packages/docs/stories/avdate.stories.js
+++ b/packages/docs/stories/avdate.stories.js
@@ -9,8 +9,8 @@ import AvDate, {
   AvDateRangeField,
 } from '@availity/reactstrap-validation-date';
 import README from '@availity/reactstrap-validation-date/README.md';
-import AvFormResults from './mocks/AvFormResults';
 import '@availity/reactstrap-validation-date/styles.scss';
+import AvFormResults from './mocks/AvFormResults';
 
 const types = {
   text: 'text',

--- a/packages/docs/stories/avdate.stories.js
+++ b/packages/docs/stories/avdate.stories.js
@@ -138,6 +138,7 @@ storiesOf('Components|AvDate', module)
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           distance={distance}
+          ranges
           errorMessage={text('Generic Error Message', 'This field is invalid')}
           validate={{
             required: {
@@ -194,6 +195,7 @@ storiesOf('Components|AvDate', module)
           min={text('Min Date (yyyy-mm-dd)')}
           max={text('Max Date (yyyy-mm-dd)')}
           distance={distance}
+          ranges
           required={boolean('Required', false)}
           disabled={boolean('Disabled', false)}
           errorMessage={text('Generic Error Message', 'This field is invalid')}

--- a/packages/icon/Icon.js
+++ b/packages/icon/Icon.js
@@ -2,25 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Icon = ({
-  name,
-  size,
-  'aria-label': ariaLabel,
-  color,
-  className,
-  ...rest
-}) => (
-  <i
-    aria-label={ariaLabel || name}
-    className={classNames(
-      'icon',
-      `icon-${name}`,
-      size && `icon-${size}`,
-      color && `text-${color}`,
-      className
-    )}
-    {...rest}
-  />
+const Icon = React.forwardRef(
+  ({ name, size, 'aria-label': ariaLabel, color, className, ...rest }, ref) => (
+    <i
+      ref={ref}
+      aria-label={ariaLabel || name}
+      className={classNames(
+        'icon',
+        `icon-${name}`,
+        size && `icon-${size}`,
+        color && `text-${color}`,
+        className
+      )}
+      {...rest}
+    />
+  )
 );
 
 Icon.propTypes = {

--- a/packages/reactstrap-validation-date/CHANGELOG.md
+++ b/packages/reactstrap-validation-date/CHANGELOG.md
@@ -56,7 +56,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-* **reactstrap-validation-select:** this required moment to be installed and the whole look and feel of the picker has changed
+* **reactstrap-validation-date:** 
+  - `moment` is now a required dep
+  -  UI has been swapped out with `react-dates`. 
+  - DateRange `onChange` callback now runs on single date selected and when both are.
 
 
 

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -34,7 +34,7 @@ import '@availity/reactstrap-validation-date/styles.scss';
 
     <AvGroup>
         <Label for="justTheDateRange">My Input Label</Label>
-        <AvDateRange name="justTheDateRange" required />
+        <AvDateRange name="justTheDateRange" required ranges/>
         <AvFeedback>Some error message</AvFeedback>
     </AvGroup>
 
@@ -123,6 +123,19 @@ See availity-reactstrap-validation for additional props, such as `name`, `valida
 *   **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 *  **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 *  **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
+*  **`ranges`**: object, boolean, array. Optional. Renders list of ranges preset to the left of the calendar
+   * boolean - `true` will render the [default ranges](./src/AvDateRange.js#L19-L45)
+   * array<string> - Will pick only the selected date ranges by name. See above default ranges for list of names. ex. ["Today"]
+   * object - list or object of ranges. structure is noted below
+
+```js
+{
+    'Tomorrow': {
+        startDate: now => now.add(1,'day'),
+        endDate: now => now.add(1,'day')
+    }
+}
+```
 
 #### AvDateRange Example usage
 
@@ -198,6 +211,7 @@ import '@availity/reactstrap-validation-date/styles.scss';
         name="dateRange" //required
         start={{name: 'date.start'}}
         end={{name: 'date.end'}}
+        ranges
     />
 </AvForm>
 ```

--- a/packages/reactstrap-validation-date/package.json
+++ b/packages/reactstrap-validation-date/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@availity/icon": "^0.4.3",
     "classnames": "^2.2.6",
+    "lodash.pick": "^4.4.0",
     "moment": "^2.24.0",
     "prop-types": "^15.5.8",
     "react-dates": "^20.2.5",

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -17,6 +17,10 @@ import { isOutsideRange, limitPropType, isSameDay } from './utils';
 let count = 0;
 
 const relativeRanges = {
+  Today: {
+    startDate: now => now,
+    endDate: now => now,
+  },
   'Last 7 Days': {
     startDate: now => now.add(-6, 'd'),
     endDate: now => now,
@@ -24,10 +28,6 @@ const relativeRanges = {
   'Last 30 Days': {
     startDate: now => now.add(-29, 'd'),
     endDate: now => now,
-  },
-  'Last Calendar Month': {
-    startDate: now => now.startOf('month').add(-1, 'M'),
-    endDate: now => now.startOf('month').add(-1, 'd'),
   },
   'Last 120 Days': {
     startDate: now => now.add(-119, 'd'),
@@ -55,7 +55,11 @@ export default class AvDateRange extends Component {
     max: limitPropType,
     min: limitPropType,
     distance: PropTypes.object,
-    ranges: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    ranges: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.array,
+      PropTypes.object,
+    ]),
     onPickerFocusChange: PropTypes.func,
     defaultValues: PropTypes.object,
     calendarIcon: PropTypes.node,
@@ -402,15 +406,18 @@ export default class AvDateRange extends Component {
     const { ranges: propsRanges } = this.props;
     const { startValue, endValue, format } = this.state;
 
-    const ranges =
-      // eslint-disable-next-line no-nested-ternary
-      propsRanges !== undefined
-        ? Array.isArray(propsRanges)
-          ? pick(relativeRanges, propsRanges)
-          : propsRanges
-        : relativeRanges;
+    console.log('propsRanges', propsRanges);
 
-    return (
+    let ranges;
+    if (typeof propsRanges === 'boolean' && propsRanges) {
+      ranges = relativeRanges;
+    } else if (propsRanges) {
+      ranges = Array.isArray(propsRanges)
+        ? pick(relativeRanges, propsRanges)
+        : propsRanges;
+    }
+
+    return ranges ? (
       <div className="d-flex flex-column ml-2 mt-2">
         {Object.keys(ranges).map(text => {
           const { startDate: startDateFunc, endDate: endDateFunc } = ranges[
@@ -460,7 +467,7 @@ export default class AvDateRange extends Component {
           );
         })}
       </div>
-    );
+    ) : null;
   };
 
   render() {

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -115,6 +115,13 @@ export default class AvDateRange extends Component {
     this.guid = `date-range-${count}-btn`;
   }
 
+  static getDerivedStateFromProps(props, prevState) {
+    return {
+      startValue: props.start.value || prevState.startValue,
+      endValue: props.end.value || prevState.endValue
+    }
+  }
+
   open = () => {
     if (!this.state.open) {
       this.setState({ open: true });

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -415,8 +415,6 @@ export default class AvDateRange extends Component {
     const { ranges: propsRanges } = this.props;
     const { startValue, endValue, format } = this.state;
 
-    console.log('propsRanges', propsRanges);
-
     let ranges;
     if (typeof propsRanges === 'boolean' && propsRanges) {
       ranges = relativeRanges;

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -343,7 +343,10 @@ export default class AvDateRange extends Component {
       this.props.end.name
     ).getViewValue();
 
-    if (start && end) {
+    const hasStart = start && start !== '';
+    const hasEnd = end && end !== '';
+
+    if (hasStart && hasEnd) {
       const mStart = moment(new Date(start));
       const mEnd = moment(new Date(end));
       if (!mStart.isValid() || !mEnd.isValid()) {
@@ -378,7 +381,10 @@ export default class AvDateRange extends Component {
       this.context.FormCtrl.getInput(this.props.end.name) &&
       this.context.FormCtrl.getInput(this.props.end.name).getViewValue();
 
-    if (!start && end) {
+    const hasStart = start && start !== '';
+    const hasEnd = end && end !== '';
+
+    if (!hasStart && hasEnd) {
       return 'Both start and end date are required.';
     }
 
@@ -395,7 +401,10 @@ export default class AvDateRange extends Component {
       this.props.end.name
     ).getViewValue();
 
-    if (start && !end) {
+    const hasStart = start && start !== '';
+    const hasEnd = end && end !== '';
+
+    if (hasStart && !hasEnd) {
       return 'Both start and end date are required.';
     }
 

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -115,11 +115,17 @@ export default class AvDateRange extends Component {
     this.guid = `date-range-${count}-btn`;
   }
 
-  static getDerivedStateFromProps(props, prevState) {
-    return {
-      startValue: props.start.value || prevState.startValue,
-      endValue: props.end.value || prevState.endValue
+  static getDerivedStateFromProps({ start, end }, { startValue, endValue }) {
+    if (
+      (start.value && start.value !== startValue) ||
+      (end.value && end.value !== endValue)
+    ) {
+      return {
+        startValue: start.value || startValue,
+        endValue: end.value || endValue,
+      };
     }
+    return null;
   }
 
   open = () => {

--- a/packages/reactstrap-validation-date/src/utils.js
+++ b/packages/reactstrap-validation-date/src/utils.js
@@ -47,3 +47,12 @@ export const limitPropType = PropTypes.oneOfType([
   PropTypes.shape({ value: PropTypes.number, units: PropTypes.string }),
   PropTypes.shape({ _d: PropTypes.string, _isValid: PropTypes.func }), // moment prop type
 ]);
+
+export const isSameDay = (a, b) => {
+  if (!moment.isMoment(a) || !moment(b)) return false;
+  // Compare least significant, most likely to change units first
+  // Moment's isSame clones moment inputs and is a tad slow
+  return (
+    a.date() === b.date() && a.month() === b.month() && a.year() === b.year()
+  );
+};

--- a/packages/reactstrap-validation-date/tests/AvDateRange.test.js
+++ b/packages/reactstrap-validation-date/tests/AvDateRange.test.js
@@ -58,6 +58,50 @@ describe('AvDateRange', () => {
     });
   });
 
+  test('should re-render with new value props', async () => {
+    const { getByText, rerender } = render(
+      <DateRange
+        name="standAlone"
+        start={{
+          name: 'date.start',
+          value: '01/01/2001',
+        }}
+        end={{
+          name: 'date.end',
+          value: '01/04/2001',
+        }}
+      />
+    );
+
+    rerender(
+      <DateRange
+        name="standAlone"
+        start={{
+          name: 'date.start',
+          value: '01/02/2001',
+        }}
+        end={{
+          name: 'date.end',
+          value: '01/04/2001',
+        }}
+      />
+    );
+
+    fireEvent.click(getByText('Submit'));
+
+    await wait(() => {
+      expect(onValidSubmit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          date: {
+            start: '2001-01-02',
+            end: '2001-01-04',
+          },
+        })
+      );
+    });
+  });
+
   test('should work with default values prop', async () => {
     const { getByText } = render(
       <DateRange


### PR DESCRIPTION
Adds `ranges` prop back.

- fix(reactstrap-validation-date): derived state from props was not implemented so the value prop was only valid on mount.
- refactor(icon): forwards ref to html element in the case of a ref being passed in

Trying to find a way to test those presets but no dice atm.