### PR TITLE
Feat/date polyfills

### DIFF
--- a/packages/date/polyfills/index.js
+++ b/packages/date/polyfills/index.js
@@ -1,0 +1,1 @@
+import './padStart';

--- a/packages/date/polyfills/padStart.js
+++ b/packages/date/polyfills/padStart.js
@@ -1,0 +1,20 @@
+// PolyFill For React Date
+if (!String.prototype.padStart) {
+  // eslint-disable-next-line no-extend-native
+  String.prototype.padStart = function padStart(targetLength, padString) {
+    // eslint-disable-next-line no-bitwise
+    targetLength >>= 0; // truncate if number, or convert non-number to 0;
+    padString = String(typeof padString !== 'undefined' ? padString : ' ');
+    if (this.length >= targetLength) {
+      return String(this);
+      // eslint-disable-next-line no-else-return
+    } else {
+      // eslint-disable-next-line operator-assignment
+      targetLength = targetLength - this.length;
+      if (targetLength > padString.length) {
+        padString += padString.repeat(targetLength / padString.length); // append to original to ensure we are longer than needed
+      }
+      return padString.slice(0, targetLength) + String(this);
+    }
+  };
+}

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -7,6 +7,7 @@ import { SingleDatePicker } from 'react-dates';
 import Icon from '@availity/icon';
 import { InputGroup, Input } from 'reactstrap';
 import moment from 'moment';
+import '../polyfills';
 import '../styles.scss';
 
 import { isOutsideRange, limitPropType } from './utils';

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -8,6 +8,7 @@ import { useField, useFormikContext } from 'formik';
 import get from 'lodash.get';
 import pick from 'lodash.pick';
 import moment from 'moment';
+import '../polyfills';
 
 import { isOutsideRange, limitPropType, isSameDay } from './utils';
 

--- a/packages/reactstrap-validation-date/polyfills/index.js
+++ b/packages/reactstrap-validation-date/polyfills/index.js
@@ -1,0 +1,1 @@
+import './padStart';

--- a/packages/reactstrap-validation-date/polyfills/padStart.js
+++ b/packages/reactstrap-validation-date/polyfills/padStart.js
@@ -1,0 +1,20 @@
+// PolyFill For React Date
+if (!String.prototype.padStart) {
+  // eslint-disable-next-line no-extend-native
+  String.prototype.padStart = function padStart(targetLength, padString) {
+    // eslint-disable-next-line no-bitwise
+    targetLength >>= 0; // truncate if number, or convert non-number to 0;
+    padString = String(typeof padString !== 'undefined' ? padString : ' ');
+    if (this.length >= targetLength) {
+      return String(this);
+      // eslint-disable-next-line no-else-return
+    } else {
+      // eslint-disable-next-line operator-assignment
+      targetLength = targetLength - this.length;
+      if (targetLength > padString.length) {
+        padString += padString.repeat(targetLength / padString.length); // append to original to ensure we are longer than needed
+      }
+      return padString.slice(0, targetLength) + String(this);
+    }
+  };
+}

--- a/packages/reactstrap-validation-date/src/AvDate.js
+++ b/packages/reactstrap-validation-date/src/AvDate.js
@@ -6,6 +6,7 @@ import { InputGroup } from 'reactstrap';
 import classNames from 'classnames';
 import moment from 'moment';
 import 'react-dates/initialize';
+import '../polyfills';
 
 import {
   inputType,

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -13,6 +13,7 @@ import 'react-dates/initialize';
 import classNames from 'classnames';
 import Icon from '@availity/icon';
 import { isOutsideRange, limitPropType, isSameDay } from './utils';
+import '../polyfills';
 
 let count = 0;
 


### PR DESCRIPTION
Attempts to fix some issues in IE with `padStart` not being defined.

This is probably the start of a long list of polyfills and then we can look at getting something together to patch workflow all together.

fixes #433 

Canary version is published under `@availity/date@canary` and `@availity/reactstrap-validation-date@canary`