### PR TITLE
refactor(authorize): set currentRegion as object instead of just curr…

### DIFF
--- a/packages/authorize/tests/useAuthorize.test.js
+++ b/packages/authorize/tests/useAuthorize.test.js
@@ -39,7 +39,7 @@ const RegionComponent = ({ permissions, ...options }) => {
   }
 
   return authorized ? (
-    <span data-testid="component-region">{currentRegion}</span>
+    <span data-testid="component-region">{currentRegion.value}</span>
   ) : (
     <span data-testid="component-content">
       You do not have permission to see this
@@ -321,7 +321,7 @@ describe('useAuthorize', () => {
     await wait(() => {
       expect(avUserPermissionsApi.getPermissions).toHaveBeenCalled();
       expect(avRegionsApi.getCurrentRegion).toHaveBeenCalled();
-      expect(getByText('WA')).toBeDefined();
+      expect(getByText('Washington')).toBeDefined();
     });
   });
 

--- a/packages/authorize/useAuthorize.js
+++ b/packages/authorize/useAuthorize.js
@@ -12,14 +12,13 @@ export default (
   const getRegion = async () => {
     if (region === true) {
       const resp = await avRegionsApi.getCurrentRegion();
-      return (
-        (resp &&
-          resp.data &&
-          resp.data.regions &&
-          resp.data.regions[0] &&
-          resp.data.regions[0].id) ||
-        undefined
-      );
+      const currentRegion =
+        (resp && resp.data && resp.data.regions && resp.data.regions[0]) ||
+        undefined;
+
+      setCurrentRegion(currentRegion);
+
+      return (currentRegion && currentRegion.id) || undefined;
     }
     if (region) {
       return region;
@@ -80,10 +79,11 @@ export default (
       ? permissions
       : [permissions];
     const permissionsList = [].concat(...permissionsSets);
-    const currentRegion = await getRegion();
-    setCurrentRegion(currentRegion);
     const newPermissions = (
-      await avUserPermissionsApi.getPermissions(permissionsList, currentRegion)
+      await avUserPermissionsApi.getPermissions(
+        permissionsList,
+        await getRegion()
+      )
     ).reduce((prev, cur) => {
       prev[cur.id] = cur;
       return prev;


### PR DESCRIPTION
…entRegion.id

Gives users more flexibility instead of just returning an abbreviation. 