### PR TITLE
refactor(form): fixed default checked when page loads if true

### DIFF
--- a/packages/form/src/Input.js
+++ b/packages/form/src/Input.js
@@ -18,7 +18,15 @@ const Input = ({ tag: Tag, className, name, ...rest }) => {
       'was-validated'
   );
 
-  return <Tag className={classes} name={name} {...field} {...rest} />;
+  const extraProps = {};
+
+  if (rest.type === 'checkbox') {
+    extraProps.checked = !!field.value;
+  }
+
+  return (
+    <Tag className={classes} name={name} {...field} {...extraProps} {...rest} />
+  );
 };
 
 Input.propTypes = {

--- a/packages/form/tests/Input.test.js
+++ b/packages/form/tests/Input.test.js
@@ -102,4 +102,26 @@ describe('Input', () => {
       expect(input.className).toContain('was-validated');
     });
   });
+
+  test('checkbox renders initial checked of true', () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: true,
+        }}
+        validationSchema={yup.object().shape({
+          hello: yup.boolean().required(),
+        })}
+        onSubmit={() => {}}
+      >
+        <Input name="hello" data-testid="hello-input" type="checkbox" />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const input = getByTestId('hello-input');
+
+    expect(input.getAttribute('value')).toBe('true');
+    expect(input.getAttribute('checked')).toBe(''); // null would mean its not checked...
+  });
 });


### PR DESCRIPTION
fixes #357 

When `initialValues` for a input of type `checkbox` is `true` the checkbox checked prop should be set to `true` for it to display properly on the DOM.