### PR TITLE
Add modalHeaderProps to FeedbackForm

### DIFF
--- a/docs/source/components/feedback/form.md
+++ b/docs/source/components/feedback/form.md
@@ -40,3 +40,6 @@ If `true`, shows an optional comments field below.
 
 ### `staticFields?: object`
 Static (non-user-entered) key/value pairs to be sent in feedback submission.
+
+### `modalHeaderProps?: ModalHeaderProps`
+Props to be spread onto the `<ModalHeader />` rendered inside of the `<FeedbackForm />`. See [ModalHeader](https://github.com/reactstrap/reactstrap/blob/master/src/ModalHeader.js)

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -30,6 +30,7 @@
     "@availity/api-axios": "^5.4.0",
     "@availity/api-core": "^5.4.0",
     "@availity/localstorage-core": "^2.6.1",
+    "@types/reactstrap": "^8.2.0",
     "axios": "^0.18.0",
     "formik": "^2.0.1-rc.12",
     "react": "^16.8.3",

--- a/packages/feedback/src/FeedbackForm.js
+++ b/packages/feedback/src/FeedbackForm.js
@@ -36,6 +36,7 @@ const FeedbackForm = ({
   prompt,
   additionalComments,
   staticFields,
+  modalHeaderProps,
 }) => {
   const [active, setActive] = useState(null);
   const [sent, setSent] = useState(null);
@@ -85,12 +86,17 @@ const FeedbackForm = ({
       aria-live="assertive"
       tabIndex="0"
       className="d-flex justify-content-center"
+      {...modalHeaderProps}
     >
       Thank you for your feedback.
     </ModalHeader>
   ) : (
     <>
-      <ModalHeader aria-live="assertive" id="feedback-form-header">
+      <ModalHeader
+        aria-live="assertive"
+        id="feedback-form-header"
+        {...modalHeaderProps}
+      >
         {prompt || `Tell us what you think about ${name}`}
       </ModalHeader>
       <Form
@@ -213,11 +219,13 @@ FeedbackForm.propTypes = {
   prompt: PropTypes.string,
   additionalComments: PropTypes.bool,
   staticFields: PropTypes.object,
+  modalHeaderProps: PropTypes.shape({ ...ModalHeader.propTypes }),
 };
 
 FeedbackForm.defaultProps = {
   aboutOptions: [],
   additionalComments: false,
+  modalHeaderProps: {},
 };
 
 export default FeedbackForm;

--- a/packages/feedback/typings/FeedbackForm.d.ts
+++ b/packages/feedback/typings/FeedbackForm.d.ts
@@ -8,15 +8,16 @@ type AboutOption = {
     label?: React.ReactNode;
 };
 
-export interface FeedBackFormProps {
+export interface FeedbackFormProps {
     name: string;
     onFeedbackSent?: (feedback?: {[key:string]:any}) => void;
     faceOptions?: FaceOption[];
     aboutOptions?: AboutOption[];
     prompt?: string;
     staticFields?: object;
+    modalHeaderProps?: object;
 }
 
-declare const FeedBackForm: React.FunctionComponent<FeedBackFormProps>;
+declare const FeedbackForm: React.FunctionComponent<FeedbackFormProps>;
 
-export default FeedBackForm;
+export default FeedbackForm;

--- a/packages/feedback/typings/FeedbackForm.d.ts
+++ b/packages/feedback/typings/FeedbackForm.d.ts
@@ -1,3 +1,5 @@
+import { ModalHeaderProps } from 'reactstrap';
+
 type FaceOption = {
     icon?: string;
     description?: string;
@@ -15,7 +17,7 @@ export interface FeedbackFormProps {
     aboutOptions?: AboutOption[];
     prompt?: string;
     staticFields?: object;
-    modalHeaderProps?: object;
+    modalHeaderProps?: ModalHeaderProps;
 }
 
 declare const FeedbackForm: React.FunctionComponent<FeedbackFormProps>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3536,6 +3536,14 @@
     "@types/react" "*"
     popper.js "^1.14.1"
 
+"@types/reactstrap@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@types/reactstrap/-/reactstrap-8.2.0.tgz#f3dd969fcc653c03cb70995bb0d4067aa68eafd6"
+  integrity sha512-QDc1yBpyK2hesWoJzEIv79C/pcvNS2Jbiit0ghyFxu3qus51sPX27f1cxTlZwJQSM/T8ggsvtFTBJZ98PIWJUg==
+  dependencies:
+    "@types/react" "*"
+    popper.js "^1.14.1"
+
 "@types/semver@^6.0.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"


### PR DESCRIPTION
Adds new prop called `modalHeaderProps` to `<FeedbackForm />`, which is spread onto the `<ModalHeader/>` rendered inside of the `<FeedbackForm />`. 

This is especially useful for overriding the default `tag` that is rendered by `<ModalHeader />`, which [defaults to h5](https://github.com/reactstrap/reactstrap/blob/master/src/ModalHeader.js#L19). Depending on the app, this prop may be needed for accessibility: https://www.w3.org/WAI/tutorials/page-structure/headings/
