### PR TITLE
refactor(favorites): add key event for enter to toggle favorite

### DIFF
--- a/packages/favorites/FavoriteHeart.js
+++ b/packages/favorites/FavoriteHeart.js
@@ -10,6 +10,14 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
   const [tooltipOpen, toggleTooltip] = useToggle(false);
   const [loading, toggleLoading] = useToggle(true);
 
+  const onChangeHandler = () => {
+    toggleFavorite();
+
+    if (onChange) {
+      onChange(isFavorite);
+    }
+  };
+
   const icon = useMemo(
     () => (
       <span
@@ -26,14 +34,8 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
             onMouseDown(e);
           }
         }}
-        onKeyPress={() => {}}
-        onClick={() => {
-          toggleFavorite();
-
-          if (onChange) {
-            onChange(isFavorite);
-          }
-        }}
+        onKeyPress={({ charCode }) => charCode === 13 && onChangeHandler()}
+        onClick={onChangeHandler}
       >
         <span className="sr-only">Favorite</span>
         <span className="sr-only" id={`av-favorite-heart-desc-${id}`}>
@@ -46,7 +48,7 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
         <span className="icon selected-filled" />
       </span>
     ),
-    [id, isFavorite, onChange, onMouseDown, props, toggleFavorite]
+    [id, isFavorite, onChangeHandler, onMouseDown, props]
   );
 
   useEffectAsync(async () => {

--- a/packages/favorites/__test__/FavoriteHeart.test.js
+++ b/packages/favorites/__test__/FavoriteHeart.test.js
@@ -212,6 +212,45 @@ describe('FavoriteHeart', () => {
     ]);
   });
 
+  test('should delete favorite and send post message with updated favorites when enter is pressed', async () => {
+    avSettingsApi.setApplication = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          favorites: [
+            {
+              id: '456',
+              pos: 0,
+            },
+          ],
+        },
+      })
+    );
+
+    const { container, getByText } = render(
+      <Favorites>
+        <FavoriteHeart id="123" />
+      </Favorites>
+    );
+
+    const heart = container.querySelector('#av-favorite-heart-123');
+
+    expect(heart).toBeDefined();
+
+    await waitForElement(() => getByText('This item is favorited.'));
+
+    // Simulate user unfavoriting item
+    fireEvent.keyPress(heart, { key: 'Enter', code: 13, charCode: 13 });
+
+    await waitForElement(() => getByText('This item is not favorited.'));
+
+    expect(avMessages.send).toHaveBeenCalledTimes(1);
+    expect(avMessages.send.mock.calls[0][0].event).toBe('av:favorites:update');
+    // Test that post message sent to window.parent sends favorites returned from settings api
+    expect(avMessages.send.mock.calls[0][0].favorites).toEqual([
+      { id: '456', pos: 0 },
+    ]);
+  });
+
   test('should add favorite and send post message with updated favorites', async () => {
     avSettingsApi.setApplication = jest.fn(() =>
       Promise.resolve({


### PR DESCRIPTION
Allows the favorite heart to be selected by hitting the enter key on the keyboard