### PR TITLE
docs: remove unneccessary semicolons following JSX tags

### DIFF
--- a/docs/source/components/authorize.mdx
+++ b/docs/source/components/authorize.mdx
@@ -19,7 +19,7 @@ import Authorize from '@availity/authorize';
 
 <Authorize permissions="1234">
   {/* stuff to render if the user is authorized with permission indicated above */}
-</Authorize>;
+</Authorize>
 ```
 
 ## Props

--- a/docs/source/components/breadcrumbs.mdx
+++ b/docs/source/components/breadcrumbs.mdx
@@ -38,7 +38,7 @@ import { BreadcrumbItem } from 'reactstrap';
       <BreadcrumbItem>Custom Bread Crumb</BreadcrumbItem>
     </Breadcrumbs>
   </div>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/components/favorites/heart.md
+++ b/docs/source/components/favorites/heart.md
@@ -12,7 +12,7 @@ import '@availity/favorites/style.scss';
   <Favorites>
     <FavoriteHeart id="12345" />
   </Favorites>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/components/favorites/index.md
+++ b/docs/source/components/favorites/index.md
@@ -23,5 +23,5 @@ import '@availity/favorites/style.scss';
       </FavoritesProvider>
     )}
   </Favorites>
-</div>;
+</div>
 ```

--- a/docs/source/components/feature.mdx
+++ b/docs/source/components/feature.mdx
@@ -28,7 +28,7 @@ import Feature from '@availity/feature';
   ]}
 >
   {/* stuff to render if the feature indicated above is enabled in the environment */}
-</Feature>;
+</Feature>
 ```
 
 Component which validates the environment's features to determine if children content should be shown.

--- a/docs/source/components/feedback/feedback.md
+++ b/docs/source/components/feedback/feedback.md
@@ -15,7 +15,7 @@ import Feedback from '@availity/feedback';
   >
     Provide Feedback
   </Feedback>
-</div>;
+</div>
 ```
 
 

--- a/docs/source/components/feedback/form.md
+++ b/docs/source/components/feedback/form.md
@@ -11,7 +11,7 @@ import { FeedbackForm } from '@availity/feedback';
 
 <div className="w-100">
   <FeedbackForm name="Payer Space" />
-</div>;
+</div>
 ```
 
 

--- a/docs/source/components/feedback/index.md
+++ b/docs/source/components/feedback/index.md
@@ -22,5 +22,5 @@ import Feedback from '@availity/feedback';
   >
     Provide Feedback
   </Feedback>
-</div>;
+</div>
 ```

--- a/docs/source/components/icon.mdx
+++ b/docs/source/components/icon.mdx
@@ -16,7 +16,7 @@ import Icon from '@availity/icon';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">
   <Icon name="home" size="3x" color="primary" />
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/components/link.mdx
+++ b/docs/source/components/link.mdx
@@ -18,7 +18,7 @@ import AvLink from '@availity/link';
   <AvLink href="/public/apps/my-app" target="newBody">
     My Application
   </AvLink>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/components/page-header.mdx
+++ b/docs/source/components/page-header.mdx
@@ -17,7 +17,7 @@ npx install-peerdeps @availity/page-header --save
 import PageHeader from '@availity/page-header';
 <div className="w-100 d-flex flex-column justify-content-around align-items-start">
   <PageHeader appName="Payer Space" appAbbr="PS" iconColor="blue" feedback />
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/components/pagination/content.md
+++ b/docs/source/components/pagination/content.md
@@ -14,7 +14,7 @@ import { PaginationContent } from '@availity/pagination';
   loadingMessage="loading"
   component={Component}
   itemkey="id"
-/>;
+/>
 ```
 
 ## Props

--- a/docs/source/components/pagination/controls.md
+++ b/docs/source/components/pagination/controls.md
@@ -9,7 +9,7 @@ summary: The controls for the pagination
 import React from 'react';
 import { PaginationControls } from '@availity/pagination';
 
-<PaginationControls directionLinks />;
+<PaginationControls directionLinks />
 ```
 
 ## Props

--- a/docs/source/components/pagination/pagination.md
+++ b/docs/source/components/pagination/pagination.md
@@ -12,7 +12,7 @@ import Pagination from '@availity/pagination';
 // ...
 <Pagination itemsPerPage={25} items={this.state.items}>
   <Pagination.Content component={Component} />
-</Pagination>;
+</Pagination>
 ```
 
 ## Props

--- a/docs/source/components/pagination/resource.md
+++ b/docs/source/components/pagination/resource.md
@@ -13,7 +13,7 @@ import { avOrganizationsApi } from '@availity/api-axios';
 
 <AvResourcePagination resource={avOrganizationsApi} itemsPerPage={25}>
   <PaginationControls />
-</AvResourcePagination>;
+</AvResourcePagination>
 ```
 
 ## Props

--- a/docs/source/components/spaces/agreement.md
+++ b/docs/source/components/spaces/agreement.md
@@ -11,7 +11,7 @@ import Spaces, { SpacesAgreement } from '@availity/spaces';
 
 <Spaces spaceIds={['73162546201441126239486200007187']} clientId="my-client-id">
   <SpacesAgreement markdown />
-</Spaces>;
+</Spaces>
 ```
 
 ## Props

--- a/docs/source/components/spaces/disclaimer.md
+++ b/docs/source/components/spaces/disclaimer.md
@@ -11,7 +11,7 @@ import Spaces, { SpacesDisclaimer } from '@availity/spaces';
 
 <Spaces spaceIds={['73162546201441126239486200007187']} clientId="my-client-id">
   <SpacesDisclaimer markdown styled />
-</Spaces>;
+</Spaces>
 ```
 
 ## Props

--- a/docs/source/components/spaces/ghost-text.md
+++ b/docs/source/components/spaces/ghost-text.md
@@ -11,7 +11,7 @@ import Spaces, { SpacesGhostText } from '@availity/spaces';
 
 <Spaces spaceIds={['73162546201441126239486200007187']} clientId="my-client-id">
   <SpacesGhostText />
-</Spaces>;
+</Spaces>
 ```
 
 ## Props

--- a/docs/source/components/spaces/images.md
+++ b/docs/source/components/spaces/images.md
@@ -22,7 +22,7 @@ import Spaces, {
   <SpacesBillboard payerId="PayerID" />
   <SpacesTile payerId="PayerID" />
   <SpacesImage payerId="PayerID" />
-</Spaces>;
+</Spaces>
 ```
 
 ## Props

--- a/docs/source/components/spaces/use-spaces-context.md
+++ b/docs/source/components/spaces/use-spaces-context.md
@@ -12,6 +12,6 @@ import { useSpacesContext } from '@availity/spaces';
 
 const SpacesComponent = () => {
   const { spaces, loading, error } = useSpacesContext();
-}
+};
 ```
 

--- a/docs/source/components/typography/agreement.md
+++ b/docs/source/components/typography/agreement.md
@@ -16,5 +16,5 @@ import { Agreement } from '@availity/typography';
     cupiditatereprehenderit quibusdam nam eveniet voluptatem quis soluta
     quamdelectus consequatur qui incidunt voluptatem consequuntur
   </p>
-</Agreement>;
+</Agreement>
 ```

--- a/docs/source/components/typography/disclaimer.md
+++ b/docs/source/components/typography/disclaimer.md
@@ -15,7 +15,7 @@ import { Disclaimer } from '@availity/typography';
   necessary legal authority to bind this organization. I further attest and
   certify my organization&apos;s designation as a Covered Entity under HIPAA, as
   more fully described in 45 CFR § 160.103.
-</Disclaimer>;
+</Disclaimer>
 ```
 
 ### Props

--- a/docs/source/form/components/feedback.md
+++ b/docs/source/form/components/feedback.md
@@ -25,7 +25,7 @@ import { Form, Input, Feedback as FormFeedback } from '@availity/form';
   <Button type="submit" color="primary">
     Submit
   </Button>
-</Form>;
+</Form>
 ```
 
 ## Props

--- a/docs/source/form/components/input.md
+++ b/docs/source/form/components/input.md
@@ -23,7 +23,7 @@ import { Button } from 'reacstrap';
   <Button type="submit" className="ml-1" color="primary">
     Submit
   </Button>
-</Form>;
+</Form>
 ```
 
 ## Props

--- a/docs/source/form/date/components/date-field.md
+++ b/docs/source/form/date/components/date-field.md
@@ -33,7 +33,7 @@ import '@availity/yup/moment';
       Submit
     </Button>
   </Form>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/form/date/components/date-range-field.md
+++ b/docs/source/form/date/components/date-range-field.md
@@ -52,7 +52,7 @@ import moment from 'moment';
       Submit
     </Button>
   </Form>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -51,7 +51,7 @@ import moment from 'moment';
       Submit
     </Button>
   </Form>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/form/date/components/date.md
+++ b/docs/source/form/date/components/date.md
@@ -38,7 +38,7 @@ import moment from 'moment';
       Submit
     </Button>
   </Form>
-</div>;
+</div>
 ```
 
 ## Props

--- a/docs/source/form/migrating.md
+++ b/docs/source/form/migrating.md
@@ -19,7 +19,7 @@ import { AvInput, AvForm } from 'availity-reactstrap-validation';
       },
     }}
   />
-</AvForm>;
+</AvForm>
 // ...
 ```
 
@@ -31,7 +31,7 @@ import { AvInput, AvForm } from 'availity-reactstrap-validation';
 // ...
 <AvForm>
   <AvInput name="myInput" type="text" required />
-</AvForm>;
+</AvForm>
 // ...
 ```
 
@@ -48,7 +48,7 @@ import { Input, Form } from '@availity/form';
   })}
 >
   <Input name="myInput" type="text" />
-</Form>;
+</Form>
 // ...
 ```
 
@@ -90,7 +90,7 @@ import * as yup from 'yup';
       },
     }}
   />
-</AvForm>;
+</AvForm>
 // ...
 ```
 

--- a/docs/source/form/select/components/resource-select.md
+++ b/docs/source/form/select/components/resource-select.md
@@ -32,7 +32,7 @@ import '@availity/yup';
   <Button color="primary" type="submit">
     Submit
   </Button>
-</Form>;
+</Form>
 ```
 
 ## Props

--- a/docs/source/form/select/components/select-field.md
+++ b/docs/source/form/select/components/select-field.md
@@ -37,7 +37,7 @@ import '@availity/yup';
   <Button className="mt-3" color="primary" type="submit">
     Submit
   </Button>
-</Form>;
+</Form>
 ```
 
 ## Props

--- a/docs/source/form/select/components/select.md
+++ b/docs/source/form/select/components/select.md
@@ -35,7 +35,7 @@ import '@availity/yup';
   <Button className="mt-3" color="primary" type="submit">
     Submit
   </Button>
-</Form>;
+</Form>
 ```
 
 ## Props

--- a/docs/source/form/upload/file-picker-btn.md
+++ b/docs/source/form/upload/file-picker-btn.md
@@ -16,7 +16,7 @@ handleFileSelection = event => {
 };
 
 <Form initialValues={{ myFile: undefined }}>
-  <FilePickerBtn name="myFile" onChange={this.handleFileSelection} />;
+  <FilePickerBtn name="myFile" onChange={this.handleFileSelection} />
 </Form>
 ```
 

--- a/docs/source/form/upload/index.md
+++ b/docs/source/form/upload/index.md
@@ -17,6 +17,6 @@ import { Form } from '@availity/form';
 import Upload from '@availity/form-upload';
 
 <Form initialValues={{ myFile: undefined }}>
-  <Upload name="myFile" clientId="a" bucketId="b" customerId="c" />;
+  <Upload name="myFile" clientId="a" bucketId="b" customerId="c" />
 </Form>
 ```

--- a/docs/source/form/upload/upload-progress-bar.md
+++ b/docs/source/form/upload/upload-progress-bar.md
@@ -9,7 +9,7 @@ summary: The raw progress bar to be used when making your own.
 import React from 'react';
 import { UploadProgressBar } from '@availity/form-upload';
 
-<UploadProgressBar upload={uploadInstance} animated />;
+<UploadProgressBar upload={uploadInstance} animated />
 ```
 
 ## Props


### PR DESCRIPTION
docs: remove unnecessary semicolons following JSX tags in code examples, for better user experience

I was using the (very handy) copy-to-clipboard function in the documentation, and noticed that there were extra semicolons in several code examples that required cleaning up when I pasted into my project. I figured, why not save everyone the extra step?

