### PR TITLE
refactor(form): added group class and inline override

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,14 @@ module.exports = api => {
   api.cache(true);
 
   return {
-    presets: ['babel-preset-react-app'],
+    presets: [
+      [
+        'babel-preset-react-app',
+        {
+          absoluteRuntime: false,
+          useESModules: false,
+        },
+      ],
+    ],
   };
 };

--- a/docs/source/form/components/checkbox-group.md
+++ b/docs/source/form/components/checkbox-group.md
@@ -5,7 +5,13 @@ title: <CheckboxGroup />
 ## Props
 
 ### `name: string`
+
 Name of the checkbox group. Should match name given in `initialValues`/`validationSchema`.
 
 ### `label?: string`
-Lbael for the group or checkboxes.
+
+Label for the group or checkboxes.
+
+### `groupClassName?: string`
+
+Class name to apply to the form control.

--- a/docs/source/form/components/checkbox.md
+++ b/docs/source/form/components/checkbox.md
@@ -20,20 +20,30 @@ summary: Inputs of type checkbox. Checkboxes should be wrapped in a CheckboxGrou
     <Checkbox label="Check Two" value="dos" />
     <Checkbox label="Check Three" value="tres" />
   </CheckboxGroup>
-  <Button type="submit" color="primary">Submit</Button>
+  <Button type="submit" color="primary">
+    Submit
+  </Button>
 </Form>
 ```
 
 ## Props
 
 ### `id?: string`
+
 Should match `<CheckboxGroup />` name for validation.
 
 ### `label?: ReactNode`
+
 Label for the checkbox.
 
 ### `value?: string`
+
 Value of the checkbox.
 
 ### `disabled?: boolean`
+
 Disables the checkbox.
+
+### `inline?: boolean`
+
+Will render the checkbox inline with other checkboxes. **Default:** true.

--- a/docs/source/form/components/radio-group.md
+++ b/docs/source/form/components/radio-group.md
@@ -5,7 +5,13 @@ title: <RadioGroup />
 ## Props
 
 ### `name: string`
+
 Name of the radio group. Should match name given in `initialValues`/`validationSchema`.
 
 ### `label?: string`
+
 Lbael for the group or radio buttons.
+
+### `groupClassName?: string`
+
+Class name to apply to the form control.

--- a/docs/source/form/components/radio.md
+++ b/docs/source/form/components/radio.md
@@ -27,13 +27,21 @@ summary: Inputs of type radio. Radios should be wrapped in a RadioGroup.
 ## Props
 
 ### `id?: string`
+
 Should match `<RadioGroup />` name for validation.
 
 ### `label?: ReactNode`
+
 Label for the checkbox.
 
 ### `value?: string`
+
 Value of the checkbox.
 
 ### `disabled?: boolean`
+
 Disables the checkbox.
+
+### `inline?: boolean`
+
+Will render the checkbox inline with other checkboxes.

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -11,6 +11,7 @@ const Checkbox = ({
   value: checkValue,
   className,
   id,
+  inline,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -24,7 +25,12 @@ const Checkbox = ({
   );
 
   return (
-    <FormGroup for={inputId} check inline disabled={attributes.disabled}>
+    <FormGroup
+      for={inputId}
+      check
+      inline={inline}
+      disabled={attributes.disabled}
+    >
       <Input
         id={inputId}
         name={inputId}
@@ -50,8 +56,13 @@ Checkbox.propTypes = {
     PropTypes.bool,
     PropTypes.object,
   ]),
+  inline: PropTypes.bool,
   disabled: PropTypes.bool,
   className: PropTypes.string,
+};
+
+Checkbox.defaultProps = {
+  inline: true,
 };
 
 export default Checkbox;

--- a/packages/form/src/CheckboxGroup.js
+++ b/packages/form/src/CheckboxGroup.js
@@ -38,12 +38,14 @@ const CheckboxGroup = ({
   name,
   children,
   onChange: groupOnChange,
+  groupClassName,
   label,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
 
   const classes = classNames(
+    groupClassName,
     'form-control border-0 p-0 h-auto',
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.touched && metadata.error && 'is-invalid'
@@ -71,6 +73,7 @@ CheckboxGroup.propTypes = {
   children: PropTypes.node,
   label: PropTypes.node,
   onChange: PropTypes.func,
+  groupClassName: PropTypes.string,
 };
 
 export default CheckboxGroup;

--- a/packages/form/src/RadioGroup.js
+++ b/packages/form/src/RadioGroup.js
@@ -28,12 +28,14 @@ const RadioGroup = ({
   children,
   label,
   onChange: groupOnChange,
+  groupClassName,
   inline = false,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
 
   const classes = classNames(
+    groupClassName,
     'form-control border-0 p-0 h-auto',
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.touched && metadata.error && 'is-invalid'
@@ -62,6 +64,7 @@ RadioGroup.propTypes = {
   label: PropTypes.node,
   onChange: PropTypes.func,
   inline: PropTypes.bool,
+  groupClassName: PropTypes.string,
 };
 
 export default RadioGroup;

--- a/packages/form/tests/Checkbox.test.js
+++ b/packages/form/tests/Checkbox.test.js
@@ -78,6 +78,25 @@ describe('Checkbox', () => {
     getByText('Check One');
   });
 
+  test('renders without inline applied', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+      >
+        <CheckboxGroup name="hello" label="Checkbox Group">
+          <Checkbox label="Check One" value="uno" inline={false} />
+        </CheckboxGroup>
+      </Form>
+    );
+
+    const checkbox = getByText('Check One').parentElement;
+
+    expect(checkbox.className).not.toContain('form-check-inline');
+  });
+
   test('should generate uuid even when id is not added', () => {
     const { container } = render(
       <Form onSubmit={() => {}}>

--- a/packages/form/tests/CheckboxGroup.test.js
+++ b/packages/form/tests/CheckboxGroup.test.js
@@ -7,6 +7,34 @@ import { Form, Checkbox, CheckboxGroup } from '..';
 afterEach(cleanup);
 
 describe('CheckboxGroup', () => {
+  test('renders with group class name', async () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: [],
+        }}
+        onSubmit={() => {}}
+        // eslint-disable-next-line no-undef
+        validationSchema={yup.object().shape({
+          hello: yup.array().required('At least one checkbox is required'),
+        })}
+      >
+        <CheckboxGroup
+          name="hello"
+          label="Checkbox Group"
+          groupClassName="some-group"
+        >
+          <Checkbox label="Chcek One" value="uno" />
+        </CheckboxGroup>
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const formControl = getByTestId('check-items-hello');
+
+    expect(formControl.className).toContain('some-group');
+  });
+
   test('renders danger className when invalid form', async () => {
     const { getByText, getByTestId } = render(
       <Form

--- a/packages/form/tests/RadioGroup.test.js
+++ b/packages/form/tests/RadioGroup.test.js
@@ -7,6 +7,32 @@ import { Form, Radio, RadioGroup } from '..';
 afterEach(cleanup);
 
 describe('RadioGroup', () => {
+  test('renders with group class name', async () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+        validationSchema={yup.object().shape({
+          hello: yup.string().required('This field is required'),
+        })}
+      >
+        <RadioGroup
+          name="hello"
+          label="Radio Group"
+          groupClassName="some-group"
+        >
+          <Radio label="Radio One" value="uno" />
+        </RadioGroup>
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const formControl = getByTestId('radio-items-hello');
+    expect(formControl.className).toContain('some-group');
+  });
+
   test('renders danger className when invalid form', async () => {
     const { getByText, getByTestId } = render(
       <Form

--- a/packages/form/typings/Checkbox.d.ts
+++ b/packages/form/typings/Checkbox.d.ts
@@ -4,6 +4,7 @@ import { InputProps } from './Input';
 interface CheckboxProps extends InputProps {
   label?: React.ReactNode;
   value?: string | boolean | object;
+  inline?: boolean;
 }
 
 declare class Checkbox extends React.Component<CheckboxProps> {}

--- a/packages/form/typings/CheckboxGroup.d.ts
+++ b/packages/form/typings/CheckboxGroup.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { FormGroupProps } from './FormGroup';
 
-
 interface CheckboxGroupProps extends FormGroupProps {
-    name: string;
-    label?: React.ReactNode;
-    onChange?: (value: any) => void;
+  name: string;
+  label?: React.ReactNode;
+  groupClassName?: string;
+  onChange?: (value: any) => void;
 }
 
 declare class CheckboxGroup extends React.Component<CheckboxGroupProps> {}

--- a/packages/form/typings/RadioGroup.d.ts
+++ b/packages/form/typings/RadioGroup.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 interface RadioGroupProps extends React.HTMLAttributes<HTMLFormElement> {
   name: string;
   label?: React.ReactNode;
+  groupClassName?: string;
   onChange?: (value: any) => void;
   inline?: boolean | false;
 }


### PR DESCRIPTION
- Fixes babel config for jest unit tests in vscode
- Adds `groupClassName` for `CheckboxGroup` and `RadioGroup`
- Adds ability to overwrite `inline` prop for `Checkbox`