### PR TITLE
refactor(pagination): allow pagination to be controlled via props

### DIFF
--- a/docs/source/components/pagination/pagination.md
+++ b/docs/source/components/pagination/pagination.md
@@ -15,23 +15,32 @@ import Pagination from '@availity/pagination';
 </Pagination>;
 ```
 
-
 ## Props
 
 ### `items? Array<Object> | (currentPage: number, itemsPerPage: number) => { items: Array<Object>, totalCount: number }`
+
 If Array, defaults `totalCount` to the length of the array, and page values are sliced from the Array. If a function, it is called with the current page as an argument and expects an array of items to be returned.
 
 ### `itemsPerPage?: number`
+
 The total amount of items to render at a time. ( After all the filtering ). **Default:** `10`.
 
+### `page?: number`
+
+Optionally pass your own page in to make the pagination component controlled from props.
+
 ### `onPageChange?: (page: number) => void`
+
 Function to call after the new page has been set when the user changes the page
 
 ### `watchList?: Array<any>`
+
 Array of data points that, when changed, causes the pagination to update. This is helpful when the `items` prop is a function and you want `items` to be called to get the most up-to-date list.
 
 ### `resetParams?: Array<any>`
+
 Array of data points that, when changed, causes pagination to reset the current page to 1.
 
 ### `defaultPage?: number`
+
 The starting page to use when the component mounts. **Default:** `1`.

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -21,6 +21,7 @@ export const usePagination = () => useContext(PaginationContext);
  */
 const Pagination = ({
   items: theItems,
+  page: propsCurrentPage,
   itemsPerPage,
   onPageChange,
   children,
@@ -29,7 +30,7 @@ const Pagination = ({
   defaultPage,
 }) => {
   const ref = React.useRef();
-  const [currentPage, setPage] = useState(defaultPage);
+  const [stateCurrentPage, setPage] = useState(defaultPage);
   const [doFocusRefOnPageChange, setDoFocusRefOnPageChange] = useState(false);
   const [pageData, setPageData] = useState({
     total: theItems != null && !isFunction(theItems) ? theItems.totalCount : 0,
@@ -40,6 +41,8 @@ const Pagination = ({
     upper: 0,
     hasMore: false,
   });
+
+  const currentPage = propsCurrentPage || stateCurrentPage;
 
   // create an abort controller for fetch to be able to cancel it
 
@@ -102,7 +105,11 @@ const Pagination = ({
   const updatePage = page => {
     if (page !== currentPage) {
       toggleLoading(true);
-      setPage(page);
+
+      // If pagination is controlling the state then set the page
+      if (!propsCurrentPage) {
+        setPage(page);
+      }
 
       if (onPageChange) {
         onPageChange(page);
@@ -154,6 +161,7 @@ Pagination.propTypes = {
   watchList: PropTypes.array,
   resetParams: PropTypes.array,
   defaultPage: PropTypes.number,
+  page: PropTypes.number,
 };
 
 Pagination.defaultProps = {

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -454,4 +454,57 @@ describe('Pagination', () => {
       })
     );
   });
+
+  test('show correct page when given page from props', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+    ];
+
+    const Component = () => {
+      const [page, setPage] = useState(2);
+
+      return (
+        <Pagination
+          items={items}
+          itemsPerPage={1}
+          page={page}
+          onPageChange={newPage => setPage(newPage)}
+        >
+          <PaginationJson />
+          <PaginationControls directionLinks />
+        </Pagination>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    let paginationCon = await waitForElement(() =>
+      getByTestId('pagination-con')
+    );
+
+    expect(paginationCon).toBeDefined();
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: [items[1]],
+      })
+    );
+
+    // Testing that clicking next still works with a defaultPage
+    fireEvent.click(getByTestId('pagination-control-next-link'));
+
+    // Wait for component to render nothing
+    waitForDomChange(() => getByTestId('pagination-con'));
+
+    // Get the component now with the new page data
+    paginationCon = await waitForElement(() => getByTestId('pagination-con'));
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: [items[2]],
+      })
+    );
+  });
 });

--- a/packages/pagination/types/Pagination.d.ts
+++ b/packages/pagination/types/Pagination.d.ts
@@ -2,6 +2,7 @@ export interface PaginationProps {
   items: object[] | Function;
   itemsPerPage?: number;
   children?: React.ReactNode;
+  page?: number;
   onPageChange?: Function;
   watchList?: any[];
   resetParams?: any[];
@@ -29,6 +30,4 @@ declare function usePagination<T>(): PaginationContext<T>;
 declare const Pagination: React.FunctionComponent<PaginationProps>;
 
 export default Pagination;
-export {
-    usePagination
-}
+export { usePagination };


### PR DESCRIPTION
Allows `Pagination` to be controlled from props rather than uncontrolled through local state.