### PR TITLE
fix(date): onFocusChange should only call setFieldTouched once

### DIFF
--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -164,7 +164,7 @@ const DateRange = ({
   };
 
   const onFocusChange = async input => {
-    if (!input) await setFieldTouched(name, true);
+    if (!input && !autoSync) await setFieldTouched(name, true);
     if (autoSync) await syncDates();
     if (focusedInput !== input) setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });


### PR DESCRIPTION
Related to issue #483 and PR #488 