### PR TITLE
fix(form): uses inputid attribute or generates uuid #303

### DIFF
--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "formik": "^2.0.1-rc.12",

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Input as RsInput, Label, FormText, Col } from 'reactstrap';
+import { v4 as uuid } from 'uuid';
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
 import Input from './Input';
@@ -23,6 +24,7 @@ const Field = ({
   ...attributes
 }) => {
   let row = false;
+  let { inputId } = attributes;
   const col = {};
   const labelCol = {};
 
@@ -37,9 +39,14 @@ const Field = ({
     });
   }
 
+  if (label && !inputId) {
+    inputId = uuid();
+  }
+
   const input = (
     <Input
       name={id}
+      id={inputId}
       className={inputClass}
       size={size}
       disabled={disabled}
@@ -71,7 +78,7 @@ const Field = ({
       {check && inputRow}
       {label && (
         <Label
-          for={id}
+          for={inputId}
           className={labelClass}
           hidden={labelHidden}
           size={size}

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Input as RsInput, Label, FormText, Col } from 'reactstrap';
-import { v4 as uuid } from 'uuid';
+import uuid from 'uuid/v4';
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
 import Input from './Input';
@@ -24,7 +24,7 @@ const Field = ({
   ...attributes
 }) => {
   let row = false;
-  let { inputId } = attributes;
+  const inputId = attributes.id || uuid();
   const col = {};
   const labelCol = {};
 
@@ -37,10 +37,6 @@ const Field = ({
         labelCol[colSize] = 12 - sizeNum;
       }
     });
-  }
-
-  if (label && !inputId) {
-    inputId = uuid();
   }
 
   const input = (

--- a/packages/form/tests/Field.test.js
+++ b/packages/form/tests/Field.test.js
@@ -112,7 +112,7 @@ describe('Field', () => {
     await expect(queryByDisplayValue('Name')).toEqual(null);
   });
 
-  test('label for attribute should point to a generated uuid when input id is not provided', () => {
+  test('should generate generated uuid when id is not provided', () => {
     const { container } = render(
       <Form onSubmit={() => {}}>
         <Field name="name" label="Greetings" />
@@ -124,11 +124,11 @@ describe('Field', () => {
     );
   });
 
-  test('label for attribute should point to input id', () => {
+  test('label for attribute should point to field id attribute', () => {
     const inputId = 'test-input-id';
     const { container } = render(
       <Form onSubmit={() => {}}>
-        <Field name="name" label="Greetings" inputId={inputId} />
+        <Field name="name" label="Greetings" id={inputId} />
       </Form>
     );
 
@@ -140,13 +140,13 @@ describe('Field', () => {
     );
   });
 
-  test('input id is not generated if no label is present', () => {
+  test('should generate uuid even when label is not added', () => {
     const { container } = render(
       <Form onSubmit={() => {}}>
         <Field name="name" />
       </Form>
     );
 
-    expect(container.querySelector('input').hasAttribute('id')).toEqual(false);
+    expect(container.querySelector('input').hasAttribute('id')).toBeTruthy();
   });
 });

--- a/packages/form/tests/Field.test.js
+++ b/packages/form/tests/Field.test.js
@@ -111,4 +111,42 @@ describe('Field', () => {
 
     await expect(queryByDisplayValue('Name')).toEqual(null);
   });
+
+  test('label for attribute should point to a generated uuid when input id is not provided', () => {
+    const { container } = render(
+      <Form onSubmit={() => {}}>
+        <Field name="name" label="Greetings" />
+      </Form>
+    );
+
+    expect(container.querySelector('input').getAttribute('id')).toEqual(
+      container.querySelector('label').getAttribute('for')
+    );
+  });
+
+  test('label for attribute should point to input id', () => {
+    const inputId = 'test-input-id';
+    const { container } = render(
+      <Form onSubmit={() => {}}>
+        <Field name="name" label="Greetings" inputId={inputId} />
+      </Form>
+    );
+
+    expect(container.querySelector('input').getAttribute('id')).toEqual(
+      inputId
+    );
+    expect(container.querySelector('label').getAttribute('for')).toEqual(
+      inputId
+    );
+  });
+
+  test('input id is not generated if no label is present', () => {
+    const { container } = render(
+      <Form onSubmit={() => {}}>
+        <Field name="name" />
+      </Form>
+    );
+
+    expect(container.querySelector('input').hasAttribute('id')).toEqual(false);
+  });
 });


### PR DESCRIPTION
# What I did

- Created a local variable `inputId` from `attributes.inputId` and set it to `uuid` when it is not sat and a label is present
- Created 3 unit tests to check for the different scenarios when `inputId` exists or not and whether a label exists or not

# How I did it

1. Checked the logic for `AvSelectField` and saw that it uses `inputId` from the attributes so I followed on the same footpath
2. Followed the logic of unit tests to create my unit tests
3. `yarn test`
4. `yarn start:docs` for good measures!

# How to verify it

1. Check the unit tests in `Field.test.js`:
 - `should generate generated uuid when id is not provided`
 - `label for attribute should point to field id attribute`
 - `should generate uuid even when label is not added`
2. Run `yarn start:docs` for good measures

# A picture of a cute animal
![dog-3029701_640](https://user-images.githubusercontent.com/87614/65955388-e8201500-e43f-11e9-8339-2a9b1ddc9d9d.jpg)

Fixes #303 

