### PR TITLE
fix(select): prevents the provided styles from react-select from bein…

### DIFF
--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -307,6 +307,9 @@ class AvSelect extends AvBaseInput {
         styles={{
           ...styles,
           placeholder: (provided, state) => {
+            if (state.isDisabled) {
+              return provided;
+            }
             const showError = touched && hasError && !state.focused;
 
             return {
@@ -320,7 +323,11 @@ class AvSelect extends AvBaseInput {
             width: '90%',
           }),
           control: (provided, state) => {
+            if (state.isDisabled) {
+              return provided;
+            }
             const showError = touched && hasError && !state.focused;
+
             return {
               ...provided,
               borderRadius: '.25em',
@@ -338,6 +345,9 @@ class AvSelect extends AvBaseInput {
             maxWidth: '99%',
           }),
           dropdownIndicator: (provided, state) => {
+            if (state.isDisabled) {
+              return provided;
+            }
             const showError = touched && hasError && !state.focused;
 
             return {

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -216,6 +216,9 @@ const Select = ({
       styles={{
         ...styles,
         placeholder: (provided, state) => {
+          if (state.isDisabled) {
+            return provided;
+          }
           const showError = touched && hasError && !state.focused;
 
           return {
@@ -229,7 +232,11 @@ const Select = ({
           width: '90%',
         }),
         control: (provided, state) => {
+          if (state.isDisabled) {
+            return provided;
+          }
           const showError = touched && hasError && !state.focused;
+
           return {
             ...provided,
             borderRadius: '.25em',
@@ -247,6 +254,9 @@ const Select = ({
           maxWidth: '99%',
         }),
         dropdownIndicator: (provided, state) => {
+          if (state.isDisabled) {
+            return provided;
+          }
           const showError = touched && hasError && !state.focused;
 
           return {


### PR DESCRIPTION
…g overridden by the styles applied in an error condition

Currently the custom styles that make the Select component red in an error condition are not allowing the default behavior when the select `isDisabled`. 
