### PR TITLE
fix(form): fixes incorrect PropType for children on Form

### DIFF
--- a/packages/form/src/Form.js
+++ b/packages/form/src/Form.js
@@ -25,9 +25,11 @@ const Form = ({
     validationSchema={validationSchema}
     validate={validate}
   >
-    {props => <RsForm data-testid="form-container" tag={FForm} {...rest}>
-      {typeof children === 'function' ? children(props) : children}
-    </RsForm>}
+    {props => (
+      <RsForm data-testid="form-container" tag={FForm} {...rest}>
+        {typeof children === 'function' ? children(props) : children}
+      </RsForm>
+    )}
   </Formik>
 );
 
@@ -41,7 +43,7 @@ Form.propTypes = {
   initialTouched: PropTypes.object,
   validationSchema: PropTypes.object,
   validate: PropTypes.func,
-  children: PropTypes.oneOf([PropTypes.func, PropTypes.node]),
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 Form.defaultProps = {


### PR DESCRIPTION
PropTypes.oneOf() is used for allowed literal values, so an invalid prop warning is thrown. PropTypes.oneOfType() should be used for allowed types