### PR TITLE
feat(authorize): add resources filter

### DIFF
--- a/docs/source/components/authorize.mdx
+++ b/docs/source/components/authorize.mdx
@@ -24,9 +24,13 @@ import Authorize from '@availity/authorize';
 
 ## Props
 
-### `permissions: string | number | Array<string | number`>`
+### `permissions: string | number | Array<string | number | Array<string | number>>` 
 
-Can either be a string, eg: `"1234"`, a number, eg: `1234`, or an array, which can contain permission ID strings as well as other arrays which contain permission ID strings/numbers, eg: `['1234', '2345', ['3456', '4567'], ['5678', '6789']]`. The items in a nested array indicate permission IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted, the user is considered authorized. The example `['1234', '2345', ['3456', '4567'], ['5678', '6789']]` is similar to `'1234' OR '2345' OR ('3456' && '4567') OR ('5678' && '6789')`.
+Can either be a string, eg: `"1234"`, a number, eg: `1234`, or an array, which can contain permission ID strings/numbers as well as other arrays which contain permission ID strings/numbers, eg: `['1234', '2345', ['3456', '4567'], ['5678', '6789']]`. The items in a nested array indicate permission IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted, the user is considered authorized. The example `['1234', '2345', ['3456', '4567'], ['5678', '6789']]` is similar to `'1234' OR '2345' OR ('3456' && '4567') OR ('5678' && '6789')`.
+
+### `resources?: string | number | Array<string | number | Array<string | number>>`
+
+When present, the permission is validated to ensure it contains the resource(s). Can either be a string, eg: `"12345"`, a number, eg: `12345`, or an array, which can contain resource ID strings/numbers as well as other arrays which contain resource ID strings/numbers, eg: `['12345', '23456', ['34567', '45678'], ['56789', '67890']]`. The items in a nested array indicate resource IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted, the user is considered authorized. The example `['12345', '23456', ['34567', '45678'], ['56789', '67890']]` is similar to `'12345' OR '23456' OR ('34567' && '45678') OR ('56789' && '67890')`.
 
 ### `loader?: boolean | ReactNode`
 
@@ -38,7 +42,7 @@ When present, the permission is validated to ensure it is assigned to the organi
 
 ### `customerId?: string`
 
-When present, the permission is validated to ensure it is assigned to the customer. Note: Cannot be used in combination with the `organizationId` prop.
+When present, the permission is validated to ensure it is assigned to the customer.
 
 ### `region?: string | boolean`
 
@@ -60,13 +64,16 @@ Hook which validates the user's permissions and returns whether the user is auth
 
 ### Arguments
 
-- **`permissions`**: String,Number,Array<`String`,`Number`>. Required.
+- **`permissions`**: String,Number,Array<`String`,`Number`,Array<`String`,`Number`>>. Required.
   - **string/number**: The permission ID, eg: `'1234'` or `1234`
-  - **array**: The array can contain permission ID strings as well as other arrays which contain permission ID strings/numbers, eg: `['1234', '2345', ['3456', '4567'], ['5678', '6789']]`. The items in a nested array indicate permission IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted to the user, the user is considered authorized. The example `['1234', '2345', ['3456', '4567'], ['5678', '6789']]` is similar to `'1234' || '2345' || ('3456' && '4567') || ('5678' && '6789')`.
+  - **array**: The array can contain permission ID strings/numbers as well as other arrays which contain permission ID strings/numbers, eg: `['1234', '2345', ['3456', '4567'], ['5678', '6789']]`. The items in a nested array indicate permission IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted to the user, the user is considered authorized. The example `['1234', '2345', ['3456', '4567'], ['5678', '6789']]` is similar to `'1234' || '2345' || ('3456' && '4567') || ('5678' && '6789')`.
 - **`options`** Object. Optional. Additional options
   - **`organizationId`**: String. Optional. When present, the permission is validated to ensure it is assigned to the organization.
-  - **`customerId`**: String. Optional. When present, the permission is validated to ensure it is assigned to the customer. Note: Cannot be used in combination with the `organizationId` prop
+  - **`customerId`**: String. Optional. When present, the permission is validated to ensure it is assigned to the customer.
   - **`region`**: String or Boolean. Optional. Default: `true`. When a string, the permission is validated to ensure it is assigned in the provided region. When true, the permission is validated to ensure it is assigned in the current region.
+  - **`resources`**: String,Number,Array<`String`,`Number`,Array<`String`,`Number`>>. Optional.
+    - **string/number**: The resource ID, eg: `'12345'` or `12345`
+    - **array**: The array can contain resource ID strings/numbers as well as other arrays which contain resource ID strings/numbers, eg: `['12345', '23456', ['34567', '45678'], ['56789', '67890']]`. The items in a nested array indicate resource IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted to the user, the user is considered authorized. The example `['12345', '23456', ['34567', '45678'], ['56789', '67890']]` is similar to `'12345' || '23456' || ('34567' && '45678') || ('56789' && '67890')`.
 
 ### Usage
 

--- a/packages/authorize/Authorize.d.ts
+++ b/packages/authorize/Authorize.d.ts
@@ -1,5 +1,10 @@
+export type NumberOrString = string | number;
+export type Permission = string | number | NumberOrString[];
+export type Resource = string | number | NumberOrString[];
+
 export interface AuthorizeProps {
-    permissions: Array<string | number> | Array<Array<string | number>>;
+    permissions: string | number | Permission[],
+    resources?: string | number | Resource[],
     region?: boolean | string;
     loader?: boolean | React.ReactType;
     organizationId?: string;

--- a/packages/authorize/Authorize.js
+++ b/packages/authorize/Authorize.js
@@ -6,6 +6,7 @@ import useAuthorize from './useAuthorize';
 
 const Authorize = ({
   permissions,
+  resources,
   customerId,
   organizationId,
   region,
@@ -18,6 +19,7 @@ const Authorize = ({
     customerId,
     organizationId,
     region,
+    resources,
   });
 
   if (loading) {
@@ -46,6 +48,19 @@ Authorize.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]).isRequired,
+  resources: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.arrayOf(
+          PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        ),
+        PropTypes.string,
+        PropTypes.number,
+      ])
+    ),
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   region: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   loader: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   organizationId: PropTypes.string,

--- a/packages/authorize/tests/Authorize.test.js
+++ b/packages/authorize/tests/Authorize.test.js
@@ -18,6 +18,17 @@ beforeEach(() => {
         {
           id: '1111',
           customerId: '1194',
+          resources: [
+            {
+              id: '1',
+            },
+            {
+              id: '2',
+            },
+            {
+              id: '3',
+            },
+          ],
         },
       ],
     },
@@ -127,6 +138,38 @@ describe('Authorize', () => {
         permissions="1234"
         customerId="1193"
         unauthorized="You do not have permission to see this"
+      >
+        You have permission to see this
+      </Authorize>
+    );
+
+    await waitForElement(() =>
+      getByText('You do not have permission to see this')
+    );
+  });
+
+  test('should render authorized with correct resources', async () => {
+    const { getByText } = render(
+      <Authorize
+        permissions="1234"
+        customerId="1194"
+        unauthorized="You do not have permission to see this"
+        resources="2"
+      >
+        You have permission to see this
+      </Authorize>
+    );
+
+    await waitForElement(() => getByText('You have permission to see this'));
+  });
+
+  test('should render unauthorized with incorrect resources', async () => {
+    const { getByText } = render(
+      <Authorize
+        permissions="1234"
+        customerId="1194"
+        unauthorized="You do not have permission to see this"
+        resources="5"
       >
         You have permission to see this
       </Authorize>

--- a/packages/authorize/tests/useAuthorize.test.js
+++ b/packages/authorize/tests/useAuthorize.test.js
@@ -35,6 +35,17 @@ beforeEach(() => {
         {
           id: '1111',
           customerId: '1194',
+          resources: [
+            {
+              id: '1',
+            },
+            {
+              id: '2',
+            },
+            {
+              id: '3',
+            },
+          ],
         },
       ],
     },
@@ -113,28 +124,6 @@ describe('useAuthorize', () => {
     await waitForElement(() => getByText('You have permission to see this'));
   });
 
-  test('should render with console warning', async () => {
-    // eslint-disable-next-line no-console
-    console.error = jest.fn();
-
-    const { getByText } = render(
-      <Component
-        permissions="1234"
-        region="FL"
-        organizationId="1111"
-        customerId="1194"
-      >
-        You have permission to see this
-      </Component>
-    );
-
-    await waitForElement(() => getByText('You have permission to see this'));
-
-    // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledWith(
-      'You provided both `organizationId` and `customerId` to Authorize but both cannot be used together; `organizationId` will be used and `customerId` will be ignored. If you want to use `customerId` do not provide `organizationId`.'
-    );
-  });
   test('should render authorized with region', async () => {
     const { getByText } = render(
       <Component permissions="1234" region="FL" organizationId="1111">
@@ -193,6 +182,94 @@ describe('useAuthorize', () => {
   test('should render unauthorized with incorrect customerId', async () => {
     const { getByText } = render(
       <Component permissions="1234" customerId="1193">
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() =>
+      getByText('You do not have permission to see this')
+    );
+  });
+
+  test('should render authorized with correct resources as string', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources="1">
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() => getByText('You have permission to see this'));
+  });
+
+  test('should render authorized with correct resources as number', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={2}>
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() => getByText('You have permission to see this'));
+  });
+
+  test('should render authorized with correct resources as array', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={['1']}>
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() => getByText('You have permission to see this'));
+  });
+
+  test('should render authorized with correct resources as nested array', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={[['1', '2']]}>
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() => getByText('You have permission to see this'));
+  });
+
+  test('should render unauthorized with incorrect resources as string', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources="5">
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() =>
+      getByText('You do not have permission to see this')
+    );
+  });
+
+  test('should render unauthorized with incorrect resources as number', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={6}>
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() =>
+      getByText('You do not have permission to see this')
+    );
+  });
+
+  test('should render unauthorized with incorrect resources as array', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={['5']}>
+        You have permission to see this
+      </Component>
+    );
+
+    await waitForElement(() =>
+      getByText('You do not have permission to see this')
+    );
+  });
+
+  test('should render unauthorized with incorrect resources as nested array', async () => {
+    const { getByText } = render(
+      <Component permissions="1234" customerId="1194" resources={[['1', '5']]}>
         You have permission to see this
       </Component>
     );

--- a/packages/authorize/useAuthorize.d.ts
+++ b/packages/authorize/useAuthorize.d.ts
@@ -1,11 +1,14 @@
+import { Permission, Resource } from './Authorize';
+
 export interface AuthorizeOpts {
   organizationId?: string;
   customerId?: string;
   region?: boolean | string;
+  resources?: string | number | Resource[];
 }
 
 declare function useAuthorize(
-  permissions: string | Array<String>,
+  permissions: string | number | Permission[],
   options?: AuthorizeOpts
 ): [boolean,boolean];
 


### PR DESCRIPTION
Adds additional prop `resources` to `<Authorize />` component and additional option `resources` in `useAuthorize` hook to filter out permissions that do not contain the `resources` provided.

Also removed the constraint that `organizationId` and `customerId` cannot be used in conjunction.
