### PR TITLE
feat(link): default rel prop when linking to external sites

### DIFF
--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -3,32 +3,54 @@ import PropTypes from 'prop-types';
 import { isAbsoluteUrl } from '@availity/resolve-url';
 
 // if absolute or loadApp is disabled, return url. otherwise loadappify the url
-export const getUrl = (url = '', loadApp) => {
-  const absolute = isAbsoluteUrl(url);
+export const getUrl = (url = '', loadApp, absolute) => {
   if (absolute || !loadApp) return url;
 
   return `/public/apps/home/#!/loadApp?appUrl=${encodeURIComponent(url)}`;
 };
 
+// takes href and transforms it so that we can compare hostnames and other properties
+const getLocation = href => {
+  const location = document.createElement('a');
+  location.href = href;
+  return location;
+};
+
 const AvLink = ({
   tag: Tag,
-  href: url,
+  href,
   target,
   children,
   onClick,
   loadApp,
+  rel,
   ...props
-}) => (
-  <Tag
-    href={getUrl(url, loadApp)}
-    target={target}
-    onClick={event => onClick && onClick(event, getUrl(url, loadApp))}
-    data-testid="av-link-tag"
-    {...props}
-  >
-    {children}
-  </Tag>
-);
+}) => {
+  const absolute = isAbsoluteUrl(href);
+  const url = getUrl(href, loadApp, absolute);
+
+  // eslint-disable-next-line no-cond-assign
+  if ((target = '_blank') && !rel && absolute) {
+    const dest = getLocation(url);
+    if (dest.hostname !== window.location.hostname) {
+      // default rel when linking to external destinations for performance and security
+      rel = 'noopener noreferrer';
+    }
+  }
+
+  return (
+    <Tag
+      href={url}
+      target={target}
+      onClick={event => onClick && onClick(event, url)}
+      data-testid="av-link-tag"
+      rel={rel}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+};
 
 AvLink.defaultProps = {
   tag: 'a',
@@ -42,6 +64,7 @@ AvLink.propTypes = {
   href: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   loadApp: PropTypes.bool,
+  rel: PropTypes.string,
 };
 
 export default AvLink;

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -16,6 +16,17 @@ const getLocation = href => {
   return location;
 };
 
+const setRel = (url, target, absolute) => {
+  if (target === '_blank' && absolute) {
+    const dest = getLocation(url);
+    if (dest.hostname !== window.location.hostname) {
+      // default rel when linking to external destinations for performance and security
+      return 'noopener noreferrer';
+    }
+  }
+  return undefined;
+};
+
 const AvLink = ({
   tag: Tag,
   href,
@@ -23,20 +34,10 @@ const AvLink = ({
   children,
   onClick,
   loadApp,
-  rel,
   ...props
 }) => {
   const absolute = isAbsoluteUrl(href);
   const url = getUrl(href, loadApp, absolute);
-
-  // eslint-disable-next-line no-cond-assign
-  if ((target = '_blank') && !rel && absolute) {
-    const dest = getLocation(url);
-    if (dest.hostname !== window.location.hostname) {
-      // default rel when linking to external destinations for performance and security
-      rel = 'noopener noreferrer';
-    }
-  }
 
   return (
     <Tag
@@ -44,7 +45,7 @@ const AvLink = ({
       target={target}
       onClick={event => onClick && onClick(event, url)}
       data-testid="av-link-tag"
-      rel={rel}
+      rel={setRel(url, target, absolute)}
       {...props}
     >
       {children}

--- a/packages/link/test/Link.test.js
+++ b/packages/link/test/Link.test.js
@@ -40,6 +40,41 @@ describe('AvLink', () => {
     expect(tag.getAttribute('href')).toBe(expected);
   });
 
+  test('should default rel prop if none provided when linking to external site', () => {
+    const { getByTestId } = render(
+      <AvLink
+        loadApp={false}
+        href="https://github.com/Availity"
+        target="_blank"
+      >
+        My App
+      </AvLink>
+    );
+
+    const tag = getByTestId('av-link-tag');
+    const expected = 'noopener noreferrer';
+
+    expect(tag.getAttribute('rel')).toBe(expected);
+  });
+
+  test('should respect rel prop if provided when linking to external site', () => {
+    const { getByTestId } = render(
+      <AvLink
+        loadApp={false}
+        href="https://github.com/Availity"
+        target="_blank"
+        rel="nofollow"
+      >
+        My App
+      </AvLink>
+    );
+
+    const tag = getByTestId('av-link-tag');
+    const expected = 'nofollow';
+
+    expect(tag.getAttribute('rel')).toBe(expected);
+  });
+
   test('should call onClick', () => {
     const onClick = jest.fn();
 


### PR DESCRIPTION
Provides `rel` with default value of `noopener noreferrer` when linking to external sites. Based on best practice detailed [here](https://developers.google.com/web/tools/lighthouse/audits/noopener).

This will only apply if `target = "_blank"`, `rel` has no specified value, the URL is `absolute`, `loadApp = false`, and the destination hostname is not the same as our current hostname.

`AvLink` has also been modified so that `getUrl` is only called once, and the `absolute` property of the `href` has been extracted for reuse.