### PR TITLE
fix(reactstrap-validation-date): if max date parameter is a string wi…

### DIFF
--- a/packages/date/src/utils.js
+++ b/packages/date/src/utils.js
@@ -29,9 +29,18 @@ export const isOutsideRange = (min, max, format = 'MM/DD/YYYY') => day => {
     }
 
     if (typeof max === 'string') {
-      isOutsideMax = day.isAfter(
-        moment(max, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'])
-      );
+      const maxMoment = moment(max, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+      if (!maxMoment._f || maxMoment._f.indexOf('H') === -1) {
+        maxMoment.hour(23);
+        maxMoment.minute(59);
+        maxMoment.second(59);
+      }
+      isOutsideMax = day.isAfter(maxMoment);
     }
 
     if (max.value !== undefined && max.units) {

--- a/packages/date/tests/utils.test.js
+++ b/packages/date/tests/utils.test.js
@@ -41,6 +41,14 @@ describe('utils', () => {
       expect(isOutside).toBe(true);
     });
 
+    it('returns false when date is same as max and max is string with no time parameter', () => {
+      const min = '2019-12-12';
+      const max = '2019-12-13';
+      const day = moment('2019-12-13T12:00:00.000');
+      const isOutside = UTILS.isOutsideRange(min, max)(day);
+      expect(isOutside).toBe(false);
+    });
+
     it('returns false when inside range and limits are of type object', () => {
       const min = { value: 1, units: 'days' };
       const max = { value: 1, units: 'days' };

--- a/packages/reactstrap-validation-date/src/utils.js
+++ b/packages/reactstrap-validation-date/src/utils.js
@@ -29,9 +29,18 @@ export const isOutsideRange = (min, max, format = 'MM/DD/YYYY') => day => {
     }
 
     if (typeof max === 'string') {
-      isOutsideMax = day.isAfter(
-        moment(max, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'])
-      );
+      const maxMoment = moment(max, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+      if (!maxMoment._f || maxMoment._f.indexOf('H') === -1) {
+        maxMoment.hour(23);
+        maxMoment.minute(59);
+        maxMoment.second(59);
+      }
+      isOutsideMax = day.isAfter(maxMoment);
     }
 
     if (max.value !== undefined && max.units) {

--- a/packages/reactstrap-validation-date/tests/utils.test.js
+++ b/packages/reactstrap-validation-date/tests/utils.test.js
@@ -41,6 +41,14 @@ describe('utils', () => {
       expect(isOutside).toBe(true);
     });
 
+    it('returns false when date is same as max and max is string with no time parameter', () => {
+      const min = '2019-12-12';
+      const max = '2019-12-13';
+      const day = moment('2019-12-13T12:00:00.000');
+      const isOutside = UTILS.isOutsideRange(min, max)(day);
+      expect(isOutside).toBe(false);
+    });
+
     it('returns false when inside range and limits are of type object', () => {
       const min = { value: 1, units: 'days' };
       const max = { value: 1, units: 'days' };


### PR DESCRIPTION
When comparing a date value to a specified max, if the max value is a string with no time parameter, then we need to set the time component to EOD. Otherwise, max will be set to midnight, and it may appear that the selected value is outside the allowed range if it has a time component after midnight.