### PR TITLE
refactor(breadcrumbs): changed home url to be overridable

### DIFF
--- a/packages/breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/breadcrumbs/Breadcrumbs.d.ts
@@ -6,6 +6,7 @@ export interface BreadcrumbsProps {
     crumbs?: Array<Crumb>;
     active: string;
     emptyState?: string;
+    homeUrl?: string;
 }
 
 declare const Breadcrumbs: React.StatelessComponent<BreadcrumbsProps>;

--- a/packages/breadcrumbs/Breadcrumbs.js
+++ b/packages/breadcrumbs/Breadcrumbs.js
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 
-const Breadcrumbs = ({ crumbs, active, emptyState, children, ...rest }) => {
+const Breadcrumbs = ({
+  crumbs,
+  active,
+  emptyState,
+  children,
+  homeUrl,
+  ...rest
+}) => {
   const renderBreadCrumb = crumb => {
     // default breadcrumbitem render
     let breadCrumbItemChildren = <span>{emptyState}</span>;
@@ -24,7 +31,7 @@ const Breadcrumbs = ({ crumbs, active, emptyState, children, ...rest }) => {
   return (
     <Breadcrumb {...rest}>
       <BreadcrumbItem>
-        <a aria-label="Home" href="/public/apps/dashboard">
+        <a aria-label="Home" href={homeUrl}>
           Home
         </a>
       </BreadcrumbItem>
@@ -45,10 +52,12 @@ Breadcrumbs.propTypes = {
   active: PropTypes.string.isRequired,
   emptyState: PropTypes.string,
   children: PropTypes.node,
+  homeUrl: PropTypes.string,
 };
 
 Breadcrumbs.defaultProps = {
   emptyState: '…',
+  homeUrl: '/public/apps/dashboard',
 };
 
 export default Breadcrumbs;

--- a/packages/breadcrumbs/tests/Breadcrumbs.test.js
+++ b/packages/breadcrumbs/tests/Breadcrumbs.test.js
@@ -63,4 +63,14 @@ describe('Breadcrumbs', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('should render custom home url', () => {
+    const { getByText } = render(
+      <Breadcrumbs homeUrl="/go-home" active="Payer Space" />
+    );
+
+    const homeBtn = getByText('Home');
+
+    expect(homeBtn.getAttribute('href')).toBe('/go-home');
+  });
 });

--- a/packages/docs/source/components/breadcrumbs.mdx
+++ b/packages/docs/source/components/breadcrumbs.mdx
@@ -30,6 +30,7 @@ Breadcrumbs showing the ancestor pages and the current active page
 - **`crumbs`**: Array of Objects contains `name` (String) and `url` (string) properties. Optional. The ancestor pages.
 - **`emptyState`**: String. Optional. The value which will be display when the active page or an ancestor does not have a value. Default `&hellip;` (&hellip;)
 - **`children`**: BreadcrumbItem Components. Optional. The children must be reactstrap BreadcrumbItem components
+- **`homeUrl`**: Url for the Home route. Optional. Default: `public/apps/dashboard`
 
 ##### Usage
 

--- a/packages/docs/source/components/page-header.mdx
+++ b/packages/docs/source/components/page-header.mdx
@@ -41,6 +41,7 @@ The standard Availity application header which appears at the top of the page. I
 - **`clientId`**: String. Optional. client id to use in [spaces](/components/spaces) to fetch the payer's logo
 - **`iconSrc`**: String. Optional. Image source for `AppIcon` instead of `appAbbr`
 - **`iconAlt`**: String. Required if `iconSrc`. Image alt property of `AppIcon`
+- **`homeUrl`**: Url for the Home route. Optional. Default: `public/apps/dashboard`
 
 ##### PageHeader Usage
 

--- a/packages/page-header/PageHeader.d.ts
+++ b/packages/page-header/PageHeader.d.ts
@@ -19,6 +19,7 @@ export interface PageHeaderProps {
     iconSrc?: string;
     iconAlt?: string;
     clientId?: string;
+    homeUrl?:string;
 }
 
 declare const PageHeader: React.FunctionComponent<PageHeaderProps>;

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -22,6 +22,7 @@ const PageHeader = ({
   clientId,
   iconSrc,
   iconAlt,
+  homeUrl,
   ...props
 }) => {
   const { space: spaceForSpaceID } = useSpace(spaceId);
@@ -69,7 +70,11 @@ const PageHeader = ({
         {React.isValidElement(crumbs) ? (
           crumbs
         ) : (
-          <Breadcrumbs crumbs={crumbs} active={appName || children} />
+          <Breadcrumbs
+            crumbs={crumbs}
+            active={appName || children}
+            homeUrl={homeUrl}
+          />
         )}
         {component}
       </div>
@@ -125,6 +130,7 @@ PageHeader.propTypes = {
     PropTypes.node,
   ]),
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  homeUrl: PropTypes.string,
   clientId: PropTypes.string,
   iconSrc: PropTypes.string,
   iconAlt: PropTypes.string,
@@ -136,6 +142,7 @@ PageHeader.defaultProps = {
   // returning a space we may not want
   spaceId: null,
   payerId: null,
+  homeUrl: '/public/apps/dashboard',
 };
 
 export default PageHeader;

--- a/packages/page-header/tests/PageHeader.test.js
+++ b/packages/page-header/tests/PageHeader.test.js
@@ -141,4 +141,14 @@ describe('PageHeader', () => {
       await waitForElement(() => getByTestId('space-logo-payer1'));
     });
   });
+
+  test('should render custom home url', () => {
+    const { getByText } = render(
+      <PageHeader homeUrl="/go-home" appName="Payer Space" />
+    );
+
+    const homeBtn = getByText('Home');
+
+    expect(homeBtn.getAttribute('href')).toBe('/go-home');
+  });
 });

--- a/packages/storybook/stories/breadcrumbs.stories.js
+++ b/packages/storybook/stories/breadcrumbs.stories.js
@@ -14,6 +14,7 @@ const ReactRouterBreadcrumbs = () => (
     <Breadcrumbs
       emptyState={text('Empty State', Breadcrumbs.defaultProps.emptyState)}
       active={text('Active Page', 'React Router Breadcrumb')}
+      homeUrl={text('Home Url', 'public/apps/dashboard')}
     >
       <BreadcrumbItem>
         <Link to="react-router-parent">Custom Breadcrumb Demo</Link>
@@ -34,7 +35,10 @@ const ReactRouterBreadcrumbs = () => (
 
 const ReactRouterDestination = () => (
   <div>
-    <Breadcrumbs active={text('Active Page', 'Custom Breadcrumb Demo')} />
+    <Breadcrumbs
+      active={text('Active Page', 'Custom Breadcrumb Demo')}
+      homeUrl={text('Home Url', 'public/apps/dashboard')}
+    />
     <Link to="/react-router-demo">react-router Link Back To demo</Link>
     <p>Sample destination page with react-router navigation</p>
   </div>
@@ -62,11 +66,13 @@ storiesOf('Components|Breadcrumbs', module)
     <Breadcrumbs
       emptyState={text('Empty State', Breadcrumbs.defaultProps.emptyState)}
       active={text('Active Page', 'Payer Spaces')}
+      homeUrl={text('Home Url', 'public/apps/dashboard')}
     />
   ))
   .add('active blank', () => <Breadcrumbs active="" />)
   .add('with parents', () => (
     <Breadcrumbs
+      homeUrl={text('Home Url', 'public/apps/dashboard')}
       emptyState={text('Empty State', Breadcrumbs.defaultProps.emptyState)}
       crumbs={[
         { name: 'Grand Parent', url: '/grand-parent' },

--- a/packages/storybook/stories/page-header.stories.js
+++ b/packages/storybook/stories/page-header.stories.js
@@ -34,6 +34,7 @@ storiesOf('Components|Header', module)
   ))
   .add('with app icon', () => (
     <PageHeader
+      homeUrl={text('Home Url', '/public/apps/dashboard')}
       appName="Payer Spaces"
       appAbbr={text('Application Abbreviation', 'PS')}
       iconColor={select(
@@ -55,6 +56,7 @@ storiesOf('Components|Header', module)
   .add('with payer logo', () => (
     <div>
       <PageHeader
+        homeUrl={text('Home Url', '/public/apps/dashboard')}
         appName="Payer Space"
         clientId={text('Client ID', 'my-client-id')}
         payerId={text('Payer ID', 'PayerID')}
@@ -69,6 +71,7 @@ storiesOf('Components|Header', module)
   ))
   .add('with payer space breadcrumb', () => (
     <PageHeader
+      homeUrl={text('Home Url', '/public/apps/dashboard')}
       appName="Payer Space"
       spaceId={text('Payer Space ID', '73162546201441126239486200007187')}
       spaceName={text('Payer Space Name', 'Payers Space')}
@@ -88,7 +91,11 @@ storiesOf('Components|Header', module)
     </PageHeader>
   ))
   .add('with custom breadcrumbs', () => (
-    <PageHeader appName="Payer Space" crumbs={CustomBreadcrumbs}>
+    <PageHeader
+      homeUrl={text('Home Url', '/public/apps/dashboard')}
+      appName="Payer Space"
+      crumbs={CustomBreadcrumbs}
+    >
       {text('Application Name', 'Payer Space')}
     </PageHeader>
   ))
@@ -99,6 +106,7 @@ storiesOf('Components|Header', module)
   ))
   .add('with feedback and payer logo', () => (
     <PageHeader
+      homeUrl={text('Home Url', '/public/apps/dashboard')}
       appName={text('Application Name', 'Payer Space')}
       payerId={text('Payer ID', 'PayerID')}
       clientId={text('Client ID', 'my-client-id')}
@@ -109,6 +117,7 @@ storiesOf('Components|Header', module)
   ))
   .add('with training link', () => (
     <PageHeader
+      homeUrl={text('Home Url', '/public/apps/dashboard')}
       feedback
       appName="Payer Spaces"
       component={


### PR DESCRIPTION
Adding this in so we can use page header for the gatsby docs.