### PR TITLE
chore(upload): updated peer dependency for react-dropzone

### DIFF
--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -26,7 +26,7 @@
     "lodash.map": "4.6.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-dropzone": "^7.0.1",
+    "react-dropzone": "^10.0.0 ||^9.0.0 ||^8.0.0 ||^7.0.1",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },


### PR DESCRIPTION
I don't think we need all of the possible peer dependencies for `react-dropzone`, but I did not want to break any existing functionality just to fix a warning. I can update if needed.