### PR TITLE
refactor(date): fixed error after picker selection

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -73,7 +73,9 @@ const AvDate = ({
       val = val.format(isoDateFormat);
     }
 
-    await setFieldValue(name, val, false);
+    await setFieldValue(name, val, true);
+
+    await setFieldTouched(name, true);
 
     if (onChange) {
       onChange(val);


### PR DESCRIPTION
For some reason, when we set the field value we also must set the field touched to true to essentially double validate. There maybe a bug in formik but this does resolve the issue and DateRange is performing the same logic without knowing that bug existed so it may be the correct way.

closes #360 