### PR TITLE
Fix/accessibility

### DIFF
--- a/packages/page-header/PageHeader.js
+++ b/packages/page-header/PageHeader.js
@@ -130,7 +130,7 @@ const PageHeader = ({
           {children || <h1 className="mb-0">{appName}</h1>}
         </Tag>
         {!RenderRightContent ? (
-          <div className="page-header-left d-flex flex-xs-wrap flex-md-nowrap flex-grow align-items-end justify-content-end">
+          <div className="page-header-left d-flex flex-wrap flex-md-nowrap flex-grow align-items-end justify-content-end">
             {showFeedback && feedback}
             {payerLogo}
           </div>
@@ -188,7 +188,7 @@ PageHeader.defaultProps = {
   homeUrl: '/public/apps/dashboard',
   titleProps: {},
   renderRightClassName:
-    'page-header-left d-flex flex-xs-wrap flex-md-nowrap flex-grow align-items-end justify-content-end',
+    'page-header-left d-flex flex-wrap flex-md-nowrap flex-grow align-items-end justify-content-end',
 };
 
 export default PageHeader;

--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -303,7 +303,7 @@ class AvSelect extends AvBaseInput {
           ...styles,
           placeholder: (provided, state) => {
             if (state.isDisabled) {
-              return { ...provided };
+              return provided;
             }
             const showError = touched && hasError && !state.focused;
 
@@ -355,7 +355,7 @@ class AvSelect extends AvBaseInput {
           }),
           dropdownIndicator: (provided, state) => {
             if (state.isDisabled) {
-              return { ...provided };
+              return provided;
             }
             const showError = touched && hasError && !state.focused;
 

--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -303,7 +303,7 @@ class AvSelect extends AvBaseInput {
           ...styles,
           placeholder: (provided, state) => {
             if (state.isDisabled) {
-              return provided;
+              return { ...provided };
             }
             const showError = touched && hasError && !state.focused;
 
@@ -317,9 +317,23 @@ class AvSelect extends AvBaseInput {
             ...provided,
             width: '90%',
           }),
+          singleValue: (provided, state) => {
+            if (state.isDisabled) {
+              return {
+                ...provided,
+                color: '#495057',
+              };
+            }
+            return { ...provided };
+          },
           control: (provided, state) => {
             if (state.isDisabled) {
-              return provided;
+              return {
+                ...provided,
+                borderRadius: '.25em',
+                borderColor: '#ced4da',
+                backgroundColor: '#e9ecef',
+              };
             }
             const showError = touched && hasError && !state.focused;
 
@@ -341,7 +355,7 @@ class AvSelect extends AvBaseInput {
           }),
           dropdownIndicator: (provided, state) => {
             if (state.isDisabled) {
-              return provided;
+              return { ...provided };
             }
             const showError = touched && hasError && !state.focused;
 

--- a/packages/reactstrap-validation-select/AvSelect.js
+++ b/packages/reactstrap-validation-select/AvSelect.js
@@ -317,14 +317,11 @@ class AvSelect extends AvBaseInput {
             ...provided,
             width: '90%',
           }),
-          singleValue: (provided, state) => {
-            if (state.isDisabled) {
-              return {
-                ...provided,
-                color: '#495057',
-              };
-            }
-            return { ...provided };
+          singleValue: provided => {
+            return {
+              ...provided,
+              color: '#495057',
+            };
           },
           control: (provided, state) => {
             if (state.isDisabled) {

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -224,7 +224,7 @@ const Select = ({
         ...styles,
         placeholder: (provided, state) => {
           if (state.isDisabled) {
-            return { ...provided };
+            return provided;
           }
           const showError = touched && hasError && !state.focused;
 
@@ -276,7 +276,7 @@ const Select = ({
         }),
         dropdownIndicator: (provided, state) => {
           if (state.isDisabled) {
-            return { ...provided };
+            return provided;
           }
           const showError = touched && hasError && !state.focused;
 

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -238,14 +238,11 @@ const Select = ({
           ...provided,
           width: '90%',
         }),
-        singleValue: (provided, state) => {
-          if (state.isDisabled) {
-            return {
-              ...provided,
-              color: '#495057',
-            };
-          }
-          return { ...provided };
+        singleValue: provided => {
+          return {
+            ...provided,
+            color: '#495057',
+          };
         },
         control: (provided, state) => {
           if (state.isDisabled) {

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -224,7 +224,7 @@ const Select = ({
         ...styles,
         placeholder: (provided, state) => {
           if (state.isDisabled) {
-            return provided;
+            return { ...provided };
           }
           const showError = touched && hasError && !state.focused;
 
@@ -238,9 +238,23 @@ const Select = ({
           ...provided,
           width: '90%',
         }),
+        singleValue: (provided, state) => {
+          if (state.isDisabled) {
+            return {
+              ...provided,
+              color: '#495057',
+            };
+          }
+          return { ...provided };
+        },
         control: (provided, state) => {
           if (state.isDisabled) {
-            return provided;
+            return {
+              ...provided,
+              borderRadius: '.25em',
+              borderColor: '#ced4da',
+              backgroundColor: '#e9ecef',
+            };
           }
           const showError = touched && hasError && !state.focused;
 
@@ -262,7 +276,7 @@ const Select = ({
         }),
         dropdownIndicator: (provided, state) => {
           if (state.isDisabled) {
-            return provided;
+            return { ...provided };
           }
           const showError = touched && hasError && !state.focused;
 


### PR DESCRIPTION
This PR matches the disabled state colors of `Select.js` to those found in Availity/form. Also brings them into 508 compliance since there was not enough contrast with the previous values.

Before:
[Contrast Ratio 3.52:1](https://webaim.org/resources/contrastchecker/?fcolor=808080&bcolor=F2F2F2)
![image](https://user-images.githubusercontent.com/664714/67306178-8abe3780-f4c4-11e9-94be-0cf1a6b10d9e.png)

After:
[Contrast Ratio 6.89:1](https://webaim.org/resources/contrastchecker/?fcolor=495057&bcolor=E9ECEF)
![image](https://user-images.githubusercontent.com/664714/67306036-521e5e00-f4c4-11e9-993c-46ca7a4ae4b5.png)