### PR TITLE
Fix for Date Range autoSync infinite loop bug

### DIFF
--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -67,7 +67,6 @@ const DateRange = ({
   const [focusedInput, setFocusedInput] = useState(null);
 
   const calendarIconRef = useRef();
-
   const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
 
   const endId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-end`;
@@ -159,7 +158,7 @@ const DateRange = ({
 
   const onFocusChange = async input => {
     if (!input) await setFieldTouched(name, true);
-    if (autoSync) await syncDates();
+    if (autoSync && !endValue) await syncDates();
     setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });
   };

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -158,9 +158,9 @@ const DateRange = ({
   };
 
   const onFocusChange = async input => {
-    if (!autoSync && !input) await setFieldTouched(name, true);
-    if (autoSync && focusedInput === input) await syncDates();
-    setFocusedInput(input);
+    if (!input) await setFieldTouched(name, true);
+    if (autoSync) await syncDates();
+    if (focusedInput !== input) setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });
   };
 

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -69,6 +69,7 @@ const DateRange = ({
   const calendarIconRef = useRef();
 
   const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
+
   const endId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-end`;
 
   const startValue = get(value, startKey);

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -159,7 +159,7 @@ const DateRange = ({
 
   const onFocusChange = async input => {
     if (!autoSync && !input) await setFieldTouched(name, true);
-    if (autoSync && !(focusedInput !== input)) await syncDates();
+    if (autoSync && focusedInput === input) await syncDates();
     setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });
   };

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -158,8 +158,8 @@ const DateRange = ({
   };
 
   const onFocusChange = async input => {
-    if (!input) await setFieldTouched(name, true);
-    if (autoSync && !endValue) await syncDates();
+    if (!autoSync && !input) await setFieldTouched(name, true);
+    if (autoSync && !(focusedInput !== input)) await syncDates();
     setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });
   };

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -67,8 +67,8 @@ const DateRange = ({
   const [focusedInput, setFocusedInput] = useState(null);
 
   const calendarIconRef = useRef();
-  const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
 
+  const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
   const endId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-end`;
 
   const startValue = get(value, startKey);


### PR DESCRIPTION
Fix for a bug that used to cause an infinite loop.  With autoSync on and with the dates already filled, the page used to infinitely try to sync dates.  Now this will no longer happen, as there is no reason to autoSync when end date is already populated.

closes #483 