### PR TITLE
fix(DateRangeField): make label target start field

### DIFF
--- a/packages/date/src/DateRangeField.js
+++ b/packages/date/src/DateRangeField.js
@@ -4,11 +4,11 @@ import { Label } from 'reactstrap';
 import { FormGroup, Feedback } from '@availity/form';
 import DateRange from './DateRange';
 
-const DateRangeField = ({ name, label, labelClass, labelHidden, labelAttrs, ...props }) => (
+const DateRangeField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name, ...props }) => (
   <FormGroup for={name}>
     {label && (
       <Label 
-        for={name}
+        for={`${id.replace(/[^a-zA-Z0-9]/gi, '')}-start`}
         className={labelClass}
         hidden={labelHidden}
         {...labelAttrs}
@@ -22,6 +22,7 @@ const DateRangeField = ({ name, label, labelClass, labelHidden, labelAttrs, ...p
 );
 
 DateRangeField.propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string,
   label: PropTypes.node,
   labelClass: PropTypes.string,

--- a/packages/date/typings/DateRangeField.d.ts
+++ b/packages/date/typings/DateRangeField.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { DateRangeProps } from './DateRange';
 
 export interface DateRangeFieldProps extends DateRangeProps {
+  id?: string;
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;


### PR DESCRIPTION
Previously, the label was not targeting any visible input.
With this change the label will target the start field, enabling the user to click the label to focus on the first field.