### PR TITLE
fix(react-docs): added yup moment extension import for date range

### DIFF
--- a/docs/source/form/date/components/date-range-field.md
+++ b/docs/source/form/date/components/date-range-field.md
@@ -10,7 +10,6 @@ The same as `DateRange` but with a `Label` that appears above the input and a `F
 import { Form } from '@availity/form';
 import { DateRange } from '@availity/date';
 import * as yup from 'yup';
-import '@availity/yup';
 import '@availity/yup/moment';
 import moment from 'moment';
 

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -10,7 +10,6 @@ A date range, consisting of 2 fields, a start date and an end date, without a `L
 import { Form } from '@availity/form';
 import { DateRange } from '@availity/date';
 import * as yup from 'yup';
-import '@availity/yup';
 import '@availity/yup/moment';
 import moment from 'moment';
 

--- a/docs/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
+++ b/docs/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
@@ -33,6 +33,7 @@ import { Disclaimer, Agreement } from '@availity/typography';
 import * as yup from 'yup';
 import moment from 'moment';
 import '@availity/favorites/style.scss';
+import '@availity/yup/moment';
 
 const scopes = {
   ...Reactstrap,


### PR DESCRIPTION
Fixes yup extension for `dateRange` not being included for the gatsby docs to display live code snippets properly.

fixes #311 