### PR TITLE
fix(upload,form-upload): ensure unique upload ids

### DIFF
--- a/packages/form-upload/Upload.js
+++ b/packages/form-upload/Upload.js
@@ -7,6 +7,7 @@ import Dropzone from 'react-dropzone';
 import Icon from '@availity/icon';
 import { useField, useFormikContext } from 'formik';
 import classNames from 'classnames';
+import uuid from 'uuid/v4';
 
 import FilePickerBtn from './FilePickerBtn';
 import FileList from './FileList';
@@ -69,6 +70,7 @@ const Upload = ({
           maxSize,
           allowedFileNameCharacters: rest.allowedFileNameCharacters,
         });
+        upload.id = `${upload.id}-${uuid()}`;
         upload.start();
         if (rest.onFileUpload) rest.onFileUpload(upload);
         return upload;

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@availity/icon": "^0.7.0",
     "@availity/progress": "^1.2.1",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@availity/form": "^0.5.1",

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -4,6 +4,7 @@ import UploadCore from '@availity/upload-core';
 import { FormFeedback } from 'reactstrap';
 import Dropzone from 'react-dropzone';
 import map from 'lodash.map';
+import uuid from 'uuid/v4';
 import FilePickerBtn from './FilePickerBtn';
 import FileList from './FileList';
 import './styles.scss';
@@ -65,6 +66,7 @@ class Upload extends Component {
           maxSize: this.props.maxSize,
           allowedFileNameCharacters: this.props.allowedFileNameCharacters,
         });
+        upload.id = `${upload.id}-${uuid()}`;
         upload.start();
         if (this.props.onFileUpload) this.props.onFileUpload(upload);
         return upload;

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@availity/progress": "^1.2.1",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@availity/upload-core": "^3.0.4",


### PR DESCRIPTION
For `upload` and `form-upload`, if `multiple` is `true`, and two or more files with same file name are uploaded, `tus-js-client` generates the same `id` for each of them.

This causes a duplicate key error from React:

https://github.com/Availity/availity-react/blob/045295b882214fc4c886ed4874659d21380acd3f/packages/form-upload/FileList.js#L10

It also causes a bug where if the user removes a single file, all files with that name are removed:

https://github.com/Availity/availity-react/blob/045295b882214fc4c886ed4874659d21380acd3f/packages/form-upload/Upload.js#L41

This patch uses `uuid` to append a unique id to each instance of `Upload`.
