### PR TITLE
fix(page-header): ensure breadcrumbs parent div never gets squished

### DIFF
--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -85,7 +85,7 @@ const PageHeader = ({
 
   return (
     <>
-      <div className="d-flex align-items-start">
+      <div className="d-flex align-items-start flex-shrink-0">
         {React.isValidElement(crumbs) ? (
           crumbs
         ) : (


### PR DESCRIPTION
Fixes an issue in Safari where the Breadcrumbs parent div could get squished and cause spacing issues.