### PR TITLE
Fix upload drop rejection error messages not displaying

### DIFF
--- a/docs/source/form/upload/upload.md
+++ b/docs/source/form/upload/upload.md
@@ -70,7 +70,7 @@ Indicates that the user will be allowed to select multiple files when selecting 
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).
 
-### `getDropRejectionMessage?: (errorCode: String, file: File) => String`
+### `getDropRejectionMessage?: (errors: Array<FileError>, file: File) => String`
 
 Override the default error message for files rejected when `showFileDrop` is `true`.
 

--- a/docs/source/form/upload/upload.md
+++ b/docs/source/form/upload/upload.md
@@ -66,9 +66,13 @@ The maximum number of files allowed to be uploaded. `0` (or a falsey value) mean
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt. **Default:** `true`.
 
-### `showFileDropdown?: boolean`
+### `showFileDrop?: boolean`
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).
+
+### `getDropRejectionMessage?: (errorCode: String, file: File) => String`
+
+Override the default error message for files rejected when `showFileDrop` is `true`.
 
 ## Example
 

--- a/packages/form-upload/Upload.d.ts
+++ b/packages/form-upload/Upload.d.ts
@@ -1,3 +1,5 @@
+import { FileError } from 'react-dropzone/typings/react-dropzone';
+
 export interface UploadProps {
     btnText?: React.ReactType;
     bucketId: string;
@@ -13,7 +15,7 @@ export interface UploadProps {
     children?: Function;
     name?: string;
     showFileDrop?: boolean;
-    getDropRejectionMessage?: ((errorCode: string, file: File) => string);
+    getDropRejectionMessage?: ((errors: FileError[], file: File) => string);
 }
 
 declare const Upload: React.ComponentType<UploadProps>;

--- a/packages/form-upload/Upload.d.ts
+++ b/packages/form-upload/Upload.d.ts
@@ -13,6 +13,7 @@ export interface UploadProps {
     children?: Function;
     name?: string;
     showFileDrop?: boolean;
+    getDropRejectionMessage?: ((errorCode: string, file: File) => string);
 }
 
 declare const Upload: React.ComponentType<UploadProps>;

--- a/packages/form-upload/Upload.js
+++ b/packages/form-upload/Upload.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import UploadCore from '@availity/upload-core';
 import { Input, InputGroup } from 'reactstrap';
 import { FormGroup, Feedback } from '@availity/form';
-import Dropzone from '@twarner/react-dropzone';
+import Dropzone from 'react-dropzone';
 import Icon from '@availity/icon';
 import { useField, useFormikContext } from 'formik';
 import classNames from 'classnames';
@@ -87,22 +87,11 @@ const Upload = ({
     setFiles(event.target.files);
   };
 
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  const getDropRejectionMessage = code => {
-    if (code === 'file-too-large') return 'File is too large';
-    if (code === 'file-too-small') return 'File is too small';
-    if (code === 'file-invalid-type') return 'File is an invalid type';
-    if (code === 'file-excessive')
-      return 'File exceeds maximum number of files';
-
-    return 'File was rejected';
-  };
-
-  const onDrop = (acceptedFiles, rejectedFiles, event, rejectReasons) => {
-    const rejectedFilesToDrop = rejectReasons.map(({ file, code }) => {
+  const onDrop = (acceptedFiles, fileRejections) => {
+    const rejectedFilesToDrop = fileRejections.map(({ file, errors }) => {
       const dropRejectionMessage = rest.getDropRejectionMessage
-        ? rest.getDropRejectionMessage(code, file)
-        : getDropRejectionMessage(code);
+        ? rest.getDropRejectionMessage(errors, file)
+        : errors.map(error => error.message).join(', ');
 
       file.dropRejectionMessage = dropRejectionMessage;
       return file;

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -27,6 +27,7 @@
     "formik": "^2.0.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "react-dropzone": "^11.0.0",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },
@@ -42,7 +43,7 @@
     "formik": "2.1.4",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "react-dropzone": "^11.0.1",
+    "react-dropzone": "^11.0.0",
     "reactstrap": "^8.0.0",
     "tus-js-client": "^1.7.1"
   }

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -24,7 +24,6 @@
   "peerDependencies": {
     "@availity/form": "^0.4.9",
     "@availity/upload-core": "^3.0.4",
-    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "formik": "^2.0.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
@@ -40,10 +39,10 @@
   "devDependencies": {
     "@availity/form": "^0.5.8",
     "@availity/upload-core": "^3.0.4",
-    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "formik": "2.1.4",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "react-dropzone": "^11.0.1",
     "reactstrap": "^8.0.0",
     "tus-js-client": "^1.7.1"
   }

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -24,10 +24,10 @@
   "peerDependencies": {
     "@availity/form": "^0.4.9",
     "@availity/upload-core": "^3.0.4",
+    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "formik": "^2.0.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-dropzone": "^10.0.0 ||^9.0.0 ||^8.0.0 ||^7.0.1",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },
@@ -40,10 +40,10 @@
   "devDependencies": {
     "@availity/form": "^0.5.8",
     "@availity/upload-core": "^3.0.4",
+    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "formik": "2.1.4",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "react-dropzone": "^10.1.5",
     "reactstrap": "^8.0.0",
     "tus-js-client": "^1.7.1"
   }

--- a/packages/form-upload/tests/Upload.test.js
+++ b/packages/form-upload/tests/Upload.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, wait } from '@testing-library/react';
 import { Form } from '@availity/form';
 import Upload from '..';
 
@@ -123,5 +123,69 @@ describe('Upload', () => {
     fireEvent.drop(inputNode, fileEvent);
 
     expect(inputNode.files.length).toBe(1);
+  });
+
+  test('uses default drop rejection message', async () => {
+    const { getByTestId, getByText } = renderUpload(
+      { initialValues: { upload: null } },
+      {
+        name: 'upload',
+        clientId: 'a',
+        bucketId: 'b',
+        customerId: 'c',
+        showFileDrop: true,
+        maxSize: 10,
+      }
+    );
+
+    const file = new Buffer.from('hello world'.split('')); // eslint-disable-line new-cap
+    file.name = 'fileName.png';
+    file.size = 11;
+
+    const inputNode = getByTestId('file-picker');
+    const fileEvent = { target: { files: [file] } };
+
+    fireEvent.drop(inputNode, fileEvent);
+
+    expect(inputNode.files.length).toBe(1);
+    await wait(() => {
+      expect(getByText('File is too large')).toBeDefined();
+    });
+  });
+
+  test('uses custom drop rejection message', async () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const getDropRejectionMessage = code => {
+      if (code === 'file-too-large') {
+        return 'my custom error message';
+      }
+      return 'this file is no good';
+    };
+
+    const { getByTestId, getByText } = renderUpload(
+      { initialValues: { upload: null } },
+      {
+        name: 'upload',
+        clientId: 'a',
+        bucketId: 'b',
+        customerId: 'c',
+        showFileDrop: true,
+        maxSize: 10,
+        getDropRejectionMessage,
+      }
+    );
+    const file = new Buffer.from('hello world'.split('')); // eslint-disable-line new-cap
+    file.name = 'fileName.png';
+    file.size = 11;
+
+    const inputNode = getByTestId('file-picker');
+    const fileEvent = { target: { files: [file] } };
+
+    fireEvent.drop(inputNode, fileEvent);
+
+    expect(inputNode.files.length).toBe(1);
+    await wait(() => {
+      expect(getByText('my custom error message')).toBeDefined();
+    });
   });
 });

--- a/packages/form-upload/tests/Upload.test.js
+++ b/packages/form-upload/tests/Upload.test.js
@@ -149,17 +149,22 @@ describe('Upload', () => {
 
     expect(inputNode.files.length).toBe(1);
     await wait(() => {
-      expect(getByText('File is too large')).toBeDefined();
+      expect(getByText('File is larger than 10 bytes')).toBeDefined();
     });
   });
 
   test('uses custom drop rejection message', async () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
-    const getDropRejectionMessage = code => {
-      if (code === 'file-too-large') {
-        return 'my custom error message';
-      }
-      return 'this file is no good';
+    const getDropRejectionMessage = errors => {
+      let msg = '';
+      errors.forEach(error => {
+        if (error.code === 'file-too-large') {
+          msg += 'my custom error message';
+        } else {
+          msg += 'this file is no good';
+        }
+      });
+      return msg;
     };
 
     const { getByTestId, getByText } = renderUpload(

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -71,7 +71,7 @@ Indicates that the user will be allowed to select multiple files when selecting 
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).
 
-### `getDropRejectionMessage?: (errorCode: String, file: File) => String`
+### `getDropRejectionMessage?: (errors: Array<FileError>, file: File) => String`
 
 Override the default error message for files rejected when `showFileDrop` is `true`.
 

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -67,9 +67,13 @@ The maximum number of files allowed to be uploaded. `0` (or a falsey value) mean
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt. **Default:** `true`.
 
-### `showFileDropdown?: boolean`
+### `showFileDrop?: boolean`
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).
+
+### `getDropRejectionMessage?: (errorCode: String, file: File) => String`
+
+Override the default error message for files rejected when `showFileDrop` is `true`.
 
 ### Example
 

--- a/packages/upload/Upload.d.ts
+++ b/packages/upload/Upload.d.ts
@@ -1,3 +1,5 @@
+import { FileError } from 'react-dropzone/typings/react-dropzone';
+
 export interface UploadProps {
     btnText?: React.ReactType;
     bucketId: string;
@@ -13,7 +15,7 @@ export interface UploadProps {
     children?: Function;
     name?: string;
     showFileDrop?: boolean;
-    getDropRejectionMessage?: ((errorCode: string, file: File) => string);
+    getDropRejectionMessage?: ((errors: FileError[], file: File) => string);
 }
 
 declare const Upload: React.ComponentType<UploadProps>;

--- a/packages/upload/Upload.d.ts
+++ b/packages/upload/Upload.d.ts
@@ -13,6 +13,7 @@ export interface UploadProps {
     children?: Function;
     name?: string;
     showFileDrop?: boolean;
+    getDropRejectionMessage?: ((errorCode: string, file: File) => string);
 }
 
 declare const Upload: React.ComponentType<UploadProps>;

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -1,9 +1,7 @@
 import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import UploadCore from '@availity/upload-core';
-import { FormFeedback } from 'reactstrap';
-import Dropzone from 'react-dropzone';
-import map from 'lodash.map';
+import Dropzone from '@twarner/react-dropzone';
 import uuid from 'uuid/v4';
 import FilePickerBtn from './FilePickerBtn';
 import FileList from './FileList';
@@ -24,10 +22,7 @@ class Upload extends Component {
 
   files = [];
 
-  error = null;
-
   removeFile = fileId => {
-    this.error = null;
     this.setState(({ files }) => {
       const newFiles = files.filter(file => file.id !== fileId);
       if (newFiles.length !== files.length) {
@@ -68,12 +63,15 @@ class Upload extends Component {
           allowedFileNameCharacters: this.props.allowedFileNameCharacters,
         });
         upload.id = `${upload.id}-${uuid()}`;
-        upload.start();
+        if (file.dropRejectionMessage) {
+          upload.errorMessage = file.dropRejectionMessage;
+        } else {
+          upload.start();
+        }
         if (this.props.onFileUpload) this.props.onFileUpload(upload);
         return upload;
       })
     );
-    this.error = null;
     this.setState({ files: this.files });
   };
 
@@ -81,19 +79,31 @@ class Upload extends Component {
     this.setFiles(event.target.files);
   };
 
-  onDrop = (acceptedFiles, rejectedFiles) => {
-    if (rejectedFiles && rejectedFiles.length > 0) {
-      const fileNames = map(rejectedFiles, 'name');
-      this.error = `Could not attach ${fileNames.slice().join(', ')}`;
-    }
+  getDropRejectionMessage = code => {
+    if (code === 'file-too-large') return 'File is too large';
+    if (code === 'file-too-small') return 'File is too small';
+    if (code === 'file-invalid-type') return 'File is an invalid type';
+    if (code === 'file-excessive')
+      return 'File exceeds maximum number of files';
 
-    this.setFiles(acceptedFiles);
+    return 'File was rejected';
+  };
+
+  onDrop = (acceptedFiles, rejectedFiles, event, rejectReasons) => {
+    const rejectedFilesToDrop = rejectReasons.map(({ file, code }) => {
+      const dropRejectionMessage = this.props.getDropRejectionMessage
+        ? this.props.getDropRejectionMessage(code, file)
+        : this.getDropRejectionMessage(code);
+
+      file.dropRejectionMessage = dropRejectionMessage;
+      return file;
+    });
+    this.setFiles([...acceptedFiles, ...rejectedFilesToDrop]);
   };
 
   reset = () => {
     this.files = [];
     this.setState({ files: [] });
-    this.error = null;
   };
 
   componentDidMount() {
@@ -167,6 +177,7 @@ class Upload extends Component {
               maxSize={maxSize}
               className="file-drop"
               activeClassName="file-drop-active"
+              accept={allowedFileTypes}
             >
               {({ getRootProps, getInputProps }) => (
                 <section>
@@ -180,9 +191,6 @@ class Upload extends Component {
                 </section>
               )}
             </Dropzone>
-            <FormFeedback valid={!this.error} className="d-block">
-              {this.error}
-            </FormFeedback>
           </div>
         );
       } else {
@@ -227,6 +235,7 @@ Upload.propTypes = {
   children: PropTypes.func,
   name: PropTypes.string,
   showFileDrop: PropTypes.bool,
+  getDropRejectionMessage: PropTypes.func,
 };
 
 Upload.defaultProps = {

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import UploadCore from '@availity/upload-core';
-import Dropzone from '@twarner/react-dropzone';
+import Dropzone from 'react-dropzone';
 import uuid from 'uuid/v4';
 import FilePickerBtn from './FilePickerBtn';
 import FileList from './FileList';
@@ -79,21 +79,11 @@ class Upload extends Component {
     this.setFiles(event.target.files);
   };
 
-  getDropRejectionMessage = code => {
-    if (code === 'file-too-large') return 'File is too large';
-    if (code === 'file-too-small') return 'File is too small';
-    if (code === 'file-invalid-type') return 'File is an invalid type';
-    if (code === 'file-excessive')
-      return 'File exceeds maximum number of files';
-
-    return 'File was rejected';
-  };
-
-  onDrop = (acceptedFiles, rejectedFiles, event, rejectReasons) => {
-    const rejectedFilesToDrop = rejectReasons.map(({ file, code }) => {
+  onDrop = (acceptedFiles, fileRejections) => {
+    const rejectedFilesToDrop = fileRejections.map(({ file, errors }) => {
       const dropRejectionMessage = this.props.getDropRejectionMessage
-        ? this.props.getDropRejectionMessage(code, file)
-        : this.getDropRejectionMessage(code);
+        ? this.props.getDropRejectionMessage(errors, file)
+        : errors.map(error => error.message).join(', ');
 
       file.dropRejectionMessage = dropRejectionMessage;
       return file;

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -23,7 +23,6 @@
   },
   "peerDependencies": {
     "@availity/upload-core": "^3.0.4",
-    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
@@ -39,7 +38,7 @@
     "lodash.map": "^4.6.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "@twarner/react-dropzone": "^0.0.0-pr-938",
+    "react-dropzone": "^11.0.1",
     "reactstrap": "^8.0.0",
     "tus-js-client": "^1.7.1"
   }

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -23,10 +23,9 @@
   },
   "peerDependencies": {
     "@availity/upload-core": "^3.0.4",
-    "lodash.map": "4.6.0",
+    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-dropzone": "^10.0.0 ||^9.0.0 ||^8.0.0 ||^7.0.1",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },
@@ -40,7 +39,7 @@
     "lodash.map": "^4.6.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
-    "react-dropzone": "^10.1.5",
+    "@twarner/react-dropzone": "^0.0.0-pr-938",
     "reactstrap": "^8.0.0",
     "tus-js-client": "^1.7.1"
   }

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -25,6 +25,7 @@
     "@availity/upload-core": "^3.0.4",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "react-dropzone": "^11.0.0",
     "reactstrap": "^8.0.0 || ^7.0.0 || ^6.0.0",
     "tus-js-client": "1.5.1"
   },

--- a/packages/upload/tests/Upload.test.js
+++ b/packages/upload/tests/Upload.test.js
@@ -119,17 +119,23 @@ describe('Upload', () => {
 
     expect(inputNode.files.length).toBe(1);
     await wait(() => {
-      expect(getByText('File is too large')).toBeDefined();
+      expect(getByText('File is larger than 10 bytes')).toBeDefined();
     });
   });
 
   test('uses custom drop rejection message', async () => {
-    const getDropRejectionMessage = code => {
-      if (code === 'file-too-large') {
-        return 'my custom error message';
-      }
-      return 'this file is no good';
+    const getDropRejectionMessage = errors => {
+      let msg = '';
+      errors.forEach(error => {
+        if (error.code === 'file-too-large') {
+          msg += 'my custom error message';
+        } else {
+          msg += 'this file is no good';
+        }
+      });
+      return msg;
     };
+
     const { getByTestId, getByText } = render(
       <Upload
         clientId="a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17672,15 +17672,6 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^10.1.5:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.1.tgz#b7520124c4a3b66f96d49f7879027c7a475eaa20"
-  integrity sha512-Me5nOu8hK9/Xyg5easpdfJ6SajwUquqYR/2YTdMotsCUgJ1pHIIwNsv0n+qcIno0tWR2V2rVQtj2r/hXYs2TnQ==
-  dependencies:
-    attr-accept "^2.0.0"
-    file-selector "^0.1.12"
-    prop-types "^15.7.2"
-
 react-element-to-jsx-string@^14.0.2:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.1.tgz#a08fa6e46eb76061aca7eabc2e70f433583cb203"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,15 +3296,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
   integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
 
-"@twarner/react-dropzone@^0.0.0-pr-938":
-  version "0.0.0-pr-938"
-  resolved "https://registry.npmjs.org/@twarner/react-dropzone/-/react-dropzone-0.0.0-pr-938.tgz#1a4ce6abb6c4d7d00b9918a101fde8cf833fce01"
-  integrity sha512-nHSUcUluTOlUobvq5dPlps5Eo3e/leaylkO5Ol8lkrK3rU3uIjc6aDGQqu8937utYHArJl74RN9mztO4kxDywA==
-  dependencies:
-    attr-accept "^2.0.0"
-    file-selector "^0.1.12"
-    prop-types "^15.7.2"
-
 "@types/babel__core@^7.1.0":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.4.tgz#5c5569cc40e5f2737dfc00692f5444e871e4a234"
@@ -17671,6 +17662,15 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-dropzone@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.0.1.tgz#c8b6a6ed02576e5365af2e2a3f3b31df31feb213"
+  integrity sha512-x/6wqRHaR8jsrNiu/boVMIPYuoxb83Vyfv77hO7/3ZRn8Pr+KH5onsCsB8MLBa3zdJl410C5FXPUINbu16XIzw==
+  dependencies:
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
+    prop-types "^15.7.2"
 
 react-element-to-jsx-string@^14.0.2:
   version "14.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,6 +3296,15 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
   integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
 
+"@twarner/react-dropzone@^0.0.0-pr-938":
+  version "0.0.0-pr-938"
+  resolved "https://registry.npmjs.org/@twarner/react-dropzone/-/react-dropzone-0.0.0-pr-938.tgz#1a4ce6abb6c4d7d00b9918a101fde8cf833fce01"
+  integrity sha512-nHSUcUluTOlUobvq5dPlps5Eo3e/leaylkO5Ol8lkrK3rU3uIjc6aDGQqu8937utYHArJl74RN9mztO4kxDywA==
+  dependencies:
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
+    prop-types "^15.7.2"
+
 "@types/babel__core@^7.1.0":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.4.tgz#5c5569cc40e5f2737dfc00692f5444e871e4a234"


### PR DESCRIPTION
This PR introduces a breaking change to `form-upload` and `upload`. the `react-dropzone` peer dependency must now be `>= 11.x` in order for this package to work.

Fixes issue in `upload` and `form-upload` where error messages for rejected files are not displayed when `showFileDrop` is true

## Explanation of issue
1. Error is set here: https://github.com/Availity/availity-react/blob/master/packages/upload/Upload.js#L87
2. Then `setFiles` is called: https://github.com/Availity/availity-react/blob/master/packages/upload/Upload.js#L90
3. `setFiles` immediately clears out the error https://github.com/Availity/availity-react/blob/master/packages/upload/Upload.js#L76

The same flow occurs in `form-upload`

## Solution
This PR resolves this by attaching the rejection reason from `react-dropzone` to each file, and allowing `<UploadProgressBar />` to render the error message: https://github.com/Availity/availity-react/blob/master/packages/upload/UploadProgressBar.js#L66 for consistent error styling regardless of whether `showFileDrop` is used. (In `form-upload`, I left the `<Feedback />` so that if someone use the `useFormikContext` hook to explicitly set a the field's error it will still display.)

## Additional Info
- this PR passes the `allowedFileTypes` prop as the `accept` prop to `react-dropzone`
- this PR adds a `getDropRejectionMessage` prop so that user land can override error messages