### PR TITLE
Refactor/favorites event

### DIFF
--- a/docs/source/components/favorites/heart.md
+++ b/docs/source/components/favorites/heart.md
@@ -21,6 +21,6 @@ import '@availity/favorites/style.scss';
 
 The unique id of the favorite item to be fetched from API.
 
-### `onChange?: (event?: Event) => void`
+### `onChange?: (isFavorited: boolean, event?: Event) => void`
 
 Called once the favorite heart has been clicked and updated.

--- a/packages/favorites/FavoriteHeart.js
+++ b/packages/favorites/FavoriteHeart.js
@@ -11,11 +11,11 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
   const [loading, toggleLoading] = useToggle(true);
 
   const icon = useMemo(() => {
-    const onChangeHandler = () => {
+    const onChangeHandler = e => {
       toggleFavorite();
 
       if (onChange) {
-        onChange(isFavorite);
+        onChange(!isFavorite, e);
       }
     };
 
@@ -34,7 +34,7 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
             onMouseDown(e);
           }
         }}
-        onKeyPress={({ charCode }) => charCode === 13 && onChangeHandler()}
+        onKeyPress={e => e.charCode === 13 && onChangeHandler(e)}
         onClick={onChangeHandler}
       >
         <span className="sr-only">Favorite</span>
@@ -64,7 +64,7 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
           placement="top"
           trigger="hover"
           delay={{
-            show: 2000,
+            show: 1500,
             hide: 0,
           }}
           target={`av-favorite-heart-${id}`}

--- a/packages/favorites/index.d.ts
+++ b/packages/favorites/index.d.ts
@@ -1,0 +1,5 @@
+import FavoriteHeart from './types/FavoriteHeart';
+import Favorites, { useFavorites, FavoritesContext } from './types/FavoritesContext';
+
+export default Favorites;
+export { FavoritesContext, useFavorites, FavoriteHeart };

--- a/packages/favorites/types/FavoriteHeart.d.ts
+++ b/packages/favorites/types/FavoriteHeart.d.ts
@@ -1,0 +1,8 @@
+import { MouseEventHandler } from 'react-select/src/types';
+
+interface FavoriteHeartProps extends React.HTMLAttributes<HTMLSpanElement> {
+  id: string;
+}
+declare const FavoriteHeart: React.FunctionComponent<FavoriteHeartProps>;
+
+export default FavoriteHeart;

--- a/packages/favorites/types/FavoritesContext.d.ts
+++ b/packages/favorites/types/FavoritesContext.d.ts
@@ -1,0 +1,26 @@
+import FavoriteHeart from './FavoriteHeart';
+
+export interface FavoriteType {
+  id: string;
+  pos: number;
+}
+
+export interface ProviderContextValues {
+  favorites: FavoriteType[];
+  deleteFavorite: (id: string) => void;
+  addFavorite: (id: string) => void;
+}
+
+interface FavoritesProps {
+  children?: React.ReactType;
+}
+
+export type FavoritesContext = React.Context<ProviderContextValues>;
+
+declare const Favorites: React.FunctionComponent<FavoritesProps>;
+
+declare function useFavorites(id: string): [string, () => void];
+
+export default Favorites;
+
+export { useFavorites };


### PR DESCRIPTION
- Fixed `onChange` callback to actually return the new state of the favorite change.
- Added `event: MouseEvent` to the callback in order to do things like `stopPropagation`
- Added Typescript Definitions