### PR TITLE
fix(DateField): use id as for in label

### DIFF
--- a/packages/date/src/DateField.js
+++ b/packages/date/src/DateField.js
@@ -22,6 +22,7 @@ const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name
 );
  
 DateField.propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string,
   label: PropTypes.node,
   labelClass: PropTypes.string,

--- a/packages/date/src/DateField.js
+++ b/packages/date/src/DateField.js
@@ -4,11 +4,11 @@ import { Label } from 'reactstrap';
 import { FormGroup, Feedback } from '@availity/form';
 import Date from './Date';
 
-const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, ...props }) => (
+const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name, ...props }) => (
   <FormGroup for={name}>
     {label && (
       <Label 
-        for={name}
+        for={id}
         className={labelClass}
         hidden={labelHidden}
         {...labelAttrs}
@@ -16,7 +16,7 @@ const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, ...props 
           {label}
         </Label>
     )}
-    <Date name={name} {...props} />
+    <Date name={name} id={id} {...props} />
     <Feedback name={name} />
   </FormGroup>
 );

--- a/packages/date/src/DateField.js
+++ b/packages/date/src/DateField.js
@@ -8,7 +8,7 @@ const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name
   <FormGroup for={name}>
     {label && (
       <Label 
-        for={id}
+        for={`${id}-picker`}
         className={labelClass}
         hidden={labelHidden}
         {...labelAttrs}

--- a/packages/date/typings/DateField.d.ts
+++ b/packages/date/typings/DateField.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { DateProps } from './Date';
 
 export interface DateFieldProps extends DateProps {
+  id?: string;
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;


### PR DESCRIPTION
While `FormGroup` `for` prop should be the `name`, `Label`'s `for` prop should be the `id` so that the label is "connected" to the input for a11y and being able to focus on the input when clicking on the label.