### PR TITLE
feat(analytics): added analytics package

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -66,6 +66,13 @@ module.exports = {
             },
           ],
           'Portal Components': [
+            {
+              resolve: 'components/analytics/index',
+              pages: [
+                'components/analytics/analytics',
+                'components/analytics/hook',
+              ],
+            },
             'components/authorize',
             'components/avatar',
             {

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,6 +22,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
+    "@availity/analytics": "^1.0.0",
     "@availity/api-axios": "^5.4.0",
     "@availity/api-core": "^5.4.0",
     "@availity/app-icon": "^1.3.1",

--- a/docs/source/components/analytics/analytics.md
+++ b/docs/source/components/analytics/analytics.md
@@ -1,0 +1,48 @@
+---
+title: <Analytics /> ( Default Export )
+summary: Component allowing page and click events to be tracked.
+---
+
+## Example
+
+```jsx
+import React from 'react';
+import { Button } from 'reactstrap';
+import Analytics from '@availity/Analytics';
+
+const plugin = {
+    trackEvent: e => {
+        alert(JSON.stringify(e))
+    }
+}
+
+<Analytics
+    plugins={[plugin]}
+    recurisve
+    attributePrefix="data-av-analytics"
+>
+  <Button type="button" data-av-analytics-action="click" id="button">Click Me</Button>
+</Analytics>
+```
+
+## Props
+
+### `plugins?: AnalyticsPlugin[]`
+
+Array of plugins to call when an event is tracked. See [@availity/analytics-core](/sdk-js) for list of prebuilt plugins.
+
+### `pageTracking?: boolean`
+
+Whether or not the initial page tracking is enabled. **Default:** `true`.
+
+### `autoTrack?: boolean`
+
+Whether or not initial event tracking is enabled. **Default:** `true`.
+
+### `recursive?: boolean`
+
+When an event is created, if `true`, will traverse up the DOM tree from the given element and take `data-analytics` attributes off each component until it reaches the root. **Default:** `true`
+
+### `attributePrefix?: string`
+
+Prefix to apply on event attributes you want to stripe off components on click. **Default:** `data-analytics`

--- a/docs/source/components/analytics/analytics.md
+++ b/docs/source/components/analytics/analytics.md
@@ -29,7 +29,7 @@ const plugin = {
 
 ### `plugins?: AnalyticsPlugin[]`
 
-Array of plugins to call when an event is tracked. See [@availity/analytics-core](/sdk-js) for list of prebuilt plugins.
+Array of plugins to call when an event is tracked. See [@availity/analytics-core](/sdk-js/features/analytics/) for list of prebuilt plugins.
 
 ### `pageTracking?: boolean`
 

--- a/docs/source/components/analytics/hook.md
+++ b/docs/source/components/analytics/hook.md
@@ -1,0 +1,21 @@
+---
+title: useAnalytics
+---
+
+Hook giving you access to the instance of `@availity/analytics-core` for manually tracking events, and changing different variables.
+
+## Example
+
+```jsx
+import React from 'react';
+import { Button } from 'reactstrap';
+import { useAnalytics } from '@availity/analytics';
+const Component = () => {
+  const { trackEvent } = useAnalytics();
+  return (
+    <Button onClick={() => trackEvent({ url: '/test', data: 'some-data' })}>
+      Click Me
+    </Button>
+  );
+};
+```

--- a/docs/source/components/analytics/index.md
+++ b/docs/source/components/analytics/index.md
@@ -1,0 +1,33 @@
+---
+title: Analytics
+summary: Track page events and user clicks.
+---
+
+[![Version](https://img.shields.io/npm/v/@availity/analytics.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/analytics)
+
+## Installation
+
+```bash
+npm install @availity/analytics --save
+```
+
+## Example
+
+```jsx
+import React from 'react';
+import { Button } from 'reactstrap';
+import Analytics from '@availity/Analytics';
+
+const plugin = {
+    trackEvent: e => {
+        alert(JSON.stringify(e))
+    }
+}
+
+<Analytics
+    plugins={[plugin]}
+    attributePrefix="data-av-analytics"
+>
+  <Button type="button" data-av-analytics-action="click" id="button">Click Me</Button>
+</Analytics>
+```

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,11 @@
+# @availity/analytics
+
+> track click and page events for the user
+
+[![Version](https://img.shields.io/npm/v/@availity/analytics.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/analytics)
+
+## Installation
+
+```bash
+npm install @availity/analytics --save
+```

--- a/packages/analytics/index.d.ts
+++ b/packages/analytics/index.d.ts
@@ -1,0 +1,3 @@
+import Analytics from './src/Analytics';
+
+export default Analytics;

--- a/packages/analytics/index.d.ts
+++ b/packages/analytics/index.d.ts
@@ -1,3 +1,3 @@
-import Analytics from './src/Analytics';
+import Analytics from './types/Analytics';
 
 export default Analytics;

--- a/packages/analytics/index.js
+++ b/packages/analytics/index.js
@@ -1,0 +1,3 @@
+import Analytics from './src/Analytics';
+
+export default Analytics;

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@availity/analytics",
+  "version": "1.0.0",
+  "author": "Kyle Gray <kyle.gray@gmail.com>",
+  "description": "Track click and page view events for the user.",
+  "main": "index.js",
+  "keywords": [
+    "react",
+    "availity"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@availity/analytics-core": "^2.8.0",
+    "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  }
+}

--- a/packages/analytics/src/Analytics.js
+++ b/packages/analytics/src/Analytics.js
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useRef, useEffect } from 'react';
+import { AvAnalytics } from '@availity/analytics-core';
+import PropTypes from 'prop-types';
+
+export const AnalyticsContext = createContext();
+
+const Analytics = ({
+  children,
+  plugins,
+  pageTracking,
+  autoTrack,
+  recursive,
+  attributePrefix,
+}) => {
+  const analytics = useRef(
+    new AvAnalytics(plugins, Promise, pageTracking, autoTrack, {
+      recursive,
+      attributePrefix,
+    })
+  );
+
+  const cleanup = () => analytics.current.stopAutoTrack();
+
+  useEffect(() => cleanup, []);
+
+  return (
+    <AnalyticsContext.Provider value={analytics.current}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+};
+
+export const useAnalytics = () => useContext(AnalyticsContext);
+
+Analytics.propTypes = {
+  children: PropTypes.node,
+  plugins: PropTypes.array,
+  pageTracking: PropTypes.bool,
+  autoTrack: PropTypes.bool,
+  recursive: PropTypes.bool,
+  attributePrefix: PropTypes.string,
+};
+
+Analytics.defaultProps = {
+  autoTrack: true,
+  pageTracking: true,
+  recursive: true,
+  attributePrefix: 'data-analytics',
+};
+
+export default Analytics;

--- a/packages/analytics/tests/Analytics.test.js
+++ b/packages/analytics/tests/Analytics.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, cleanup, fireEvent, wait } from '@testing-library/react';
+import Analytics from '..';
+import { useAnalytics } from '../src/Analytics';
+
+const makePlugin = () => ({
+  isEnabled: jest.fn(() => true),
+  init: jest.fn(),
+  trackEvent: jest.fn(),
+  trackPageView: jest.fn(),
+});
+
+describe('Analytics', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should allow click events', async () => {
+    const plugins = [makePlugin()];
+
+    const { getByText } = render(
+      <Analytics plugins={plugins} attributePrefix="data-av-analytics">
+        <button
+          data-av-analytics-on="click"
+          data-av-analytics-action="click"
+          type="button"
+        >
+          Hello World
+        </button>
+      </Analytics>
+    );
+
+    const btn = getByText('Hello World');
+
+    fireEvent.click(btn);
+
+    await wait(() => {
+      expect(plugins[0].trackEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('should allow trackEvents from code', async () => {
+    const plugins = [makePlugin()];
+
+    const Button = () => {
+      const { trackEvent } = useAnalytics();
+      return (
+        <button
+          onClick={() =>
+            trackEvent({
+              url: '/test',
+            })
+          }
+          type="button"
+        >
+          Hello World
+        </button>
+      );
+    };
+
+    const { getByText } = render(
+      <Analytics plugins={plugins}>
+        <Button />
+      </Analytics>
+    );
+
+    const btn = getByText('Hello World');
+
+    fireEvent.click(btn);
+
+    await wait(() => {
+      expect(plugins[0].trackEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/analytics/types/Analytics.d.ts
+++ b/packages/analytics/types/Analytics.d.ts
@@ -1,0 +1,28 @@
+export interface AnalyticsEvent {
+  [key: string]: any;
+  url: string;
+}
+
+export interface AnalyticsPlugin {
+  isEnabled: () => boolean;
+  init: () => void;
+  trackEvent: (event: AnalyticsEvent) => void;
+  trackPageView: (url: string) => void;
+}
+
+interface AdditionalOptions {
+  recursive?: boolean;
+  attributePrefix?: string;
+}
+
+export interface AnalyticsProps {
+  children?: React.ReactType;
+  plugins?: AnalyticsPlugin[];
+  pageTracking?: boolean;
+  autoTrack?: boolean;
+  options?: AdditionalOptions;
+}
+
+declare const Analytics: React.FunctionComponent<AnalyticsProps>;
+
+export default Analytics;

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@availity/analytics": "^1.0.0",
     "@availity/api-axios": "^5.4.0",
     "@availity/api-core": "^5.4.0",
     "@availity/app-icon": "^1.3.1",

--- a/storybook/stories/analytics.stories.js
+++ b/storybook/stories/analytics.stories.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs/react';
+import { Button } from 'reactstrap';
+import Analytics from '@availity/analytics';
+import README from '@availity/analytics/README.md';
+
+storiesOf('Components|Analytics', module)
+  .addParameters({
+    readme: {
+      // Show readme at the addons panel
+      sidebar: README,
+      // eslint-disable-next-line react/prop-types
+      StoryPreview: ({ children }) => <div>{children}</div>,
+    },
+  })
+  .addDecorator(withKnobs)
+  .add('default', () => {
+    const plugin = {
+      isEnabled: () => true,
+      init: () => {},
+      trackEvent: e => {
+        alert(JSON.stringify(e));
+      },
+      trackPageView: () => {},
+    };
+
+    return (
+      <Analytics
+        plugins={[plugin]}
+        options={{
+          recursive: true,
+          attributePrefix: 'data-av-analytics',
+        }}
+      >
+        <Button
+          id="buttonId"
+          data-av-analytics-on="click"
+          data-av-analytics-action="click"
+          data-av-analytics-test-id="hello"
+        >
+          Click Me
+        </Button>
+      </Analytics>
+    );
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@availity/analytics-core/-/analytics-core-2.7.2.tgz#92f039fe451ed5bb4a5f8191c41f6ec68e4e1196"
   integrity sha512-2R5k7du/pDX8j8l93XBYPbRMp7gYA36RRbQj4KOn5OF0iUHrOnnW7uzcxfmH9GalQ7HOUsXsyP85FRjWgaGIUw==
 
+"@availity/analytics-core@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@availity/analytics-core/-/analytics-core-2.8.0.tgz#cb2109c042d4192362abde4130920b81e5d2f5d7"
+  integrity sha512-VDXQHwofOSEn/AT5masBx/TKd+TWam1LlbT9cdw7+uzD0X8cdxwqzbXWfgbehD23R9ulDVDXBsjeLAImiMbAOg==
+
 "@availity/api-axios@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@availity/api-axios/-/api-axios-5.4.1.tgz#c7b1b486c369787860b7075fdec70c875fb38bfd"


### PR DESCRIPTION
Adds wrapper around `@availity/analytics-core` package.

Makes it much easier to configure analytics instead of having to define it all using base javascript.

React also allows the component to unmount, removing all event listeners when developing locally. This prevents the number of API calls from being duplicated once the DOM Hot reloads after making changes.

I'm up for suggestions, I was thinking maybe for the React side we just allow a boolean or enum for what log message service you want to use and create it for the user rather than still having them provide the array themselves. We can still optionally allow them to pass in their own but feel like the same logic is duplicated across all our apps.