### PR TITLE
fix(select,reactstrap-validation-select): fix parameters as props not being used

### DIFF
--- a/packages/reactstrap-validation-select/AvResourceSelect.js
+++ b/packages/reactstrap-validation-select/AvResourceSelect.js
@@ -90,6 +90,11 @@ class AvResourceSelect extends Component {
         params.offset = (page - 1) * this.props.itemsPerPage;
         if (typeof this.props.parameters === 'function') {
           params = this.props.parameters(params);
+        } else {
+          params = {
+            ...params,
+            ...this.props.parameters,
+          };
         }
       }
     } else {

--- a/packages/reactstrap-validation-select/tests/AvResourceSelect.test.js
+++ b/packages/reactstrap-validation-select/tests/AvResourceSelect.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   fireEvent,
   waitForElement,
@@ -6,8 +6,9 @@ import {
   cleanup,
   wait,
 } from '@testing-library/react';
-import { avRegionsApi, avProvidersApi } from '@availity/api-axios';
+import { avRegionsApi, avProvidersApi, avCodesApi } from '@availity/api-axios';
 import { AvForm } from 'availity-reactstrap-validation';
+import { Button } from 'reactstrap';
 
 import { AvResourceSelect } from '..';
 import { AvProviderSelect } from '../resources';
@@ -274,6 +275,64 @@ describe('AvResourceSelect', () => {
     expect(regionsSelect.querySelector('.test__regions__placeholder')).toBe(
       null
     );
+  });
+  it('waits to query until requiredParams are set', async () => {
+    const renderDropdown = ({ parameters = {}, ...props }) => {
+      const Component = () => {
+        const [listParameter, setListParameter] = useState(undefined);
+
+        return (
+          <AvForm>
+            <AvResourceSelect
+              name="test-form-input"
+              parameters={{ ...parameters, list: listParameter }}
+              {...props}
+            />
+            <Button
+              type="button"
+              data-testid="btn-set-list"
+              onClick={() => setListParameter('foo')}
+            >
+              Set List Parameter
+            </Button>
+            <Button type="submit">Submit</Button>
+          </AvForm>
+        );
+      };
+      return render(<Component />);
+    };
+
+    avCodesApi.postGet.mockResolvedValue({
+      data: {
+        codes: [
+          {
+            id: 'code1',
+            value: 'value1',
+          },
+        ],
+      },
+    });
+
+    const { getByTestId } = renderDropdown({
+      resource: avCodesApi,
+      labelKey: 'value',
+      valueKey: 'id',
+      classNamePrefix: 'test__codes',
+      getResult: 'codes',
+      requiredParams: ['list'],
+    });
+
+    await wait(() => {
+      expect(avCodesApi.postGet).not.toHaveBeenCalled();
+    });
+
+    // Set required parameter list
+    fireEvent.click(getByTestId('btn-set-list'));
+
+    // Check that query was fired off after required parameter set
+    await wait(() => {
+      expect(avCodesApi.postGet).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/packages/select/src/ResourceSelect.js
+++ b/packages/select/src/ResourceSelect.js
@@ -124,6 +124,11 @@ const ResourceSelect = ({
         params.offset = (page - 1) * itemsPerPage;
         if (typeof rest.parameters === 'function') {
           params = rest.parameters(params);
+        } else {
+          params = {
+            ...params,
+            ...rest.parameters,
+          };
         }
       }
     } else {
@@ -142,6 +147,7 @@ const ResourceSelect = ({
         requiredSatisfied = rest.requiredParams.every(param => params[param]);
       }
     }
+
     if (rest.isDisabled || !requiredSatisfied) {
       return {
         options: [],


### PR DESCRIPTION
Patches issue introduced with #406 that caused `parameters` passed in through `props` to be swallowed