### PR TITLE
Refactor/link tag

### DIFF
--- a/packages/breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/breadcrumbs/Breadcrumbs.d.ts
@@ -2,10 +2,13 @@ type Crumb = {
     name: string;
     url: string;
 }
+
+
 export interface BreadcrumbsProps {
     crumbs?: Array<Crumb>;
     active: string;
     emptyState?: string;
+    linkTag?: React.ComponentType<React.HTMLAttributes<HTMLAnchorElement>> | string;
     homeUrl?: string;
 }
 

--- a/packages/breadcrumbs/Breadcrumbs.js
+++ b/packages/breadcrumbs/Breadcrumbs.js
@@ -7,6 +7,7 @@ const Breadcrumbs = ({
   active,
   emptyState,
   children,
+  linkTag: LinkTag,
   homeUrl,
   ...rest
 }) => {
@@ -16,9 +17,9 @@ const Breadcrumbs = ({
     // render static links
     if (crumb.name && crumb.url) {
       breadCrumbItemChildren = (
-        <a aria-label={crumb.name} href={crumb.url}>
+        <LinkTag aria-label={crumb.name} href={crumb.url}>
           {crumb.name}
-        </a>
+        </LinkTag>
       );
     }
     return (
@@ -31,9 +32,9 @@ const Breadcrumbs = ({
   return (
     <Breadcrumb {...rest}>
       <BreadcrumbItem>
-        <a aria-label="Home" href={homeUrl}>
+        <LinkTag aria-label="Home" href={homeUrl}>
           Home
-        </a>
+        </LinkTag>
       </BreadcrumbItem>
       {crumbs && crumbs.length > 0 && crumbs.map(renderBreadCrumb)}
       {children}
@@ -49,6 +50,7 @@ Breadcrumbs.propTypes = {
       url: PropTypes.string,
     })
   ),
+  linkTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   active: PropTypes.string.isRequired,
   emptyState: PropTypes.string,
   children: PropTypes.node,
@@ -58,6 +60,7 @@ Breadcrumbs.propTypes = {
 Breadcrumbs.defaultProps = {
   emptyState: '…',
   homeUrl: '/public/apps/dashboard',
+  linkTag: 'a',
 };
 
 export default Breadcrumbs;

--- a/packages/breadcrumbs/tests/Breadcrumbs.test.js
+++ b/packages/breadcrumbs/tests/Breadcrumbs.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
+import { NavLink } from 'reactstrap';
 import Breadcrumbs from '..';
 
 afterEach(cleanup);
@@ -72,5 +73,15 @@ describe('Breadcrumbs', () => {
     const homeBtn = getByText('Home');
 
     expect(homeBtn.getAttribute('href')).toBe('/go-home');
+  });
+
+  test('should render custom link tag', () => {
+    const { getByText } = render(
+      <Breadcrumbs homeUrl="/go-home" active="Payer Space" linkTag={NavLink} />
+    );
+
+    const homeBtn = getByText('Home');
+
+    expect(homeBtn.className).toBe('nav-link');
   });
 });

--- a/packages/docs/source/components/breadcrumbs.mdx
+++ b/packages/docs/source/components/breadcrumbs.mdx
@@ -60,3 +60,6 @@ The children must be a reactstrap `BreadcrumbItem` components.
 
 ### `homeUrl?: string`
 Url for the Home route. **Default:** `public/apps/dashboard`
+
+### `linkTag?: React.ComponentType<React.HTMLAttributes<HTMLAnchorElement>> | string`
+Custom link tag for the links. **Default:** `<a>`

--- a/packages/docs/source/components/page-header.mdx
+++ b/packages/docs/source/components/page-header.mdx
@@ -97,3 +97,6 @@ Additional props passed to the `page-header-title`.
 ### `renderRightContent: React.ComponentType<{ payerLogo: ReactNode, feedback: ReactNode, className: string }>`
 
 Used to customize the contents of the right side of the page header where the feedback and payer logo get rendered. Accepts the rendered `payerLogo` and `feedback` as props
+
+### `linkTag?: React.ComponentType<React.HTMLAttributes<HTMLAnchorElement>> | string`
+Custom link tag for the links. **Default:** `<a>`

--- a/packages/page-header/PageHeader.d.ts
+++ b/packages/page-header/PageHeader.d.ts
@@ -19,6 +19,7 @@ export interface PageHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   component?: React.ReactType;
   feedback?: boolean;
   feedbackProps?: any;
+  linkTag?: React.ComponentType<React.HTMLAttributes<HTMLAnchorElement>> | string;
   titleProps?: React.HTMLAttributes<HTMLDivElement>;
   renderRightContent?: React.FunctionComponent<RightContentProps>;
   children?: React.ReactType;

--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -26,6 +26,7 @@ const PageHeader = ({
   iconSrc,
   iconAlt,
   homeUrl,
+  linkTag,
   className,
   ...props
 }) => {
@@ -89,6 +90,7 @@ const PageHeader = ({
             crumbs={crumbs}
             active={appName || children}
             homeUrl={homeUrl}
+            linkTag={linkTag}
           />
         )}
         {component}
@@ -155,6 +157,7 @@ PageHeader.propTypes = {
   feedbackProps: PropTypes.shape({ ...Feedback.propTypes }),
   titleProps: PropTypes.object,
   children: PropTypes.node,
+  linkTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   crumbs: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({

--- a/packages/page-header/tests/PageHeader.test.js
+++ b/packages/page-header/tests/PageHeader.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, cleanup, waitForElement } from '@testing-library/react';
 import TrainingLink from '@availity/training-link';
 import { avSlotMachineApi } from '@availity/api-axios';
+import { NavLink } from 'reactstrap';
 import Spaces from '@availity/spaces';
 import PageHeader from '..';
 
@@ -197,5 +198,24 @@ describe('PageHeader', () => {
 
     getByText('Hello World');
     getByText('Give Feedback');
+  });
+
+  test('should render custom link tag', () => {
+    const { getByText } = render(
+      <PageHeader
+        appName="Payer Space"
+        renderRightContent={({ feedback, ...props }) => (
+          <div {...props}>
+            Hello World
+            {feedback}
+          </div>
+        )}
+        linkTag={NavLink}
+      />
+    );
+
+    const homeBtn = getByText('Home');
+
+    expect(homeBtn.className).toBe('nav-link');
   });
 });


### PR DESCRIPTION
Allows us to add custom link tags to the page header.

In cases like the gatsby docs we want to use the `Link` tag instead of the native `<a>` tag.