### PR TITLE
Added string type to label field

### DIFF
--- a/packages/reactstrap-validation-select/AvSelectField.d.ts
+++ b/packages/reactstrap-validation-select/AvSelectField.d.ts
@@ -1,5 +1,5 @@
 export interface AvSelectFieldProps {
-    label?: React.ReactType;
+    label?: React.ReactType | string;
     labelHidden?: boolean;
     id?: string;
     feedbackClass?: string;


### PR DESCRIPTION
`AvSelectField`'s `label` field should accept `string` values.