### PR TITLE
Feat/date year picker

### DIFF
--- a/docs/source/components/pagination/controls.md
+++ b/docs/source/components/pagination/controls.md
@@ -15,7 +15,7 @@ import { PaginationControls } from '@availity/pagination';
 ## Props
 
 ### `directionLinks?: boolean`
-If enabled, shows next and previous aroos on the "Next" and "Back" buttons.
+If enabled, shows next and previous arrows on the "Next" and "Back" buttons.
 
 ### `autoHide?: boolean`
 If enabled and there are no items, the component is hidden.

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -138,3 +138,20 @@ interface MomentDateRange {
   endDate: (moment: Moment) => Moment;
 }
 ```
+
+### `yearPickerProps?: object`
+
+Props to passed to the `renderMonthElement` function for `SingleDatePicker`. `renderMonthElement` will render both month and year pickers to help speed up selection of dates.
+
+```js
+yearPickerProps: {
+  minYear: 1999,
+  maxYear: 2020,
+}
+```
+
+**Defaults:
+
+`minYear: moment().year() - 100`
+
+`maxYear: moment().year()`

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -72,7 +72,8 @@ Key to return end date as on form submit. Should match the yup schema `endKey`.
 
 ### `min?: string | LimitType`
 
-Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates`. Dates outside the allowed range will not be clickable in datepicker.
+Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates` and selectable year options in datepicker. Dates outside the allowed range will not be clickable in datepicker.
+
 
 ```json hideCopy=true
 {
@@ -84,7 +85,7 @@ Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates
 
 ### `max?: string | LimitType`
 
-Used in conjunction with `min` to derive `isOutsideRange` prop from `react-dates`. Dates outside the allowed range will not be clickable in datepicker.
+Used in conjunction with `min` to derive `isOutsideRange` prop from `react-dates` and selectable year options in datepicker. Dates outside the allowed range will not be clickable in datepicker.
 
 ```json hideCopy=true
 {
@@ -138,20 +139,3 @@ interface MomentDateRange {
   endDate: (moment: Moment) => Moment;
 }
 ```
-
-### `yearPickerProps?: object`
-
-Props to passed to the `renderMonthElement` function for `SingleDatePicker`. `renderMonthElement` will render both month and year pickers to help speed up selection of dates.
-
-```js
-yearPickerProps: {
-  minYear: 1999,
-  maxYear: 2020,
-}
-```
-
-**Defaults:
-
-`minYear: moment().year() - 100`
-
-`maxYear: moment().year()`

--- a/docs/source/form/date/components/date.md
+++ b/docs/source/form/date/components/date.md
@@ -38,7 +38,7 @@ import moment from 'moment';
       Submit
     </Button>
   </Form>
-</div>;
+</div>
 ```
 
 ## Props
@@ -96,3 +96,20 @@ Toggle whether the calendar is shown.
 ### `datePickerProps?: SingleDatePickerShape`
 
 Props to be spread onto the datepicker component from [react-dates](https://github.com/airbnb/react-dates#singledatepicker).
+
+### `yearPickerProps?: object`
+
+Props to passed to the `renderMonthElement` function for `SingleDatePicker`. `renderMonthElement` will render both month and year pickers to help speed up selection of dates.
+
+```js
+yearPickerProps: {
+  minYear: 1999,
+  maxYear: 2020,
+}
+```
+
+**Defaults:
+
+`minYear: moment().year() - 100`
+
+`maxYear: moment().year()`

--- a/docs/source/form/date/components/date.md
+++ b/docs/source/form/date/components/date.md
@@ -55,7 +55,7 @@ Whether the date is disabled.
 
 ### `min?: string | LimitType`
 
-Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates`. Dates outside the allowed range will not be clickable in datepicker.
+Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates` and selectable year options in datepicker. Dates outside the allowed range will not be clickable in datepicker.
 
 ```json hideCopy=true
 {
@@ -67,7 +67,7 @@ Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates
 
 ### `max?: string | LimitType`
 
-Used in conjunction with `min` to derive `isOutsideRange` prop from `react-dates`. Dates outside the allowed range will not be clickable in datepicker.
+Used in conjunction with `min` to derive `isOutsideRange` prop from `react-dates` and selectable year options in datepicker. Dates outside the allowed range will not be clickable in datepicker.
 
 ```json hideCopy=true
 {
@@ -96,20 +96,3 @@ Toggle whether the calendar is shown.
 ### `datePickerProps?: SingleDatePickerShape`
 
 Props to be spread onto the datepicker component from [react-dates](https://github.com/airbnb/react-dates#singledatepicker).
-
-### `yearPickerProps?: object`
-
-Props to passed to the `renderMonthElement` function for `SingleDatePicker`. `renderMonthElement` will render both month and year pickers to help speed up selection of dates.
-
-```js
-yearPickerProps: {
-  minYear: 1999,
-  maxYear: 2020,
-}
-```
-
-**Defaults:
-
-`minYear: moment().year() - 100`
-
-`maxYear: moment().year()`

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -27,7 +27,6 @@ const AvDate = ({
   format,
   validate,
   datePickerProps,
-  yearPickerProps,
   'data-testid': dataTestId,
   ...attributes
 }) => {
@@ -111,9 +110,7 @@ const AvDate = ({
   };
 
   const renderMonthElement = ({ month, onMonthSelect, onYearSelect }) => {
-    const { minYear, maxYear } = yearPickerProps;
-    // TODO: optimize call to buildYearPickerOptions
-    const yearPickerOptions = buildYearPickerOptions(minYear, maxYear, month);
+    const yearPickerOptions = buildYearPickerOptions(min, max, month, format);
     return (
       <Row>
         <Col>
@@ -207,17 +204,12 @@ AvDate.propTypes = {
   datepicker: PropTypes.bool,
   validate: PropTypes.func,
   datePickerProps: PropTypes.object,
-  yearPickerProps: PropTypes.object,
 };
 
 AvDate.defaultProps = {
   calendarIcon: <Icon name="calendar" />,
   format: 'MM/DD/YYYY',
   datepicker: true,
-  yearPickerProps: {
-    minYear: moment().year() - 100,
-    maxYear: moment().year(),
-  },
 };
 
 export default AvDate;

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -116,13 +116,14 @@ const AvDate = ({
         <Col>
           <select
             data-testid="monthPicker"
+            aria-label="month picker"
             value={month.month()}
             onChange={e => {
               onMonthSelect(month, e.target.value);
             }}
           >
             {moment.months().map((label, value) => (
-              <option key={label} value={value}>
+              <option key={label} value={value} aria-label={label}>
                 {label}
               </option>
             ))}
@@ -131,6 +132,7 @@ const AvDate = ({
         <Col>
           <select
             data-testid="yearPicker"
+            aria-label="year picker"
             style={{
               minWidth: '100%', // 4 digit years not wide enough to fill column
             }}
@@ -140,7 +142,7 @@ const AvDate = ({
             }}
           >
             {yearPickerOptions.map(({ value, label }) => (
-              <option key={label} value={value}>
+              <option key={label} value={value} aria-label={label}>
                 {label}
               </option>
             ))}

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -66,7 +66,6 @@ const DateRange = ({
   autoSync,
   ranges: propsRanges,
   customArrowIcon,
-  yearPickerProps,
   ...attributes
 }) => {
   const { setFieldValue, setFieldTouched } = useFormikContext();
@@ -232,8 +231,8 @@ const DateRange = ({
                 setFieldTouched(startKey, true);
                 setFieldTouched(endKey, true);
 
-                // // Focucs the calendar icon once clicked because we don't
-                // // want to get back in the loop of opening the calendar
+                // Focus the calendar icon once clicked because we don't
+                // want to get back in the loop of opening the calendar
                 calendarIconRef.current.parentElement.focus();
               }}
             >
@@ -246,9 +245,7 @@ const DateRange = ({
   };
 
   const renderMonthElement = ({ month, onMonthSelect, onYearSelect }) => {
-    const { minYear, maxYear } = yearPickerProps;
-    // TODO: optimize call to buildYearPickerOptions
-    const yearPickerOptions = buildYearPickerOptions(minYear, maxYear, month);
+    const yearPickerOptions = buildYearPickerOptions(min, max, month, format);
     return (
       <Row>
         <Col>
@@ -371,7 +368,6 @@ DateRange.propTypes = {
     PropTypes.object,
   ]),
   customArrowIcon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  yearPickerProps: PropTypes.object,
 };
 
 DateRange.defaultProps = {
@@ -380,10 +376,6 @@ DateRange.defaultProps = {
   startKey: 'startDate',
   endKey: 'endDate',
   datepicker: true,
-  yearPickerProps: {
-    minYear: moment().year() - 10,
-    maxYear: moment().year(),
-  },
 };
 
 export default DateRange;

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -251,13 +251,14 @@ const DateRange = ({
         <Col>
           <select
             data-testid="monthPicker"
+            aria-label="month picker"
             value={month.month()}
             onChange={e => {
               onMonthSelect(month, e.target.value);
             }}
           >
             {moment.months().map((label, value) => (
-              <option key={label} value={value}>
+              <option key={label} value={value} aria-label={label}>
                 {label}
               </option>
             ))}
@@ -266,6 +267,7 @@ const DateRange = ({
         <Col>
           <select
             data-testid="yearPicker"
+            aria-label="year picker"
             style={{
               minWidth: '100%', // 4 digit years not wide enough to fill column
             }}
@@ -275,7 +277,7 @@ const DateRange = ({
             }}
           >
             {yearPickerOptions.map(({ value, label }) => (
-              <option key={label} value={value}>
+              <option key={label} value={value} aria-label={label}>
                 {label}
               </option>
             ))}

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -60,6 +60,7 @@ const DateRange = ({
   datepicker,
   autoSync,
   ranges: propsRanges,
+  customArrowIcon,
   ...attributes
 }) => {
   const { setFieldValue, setFieldTouched } = useFormikContext();
@@ -265,7 +266,7 @@ const DateRange = ({
           disabled={attributes.disabled}
           onFocusChange={onFocusChange}
           renderCalendarInfo={renderDateRanges}
-          customArrowIcon="-"
+          customArrowIcon={customArrowIcon}
           isOutsideRange={isOutsideRange(min, max, format)}
           customInputIcon={
             datepicker
@@ -312,6 +313,7 @@ DateRange.propTypes = {
     PropTypes.array,
     PropTypes.object,
   ]),
+  customArrowIcon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
 DateRange.defaultProps = {

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -339,6 +339,7 @@ const DateRange = ({
           showDefaultInputIcon={datepicker}
           inputIconPosition="after"
           numberOfMonths={2}
+          navPosition="navPositionBottom"
         />
       </InputGroup>
     </>

--- a/packages/date/src/utils.js
+++ b/packages/date/src/utils.js
@@ -65,3 +65,26 @@ export const isSameDay = (a, b) => {
     a.date() === b.date() && a.month() === b.month() && a.year() === b.year()
   );
 };
+
+export const buildYearPickerOptions = (minYear, maxYear, month) => {
+  // As user scrolls forwards or backwards (or inputs date on their own), it's possible for them to end up
+  // with a year outside the min or max range. To avoid displaying incorrect year values in <select/> , we should
+  // compare month.year() to minYear and maxYear and use the appropriate value for min/max
+  const yearPickerOptions = [];
+
+  let min = minYear;
+  let max = maxYear;
+  if (month.year() > maxYear) {
+    max = month.year();
+  } else if (month.year() < minYear) {
+    min = month.year();
+  }
+
+  for (let year = min; year <= max; year++) {
+    yearPickerOptions.push({
+      value: year,
+      label: `${year}`,
+    });
+  }
+  return yearPickerOptions;
+};

--- a/packages/date/src/utils.js
+++ b/packages/date/src/utils.js
@@ -66,21 +66,68 @@ export const isSameDay = (a, b) => {
   );
 };
 
-export const buildYearPickerOptions = (minYear, maxYear, month) => {
-  // As user scrolls forwards or backwards (or inputs date on their own), it's possible for them to end up
-  // with a year outside the min or max range. To avoid displaying incorrect year values in <select/> , we should
-  // compare month.year() to minYear and maxYear and use the appropriate value for min/max
+export const buildYearPickerOptions = (
+  min,
+  max,
+  month,
+  format = 'MM/DD/YYYY'
+) => {
   const yearPickerOptions = [];
+  let minYear;
+  let maxYear;
 
-  let min = minYear;
-  let max = maxYear;
-  if (month.year() > maxYear) {
-    max = month.year();
-  } else if (month.year() < minYear) {
-    min = month.year();
+  if (min) {
+    if (moment.isMoment(min)) {
+      minYear = min.year();
+    } else if (min.value && min.units) {
+      minYear = moment()
+        .subtract(min.value, min.units)
+        .year();
+    } else if (typeof min === 'string') {
+      const minMoment = moment(min, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+
+      minYear = minMoment.year();
+    }
+  } else {
+    minYear = moment().year() - 100;
   }
 
-  for (let year = min; year <= max; year++) {
+  if (max) {
+    if (moment.isMoment(max)) {
+      maxYear = max.year();
+    } else if (max.value && max.units) {
+      maxYear = moment()
+        .add(max.value, max.units)
+        .year();
+    } else if (typeof max === 'string') {
+      const maxMoment = moment(max, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+
+      maxYear = maxMoment.year();
+    }
+  } else {
+    maxYear = moment().year();
+  }
+
+  // As user scrolls forwards or backwards (or inputs date on their own), it's possible for them to end up
+  // with a year outside the min or max range. To avoid displaying incorrect year values in <select/> , we should
+  // compare month.year() to min and max and use the appropriate value for min/max
+  if (month.year() > maxYear) {
+    maxYear = month.year();
+  } else if (month.year() < minYear) {
+    minYear = month.year();
+  }
+
+  for (let year = minYear; year <= maxYear; year++) {
     yearPickerOptions.push({
       value: year,
       label: `${year}`,

--- a/packages/date/styles.scss
+++ b/packages/date/styles.scss
@@ -162,7 +162,9 @@
 .is-invalid {
   .SingleDatePicker input.DateInput_input,
   .DateRangePickerInput .DateRangePickerInput_arrow,
-  .DateRangePickerInput input.DateInput_input {
+  .DateRangePickerInput input.DateInput_input,
+  .DateRangePickerInput_calendarIcon,
+  .SingleDatePickerInput_calendarIcon {
     border-color: #dc3545;
   }
   .DateRangePickerInput .DateInput:nth-of-type(1) input.DateInput_input {

--- a/packages/date/styles.scss
+++ b/packages/date/styles.scss
@@ -1,6 +1,8 @@
 @import '~react-dates/lib/css/_datepicker.css';
 
 .DateInput {
+  flex: 1 0 0;
+  border-radius: 0.25em;
   font-size: 16px;
   font-weight: normal;
   line-height: normal;
@@ -12,27 +14,35 @@
 }
 
 .DateRangePickerInput_arrow {
-  padding: 0.375rem 0.75rem;
+  padding: 0.25rem 0.5rem;
   background-color: #e9ecef;
   border: 1px solid #ced4da;
   border-left: none;
   border-right: none;
+  height: calc(
+    1.5em + 0.75rem + 2px
+  ); /* Do not remove this. Used to match Date Input heights to Reactstrap Input heights */
 }
 
 .DateRangePickerInput_calendarIcon,
 .SingleDatePickerInput_calendarIcon {
+  padding: 0.25rem 0.5rem;
   background-color: #e9ecef;
   margin-right: 0;
   margin-left: 0;
+  border: 1px solid #ced4da;
   border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  height: calc(
+    1.5em + 0.75rem + 2px
+  ); /* Do not remove this. Used to match Date Input heights to Reactstrap Input heights */
 }
 
 .DateRangePickerInput_calendarIcon:hover,
 .SingleDatePickerInput_calendarIcon:hover {
   color: #212529;
-background-color: #d4d9d9;
-border-color: #cdd3d3;
+  background-color: #d4d9d9;
+  border-color: #cdd3d3;
 }
 
 .DateRangePickerInput_calendarIcon:focus,
@@ -40,7 +50,6 @@ border-color: #cdd3d3;
   box-shadow: 0 0 0 0.2rem rgba(202, 205, 206, 0.5);
   outline: 0;
 }
-
 
 .current-day-highlight {
   .CalendarDay__today {
@@ -57,29 +66,18 @@ border-color: #cdd3d3;
   border: none;
 }
 
-
-.DateInput {
-  border-radius: 0.25em;
-  flex: 1;
-}
-
-
 .DateInput_input {
   font-size: 16px;
   font-weight: normal;
-  height: calc(1.5em + 0.75rem + 2px); /* Do not remove this */
   line-height: normal;
-  padding: 0.375rem 0.75rem;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  height: calc(
+    1.5em + 0.75rem + 2px
+  ); /* Do not remove this. Used to match Date Input heights to Reactstrap Input heights */
 }
 
-// .DateInput:has > input.DateInput_input {
-//   border-top-right-radius: 0;
-//   border-bottom-right-radius: 0;
-//   border-right:none;  
-// }
 .av-calendar-show .SingleDatePicker input.DateInput_input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -89,18 +87,24 @@ border-color: #cdd3d3;
 .DateRangePickerInput .DateInput:nth-of-type(1) input.DateInput_input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-};
+}
 
-.DateRangePickerInput .DateRangePickerInput_arrow ~ .DateInput input.DateInput_input {
+.DateRangePickerInput
+  .DateRangePickerInput_arrow
+  ~ .DateInput
+  input.DateInput_input {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-};
-.av-calendar-show .DateRangePickerInput .DateRangePickerInput_arrow ~ .DateInput input.DateInput_input{
+}
+
+.av-calendar-show
+  .DateRangePickerInput
+  .DateRangePickerInput_arrow
+  ~ .DateInput
+  input.DateInput_input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right: none;
-  // background-color:purple;
-  // color:purple;
 }
 
 .CalendarDay__selected,
@@ -155,17 +159,20 @@ border-color: #cdd3d3;
   color: #fff;
 }
 
-
 .is-invalid {
-  .SingleDatePicker input.DateInput_input,.DateRangePickerInput .DateRangePickerInput_arrow, .DateRangePickerInput input.DateInput_input {
+  .SingleDatePicker input.DateInput_input,
+  .DateRangePickerInput .DateRangePickerInput_arrow,
+  .DateRangePickerInput input.DateInput_input {
     border-color: #dc3545;
   }
   .DateRangePickerInput .DateInput:nth-of-type(1) input.DateInput_input {
     border-right-color: #cdd3d3;
   }
-  
-  .DateRangePickerInput .DateRangePickerInput_arrow ~ .DateInput input.DateInput_input {
-    border-left-color: #cdd3d3
+
+  .DateRangePickerInput
+    .DateRangePickerInput_arrow
+    ~ .DateInput
+    input.DateInput_input {
+    border-left-color: #cdd3d3;
   }
 }
-

--- a/packages/date/tests/Date.test.js
+++ b/packages/date/tests/Date.test.js
@@ -175,8 +175,8 @@ describe('Date', () => {
   });
 
   test('renders year picker with given range', async () => {
-    const minYear = 1919;
-    const maxYear = 2020;
+    const min = moment().subtract(101, 'years');
+    const max = moment();
     const someYear = '1947';
 
     const { container, getAllByTestId } = render(
@@ -185,13 +185,7 @@ describe('Date', () => {
           singleDate: '',
         }}
       >
-        <FormikDate
-          name="singleDate"
-          yearPickerProps={{
-            minYear,
-            maxYear,
-          }}
-        />
+        <FormikDate name="singleDate" min={min} max={max} />
       </Form>
     );
 
@@ -204,7 +198,9 @@ describe('Date', () => {
     expect(yearPickers.length).toBe(3);
 
     const currentGridYearPicker = yearPickers[1];
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
 
     const pickedYear = within(currentGridYearPicker).getByText(someYear);
     expect(pickedYear).toBeDefined();
@@ -213,9 +209,9 @@ describe('Date', () => {
   test('renders new year option when navigating past initial range', async () => {
     const onChange = jest.fn();
 
-    const minYear = 2019;
-    const maxYear = 2020;
-    const newYear = `${maxYear + 1}`;
+    const min = moment().subtract(1, 'years');
+    const max = moment('12/31/2020');
+    const newYear = `${max.year() + 1}`;
 
     const { container, getAllByTestId } = render(
       <Form
@@ -223,14 +219,7 @@ describe('Date', () => {
           singleDate: '',
         }}
       >
-        <FormikDate
-          name="singleDate"
-          yearPickerProps={{
-            minYear,
-            maxYear,
-          }}
-          onChange={onChange}
-        />
+        <FormikDate name="singleDate" min={min} max={max} onChange={onChange} />
       </Form>
     );
 
@@ -246,17 +235,21 @@ describe('Date', () => {
     let nextGridYearPicker = yearPickers[2]; // next in this context refers to the next CalendarMonthGrid to be rendered
 
     // Expect year options to have same length as range of initial options
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
-    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
+    expect(nextGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
 
     fireEvent.change(input, {
       target: {
-        value: `12/25/${maxYear}`,
+        value: `12/25/${max.year()}`,
       },
     });
 
     await wait(() => {
-      expect(onChange.mock.calls[0][0]).toBe(`${maxYear}-12-25`);
+      expect(onChange.mock.calls[0][0]).toBe(`${max.year()}-12-25`);
     });
 
     fireEvent.focus(input);
@@ -266,10 +259,14 @@ describe('Date', () => {
     currentGridYearPicker = yearPickers[1];
     nextGridYearPicker = yearPickers[2];
 
-    // Expect current MonthGrid to have same number of options, it is still December of maxYear
+    // Expect current MonthGrid to have same number of options, it is still December of max
     // Expect next MonthGrid (January) to have new year option created
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
-    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 2);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
+    expect(nextGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 2
+    );
 
     const pickedYear = within(nextGridYearPicker).getByText(newYear);
     expect(pickedYear).toBeDefined();

--- a/packages/date/tests/Date.test.js
+++ b/packages/date/tests/Date.test.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, fireEvent, wait, cleanup } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  wait,
+  cleanup,
+  within,
+} from '@testing-library/react';
 import { Button } from 'reactstrap';
 import { Form } from '@availity/form';
 import '@availity/yup/moment';
@@ -140,5 +146,132 @@ describe('Date', () => {
         expect.anything()
       );
     });
+  });
+
+  test('renders month picker', async () => {
+    const { container, getAllByTestId } = render(
+      <Form
+        initialValues={{
+          singleDate: '',
+        }}
+      >
+        <FormikDate name="singleDate" />
+      </Form>
+    );
+
+    const input = container.querySelector('.DateInput_input');
+
+    fireEvent.focus(input);
+
+    // There will be multiple pickers because react-dates renders hidden prev/next CalendarMonthGrids
+    const monthPickers = getAllByTestId('monthPicker');
+    expect(monthPickers.length).toBe(3);
+
+    const currentGridMonthPicker = monthPickers[1];
+    expect(currentGridMonthPicker.children.length).toBe(12); // 12 options -> 12 months of year
+
+    const jan = within(currentGridMonthPicker).getByText('January');
+    expect(jan).toBeDefined();
+  });
+
+  test('renders year picker with given range', async () => {
+    const minYear = 1919;
+    const maxYear = 2020;
+    const someYear = '1947';
+
+    const { container, getAllByTestId } = render(
+      <Form
+        initialValues={{
+          singleDate: '',
+        }}
+      >
+        <FormikDate
+          name="singleDate"
+          yearPickerProps={{
+            minYear,
+            maxYear,
+          }}
+        />
+      </Form>
+    );
+
+    const input = container.querySelector('.DateInput_input');
+
+    fireEvent.focus(input);
+
+    // There will be multiple pickers because react-dates renders hidden prev/next CalendarMonthGrids
+    const yearPickers = getAllByTestId('yearPicker');
+    expect(yearPickers.length).toBe(3);
+
+    const currentGridYearPicker = yearPickers[1];
+    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+
+    const pickedYear = within(currentGridYearPicker).getByText(someYear);
+    expect(pickedYear).toBeDefined();
+  });
+
+  test('renders new year option when navigating past initial range', async () => {
+    const onChange = jest.fn();
+
+    const minYear = 2019;
+    const maxYear = 2020;
+    const newYear = `${maxYear + 1}`;
+
+    const { container, getAllByTestId } = render(
+      <Form
+        initialValues={{
+          singleDate: '',
+        }}
+      >
+        <FormikDate
+          name="singleDate"
+          yearPickerProps={{
+            minYear,
+            maxYear,
+          }}
+          onChange={onChange}
+        />
+      </Form>
+    );
+
+    const input = container.querySelector('.DateInput_input');
+
+    fireEvent.focus(input);
+
+    // There will be multiple pickers because react-dates renders hidden prev/next CalendarMonthGrids
+    let yearPickers = getAllByTestId('yearPicker');
+    expect(yearPickers.length).toBe(3);
+
+    let currentGridYearPicker = yearPickers[1];
+    let nextGridYearPicker = yearPickers[2]; // next in this context refers to the next CalendarMonthGrid to be rendered
+
+    // Expect year options to have same length as range of initial options
+    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+
+    fireEvent.change(input, {
+      target: {
+        value: `12/25/${maxYear}`,
+      },
+    });
+
+    await wait(() => {
+      expect(onChange.mock.calls[0][0]).toBe(`${maxYear}-12-25`);
+    });
+
+    fireEvent.focus(input);
+
+    // re-query to grab updated values and reassign
+    yearPickers = getAllByTestId('yearPicker');
+    currentGridYearPicker = yearPickers[1];
+    nextGridYearPicker = yearPickers[2];
+
+    // Expect current MonthGrid to have same number of options, it is still December of maxYear
+    // Expect next MonthGrid (January) to have new year option created
+    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 2);
+
+    const pickedYear = within(nextGridYearPicker).getByText(newYear);
+    expect(pickedYear).toBeDefined();
   });
 });

--- a/packages/date/tests/DateRange.test.js
+++ b/packages/date/tests/DateRange.test.js
@@ -410,8 +410,8 @@ describe('DateRange', () => {
   });
 
   test('renders year picker with given range', async () => {
-    const minYear = 1919;
-    const maxYear = 2020;
+    const min = moment().subtract(101, 'years');
+    const max = moment();
     const someYear = '1947';
 
     const { container, getAllByTestId } = render(
@@ -420,13 +420,7 @@ describe('DateRange', () => {
           dateRange: '',
         }}
       >
-        <DateRange
-          name="dateRange"
-          yearPickerProps={{
-            minYear,
-            maxYear,
-          }}
-        />
+        <DateRange name="dateRange" min={min} max={max} />
       </Form>
     );
 
@@ -440,7 +434,9 @@ describe('DateRange', () => {
     expect(yearPickers.length).toBe(4);
 
     const currentGridYearPicker = yearPickers[1];
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
 
     const pickedYear = within(currentGridYearPicker).getByText(someYear);
     expect(pickedYear).toBeDefined();
@@ -449,9 +445,9 @@ describe('DateRange', () => {
   test('renders new year option when navigating past initial range', async () => {
     const onChange = jest.fn();
 
-    const minYear = 2019;
-    const maxYear = 2020;
-    const newYear = `${maxYear + 1}`;
+    const min = moment().subtract(1, 'years');
+    const max = moment('12/31/2020');
+    const newYear = `${max.year() + 1}`;
 
     const { container, getAllByTestId } = render(
       <Form
@@ -459,14 +455,7 @@ describe('DateRange', () => {
           dateRange: '',
         }}
       >
-        <DateRange
-          name="dateRange"
-          yearPickerProps={{
-            minYear,
-            maxYear,
-          }}
-          onChange={onChange}
-        />
+        <DateRange name="dateRange" min={min} max={max} onChange={onChange} />
       </Form>
     );
 
@@ -484,12 +473,16 @@ describe('DateRange', () => {
     let nextGridYearPicker = yearPickers[2]; // next in this context refers to the next CalendarMonthGrid to be rendered
 
     // Expect year options to have same length as range of initial options
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
-    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 1);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
+    expect(nextGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
 
     fireEvent.change(start, {
       target: {
-        value: `12/25/${maxYear}`,
+        value: `12/25/${max.year()}`,
       },
     });
 
@@ -497,19 +490,19 @@ describe('DateRange', () => {
 
     fireEvent.change(end, {
       target: {
-        value: `12/26/${maxYear}`,
+        value: `12/26/${max.year()}`,
       },
     });
 
     await wait(() => {
       expect(onChange.mock.calls[0][0]).toStrictEqual({
         endDate: undefined,
-        startDate: `${maxYear}-12-25`,
+        startDate: `${max.year()}-12-25`,
       });
 
       expect(onChange.mock.calls[1][0]).toStrictEqual({
-        endDate: `${maxYear}-12-26`,
-        startDate: `${maxYear}-12-25`,
+        endDate: `${max.year()}-12-26`,
+        startDate: `${max.year()}-12-25`,
       });
     });
 
@@ -520,10 +513,14 @@ describe('DateRange', () => {
     currentGridYearPicker = yearPickers[1];
     nextGridYearPicker = yearPickers[3];
 
-    // Expect current MonthGrid to have same number of options, it is still December of maxYear
+    // Expect current MonthGrid to have same number of options, it is still December of max
     // Expect next MonthGrid (January) to have new year option created
-    expect(currentGridYearPicker.children.length).toBe(maxYear - minYear + 1);
-    expect(nextGridYearPicker.children.length).toBe(maxYear - minYear + 2);
+    expect(currentGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 1
+    );
+    expect(nextGridYearPicker.children.length).toBe(
+      max.year() - min.year() + 2
+    );
 
     const pickedYear = within(nextGridYearPicker).getByText(newYear);
     expect(pickedYear).toBeDefined();

--- a/packages/date/tests/utils.test.js
+++ b/packages/date/tests/utils.test.js
@@ -78,37 +78,79 @@ describe('utils', () => {
   });
 
   describe('buildYearPickerOptions', () => {
-    it('renders correct options based on minYear and maxYear', () => {
+    it('renders correct options when min and max are moments', () => {
       const month = moment();
-      const minYear = 2019;
-      const maxYear = 2020;
+      const min = moment().subtract(2, 'years');
+      const max = moment().add(2, 'years');
 
-      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+      const yearPicker = UTILS.buildYearPickerOptions(min, max, month);
 
-      expect(yearPicker.length).toBe(maxYear - minYear + 1);
+      expect(yearPicker.length).toBe(max.year() - min.year() + 1);
     });
 
-    it('renders correct options when current month.year() > maxYear', () => {
+    it('renders correct options when min and max are objects with values and units', () => {
+      const month = moment();
+      const min = { value: 3, units: 'years' };
+      const max = { value: 1, units: 'years' };
+
+      const yearPicker = UTILS.buildYearPickerOptions(min, max, month);
+
+      expect(yearPicker.length).toBe(
+        moment()
+          .add(max.value, max.units)
+          .year() -
+          moment()
+            .subtract(min.value, min.units)
+            .year() +
+          1
+      );
+    });
+
+    it('renders correct options when min and max are strings', () => {
+      const month = moment();
+      const min = '01/01/1999';
+      const max = '12/31/2020';
+
+      const minMoment = moment(min, [
+        'YYYY-MM-DD',
+        'MM/DD/YYYY',
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+
+      const maxMoment = moment(max, [
+        'YYYY-MM-DD',
+        'MM/DD/YYYY',
+        'MMDDYYYY',
+        'YYYYMMDD',
+      ]);
+
+      const yearPicker = UTILS.buildYearPickerOptions(min, max, month);
+
+      expect(yearPicker.length).toBe(maxMoment.year() - minMoment.year() + 1);
+    });
+
+    it('renders correct options when current month.year() > max', () => {
       const month = moment().add(2, 'years');
-      const minYear = 2019;
-      const maxYear = 2020;
+      const min = moment().subtract(1, 'years');
+      const max = moment().add(1, 'years');
 
-      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+      const yearPicker = UTILS.buildYearPickerOptions(min, max, month);
 
-      expect(yearPicker.length).toBe(month.year() - minYear + 1);
-      expect(yearPicker.length).not.toBe(maxYear - minYear + 1);
+      expect(yearPicker.length).toBe(month.year() - min.year() + 1);
+      expect(yearPicker.length).not.toBe(max.year() - min.year() + 1);
       expect(yearPicker[yearPicker.length - 1].value).toBe(month.year());
     });
 
-    it('renders correct options current month.year() < minYear', () => {
+    it('renders correct options current month.year() < min', () => {
       const month = moment().subtract(2, 'years');
-      const minYear = 2019;
-      const maxYear = 2020;
+      const min = moment().subtract(1, 'years');
+      const max = moment().add(1, 'years');
 
-      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+      const yearPicker = UTILS.buildYearPickerOptions(min, max, month);
 
-      expect(yearPicker.length).toBe(maxYear - month.year() + 1);
-      expect(yearPicker.length).not.toBe(maxYear - minYear + 1);
+      expect(yearPicker.length).toBe(max.year() - month.year() + 1);
+      expect(yearPicker.length).not.toBe(max.year() - min.year() + 1);
       expect(yearPicker[0].value).toBe(month.year());
     });
   });

--- a/packages/date/tests/utils.test.js
+++ b/packages/date/tests/utils.test.js
@@ -76,4 +76,40 @@ describe('utils', () => {
       expect(isOutside).toBe(false);
     });
   });
+
+  describe('buildYearPickerOptions', () => {
+    it('renders correct options based on minYear and maxYear', () => {
+      const month = moment();
+      const minYear = 2019;
+      const maxYear = 2020;
+
+      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+
+      expect(yearPicker.length).toBe(maxYear - minYear + 1);
+    });
+
+    it('renders correct options when current month.year() > maxYear', () => {
+      const month = moment().add(2, 'years');
+      const minYear = 2019;
+      const maxYear = 2020;
+
+      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+
+      expect(yearPicker.length).toBe(month.year() - minYear + 1);
+      expect(yearPicker.length).not.toBe(maxYear - minYear + 1);
+      expect(yearPicker[yearPicker.length - 1].value).toBe(month.year());
+    });
+
+    it('renders correct options current month.year() < minYear', () => {
+      const month = moment().subtract(2, 'years');
+      const minYear = 2019;
+      const maxYear = 2020;
+
+      const yearPicker = UTILS.buildYearPickerOptions(minYear, maxYear, month);
+
+      expect(yearPicker.length).toBe(maxYear - month.year() + 1);
+      expect(yearPicker.length).not.toBe(maxYear - minYear + 1);
+      expect(yearPicker[0].value).toBe(month.year());
+    });
+  });
 });

--- a/packages/date/typings/Date.d.ts
+++ b/packages/date/typings/Date.d.ts
@@ -11,11 +11,6 @@ export type limitTypeAlt = {
   _isValid?: Function;
 };
 
-type yearPickerProps = {
-  minYear?: number;
-  maxYear?: number;
-};
-
 export interface DateBaseProps {
   id: string;
   name: string;
@@ -29,7 +24,6 @@ export interface DateBaseProps {
   innerRef?: Function | string;
   datePickerProps?: object;
   format?: string;
-  yearPickerProps?: yearPickerProps;
 }
 
 export interface DateProps extends SingleDatePickerShape, DateBaseProps {}

--- a/packages/date/typings/Date.d.ts
+++ b/packages/date/typings/Date.d.ts
@@ -3,7 +3,7 @@ import { SingleDatePickerShape } from 'react-dates';
 
 export type limitType = {
   value?: number;
-  units?: String;
+  units?: string;
 };
 
 export type limitTypeAlt = {
@@ -11,8 +11,13 @@ export type limitTypeAlt = {
   _isValid?: Function;
 };
 
+type yearPickerProps = {
+  minYear?: number;
+  maxYear?: number;
+};
+
 export interface DateBaseProps {
-  id?: string;
+  id: string;
   name: string;
   disabled?: boolean | false;
   className?: string;
@@ -24,6 +29,7 @@ export interface DateBaseProps {
   innerRef?: Function | string;
   datePickerProps?: object;
   format?: string;
+  yearPickerProps?: yearPickerProps;
 }
 
 export interface DateProps extends SingleDatePickerShape, DateBaseProps {}

--- a/packages/date/typings/DateField.d.ts
+++ b/packages/date/typings/DateField.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DateProps } from './Date';
 
 export interface DateFieldProps extends DateProps {
-  id?: string;
+  id: string;
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;

--- a/packages/date/typings/DateRange.d.ts
+++ b/packages/date/typings/DateRange.d.ts
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { DateRangePicker } from 'react-dates';
-import { limitType, limitTypeAlt, DateBaseProps } from './Date';
 import { Moment } from 'moment';
+import { limitType, limitTypeAlt, DateBaseProps } from './Date';
 
 interface MomentDateRange {
-    startDate: (moment: Moment) => Moment;
-    endDate: (moment: Moment) => Moment;
+  startDate: (moment: Moment) => Moment;
+  endDate: (moment: Moment) => Moment;
 }
 
-export interface DateRangeProps extends DateRangePicker,DateBaseProps {
-    ranges?: boolean | string[] | {[key:string]:MomentDateRange};
-    autoSync?: boolean;
+export interface DateRangeProps extends DateRangePicker, DateBaseProps {
+  ranges?: boolean | string[] | { [key: string]: MomentDateRange };
+  autoSync?: boolean;
 }
 
 declare class DateRange extends React.Component<DateRangeProps> {}

--- a/packages/date/typings/DateRangeField.d.ts
+++ b/packages/date/typings/DateRangeField.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DateRangeProps } from './DateRange';
 
 export interface DateRangeFieldProps extends DateRangeProps {
-  id?: string;
+  id: string;
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -26,7 +26,11 @@ const PaginationControls = ({
       aria-current={currentPage === pageNumber}
       data-testid={`control-page-${pageNumber}`}
     >
-      <PaginationLink onClick={() => setPage(pageNumber)} type="button">
+      <PaginationLink
+        style={{ zIndex: 'auto' }}
+        onClick={() => setPage(pageNumber)}
+        type="button"
+      >
         {pageNumber}
       </PaginationLink>
     </PaginationItem>


### PR DESCRIPTION
Closes #469. 

Adds the ability to select both month and year values from a single date picker and a date range picker, allowing for quicker navigation through the picker when not inputting date via text.

![Date - general](https://user-images.githubusercontent.com/18055194/76657030-4a308a80-6547-11ea-82c3-b44e5ce2f24b.png)

Adds ability for user to pass in a `customArrowIcon`, new default is the svg arrow from `react-dates`.

Moves `navPosition` to `navPositionBottom` so that we don't have to resort to a bunch of CSS styling to get a clean look.

`navPositionTop`:
![Date - navPositionTop](https://user-images.githubusercontent.com/18055194/76656426-ed80a000-6545-11ea-82f3-dfa3d526152a.png)

`navPositionBottom`:
![Date - navPositionBottom](https://user-images.githubusercontent.com/18055194/76656434-f1142700-6545-11ea-85fb-5d59eb96596b.png)

Fixes styling issue in Firefox where component size was not uniform:

Before:
![FF CSS issue](https://user-images.githubusercontent.com/18055194/76656708-93cca580-6546-11ea-9cd2-318a4a1df52d.png)

After:
![FF CSS issue fixed](https://user-images.githubusercontent.com/18055194/76656816-ceced900-6546-11ea-9289-d466823a770b.png)

