### PR TITLE
Add debounceTimeout, shouldGetPageData props to pagination package

### DIFF
--- a/docs/source/components/pagination/pagination.md
+++ b/docs/source/components/pagination/pagination.md
@@ -44,3 +44,7 @@ Array of data points that, when changed, causes pagination to reset the current 
 ### `defaultPage?: number`
 
 The starting page to use when the component mounts. **Default:** `1`.
+
+### `debounceTimeout?: number`
+
+The amount of time (in milliseconds) to delay fetching page data since the last time page data was fetched (debounced input). Useful for when `items` is a function that's calling an api that you want to relieve pressure on. **Default**: `0`

--- a/docs/source/components/pagination/pagination.md
+++ b/docs/source/components/pagination/pagination.md
@@ -49,6 +49,6 @@ The starting page to use when the component mounts. **Default:** `1`.
 
 The amount of time (in milliseconds) to delay fetching page data since the last time page data was fetched (debounced input). Useful for when `items` is a function that's calling an api that you want to relieve pressure on. **Default**: `0`
 
-### `shouldGetPageData?: boolean`
+### `shouldReturnPrevious?: boolean`
 
-If `false`, the page data is not fetched. Useful for when `items` is a function and the page data should not be fetched until certain criteria is met. **Default:** `true`.
+If `true`, the previous results are returned. Note: if no results have been fetched thus far, an empty array is returned. Useful for when `items` is a function and new results should not be fetched until certain criteria is met. **Default:** `false`.

--- a/docs/source/components/pagination/pagination.md
+++ b/docs/source/components/pagination/pagination.md
@@ -48,3 +48,7 @@ The starting page to use when the component mounts. **Default:** `1`.
 ### `debounceTimeout?: number`
 
 The amount of time (in milliseconds) to delay fetching page data since the last time page data was fetched (debounced input). Useful for when `items` is a function that's calling an api that you want to relieve pressure on. **Default**: `0`
+
+### `shouldGetPageData?: boolean`
+
+If `false`, the page data is not fetched. Useful for when `items` is a function and the page data should not be fetched until certain criteria is met. **Default:** `true`.

--- a/docs/source/form/select/components/resource-select.md
+++ b/docs/source/form/select/components/resource-select.md
@@ -79,9 +79,9 @@ Availity API resource (see [@availity/api-core](https://github.com/Availity/sdk-
 
 When a function, the function is called with the response body from the API call and is expected to return an array. When a string, the string is expected to be a simple key used to get the value from the response. ("simple" means dot notation is not supported for grabbing values from nested objects. If your result is deeply nested, provide a function.)
 
-### `debounceTimeOut?: number`
+### `debounceTimeout?: number`
 
-The amount of time (in milliseconds) to wait after the user has stopped typing ebfore making the network request ( debounced input). **Default**: `350`
+The amount of time (in milliseconds) to wait after the user has stopped typing before making the network request (debounced input). **Default**: `350`
 
 ### `delay?: number`
 

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -27,7 +27,8 @@
     "lodash.isfunction": "^3.0.9",
     "prop-types": "^15.5.8",
     "react-block-ui": "^1.1.3",
-    "react-infinite-scroll-component": "^4.5.3"
+    "react-infinite-scroll-component": "^4.5.3",
+    "react-use": "^13.27.0"
   },
   "devDependencies": {
     "react": "^16.8.3",

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import isFunction from 'lodash.isfunction';
 import isEqual from 'lodash.isequal';
 import * as avLocalStorage from '@availity/localstorage-core';
+import { useDebounce } from 'react-use';
 
 export const PaginationContext = React.createContext();
 
@@ -26,6 +27,7 @@ const Pagination = ({
   watchList,
   resetParams,
   defaultPage,
+  debounceTimeout,
 }) => {
   const ref = React.useRef();
   const [stateCurrentPage, setPage] = useState(defaultPage);
@@ -93,14 +95,18 @@ const Pagination = ({
     toggleLoading(false);
   };
 
-  useEffect(() => {
-    getPageData();
-  }, [
-    currentPage,
-    itemsPerPage,
-    isFunction(theItems) ? null : theItems,
-    ...watchList,
-  ]);
+  useDebounce(
+    () => {
+      getPageData();
+    },
+    debounceTimeout,
+    [
+      currentPage,
+      itemsPerPage,
+      isFunction(theItems) ? null : theItems,
+      ...watchList,
+    ]
+  );
 
   const updatePage = page => {
     if (page !== currentPage) {
@@ -132,7 +138,6 @@ const Pagination = ({
         getPageData();
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...resetParams]);
 
   // boom roasted
@@ -162,6 +167,7 @@ Pagination.propTypes = {
   resetParams: PropTypes.array,
   defaultPage: PropTypes.number,
   page: PropTypes.number,
+  debounceTimeout: PropTypes.number,
 };
 
 Pagination.defaultProps = {
@@ -170,6 +176,7 @@ Pagination.defaultProps = {
   watchList: [],
   resetParams: [],
   defaultPage: 1,
+  debounceTimeout: 0,
 };
 
 export default Pagination;

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -28,6 +28,7 @@ const Pagination = ({
   resetParams,
   defaultPage,
   debounceTimeout,
+  shouldGetPageData,
 }) => {
   const ref = React.useRef();
   const [stateCurrentPage, setPage] = useState(defaultPage);
@@ -97,13 +98,16 @@ const Pagination = ({
 
   useDebounce(
     () => {
-      getPageData();
+      if (shouldGetPageData) {
+        getPageData();
+      }
     },
     debounceTimeout,
     [
       currentPage,
       itemsPerPage,
       isFunction(theItems) ? null : theItems,
+      shouldGetPageData,
       ...watchList,
     ]
   );
@@ -168,6 +172,7 @@ Pagination.propTypes = {
   defaultPage: PropTypes.number,
   page: PropTypes.number,
   debounceTimeout: PropTypes.number,
+  shouldGetPageData: PropTypes.bool,
 };
 
 Pagination.defaultProps = {
@@ -177,6 +182,7 @@ Pagination.defaultProps = {
   resetParams: [],
   defaultPage: 1,
   debounceTimeout: 0,
+  shouldGetPageData: true,
 };
 
 export default Pagination;

--- a/packages/pagination/src/Pagination.js
+++ b/packages/pagination/src/Pagination.js
@@ -28,7 +28,7 @@ const Pagination = ({
   resetParams,
   defaultPage,
   debounceTimeout,
-  shouldGetPageData,
+  shouldReturnPrevious,
 }) => {
   const ref = React.useRef();
   const [stateCurrentPage, setPage] = useState(defaultPage);
@@ -98,7 +98,7 @@ const Pagination = ({
 
   useDebounce(
     () => {
-      if (shouldGetPageData) {
+      if (!shouldReturnPrevious) {
         getPageData();
       }
     },
@@ -107,7 +107,7 @@ const Pagination = ({
       currentPage,
       itemsPerPage,
       isFunction(theItems) ? null : theItems,
-      shouldGetPageData,
+      shouldReturnPrevious,
       ...watchList,
     ]
   );
@@ -172,7 +172,7 @@ Pagination.propTypes = {
   defaultPage: PropTypes.number,
   page: PropTypes.number,
   debounceTimeout: PropTypes.number,
-  shouldGetPageData: PropTypes.bool,
+  shouldReturnPrevious: PropTypes.bool,
 };
 
 Pagination.defaultProps = {
@@ -182,7 +182,7 @@ Pagination.defaultProps = {
   resetParams: [],
   defaultPage: 1,
   debounceTimeout: 0,
-  shouldGetPageData: true,
+  shouldReturnPrevious: false,
 };
 
 export default Pagination;

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useToggle } from '@availity/hooks';
 import {
   render,
+  wait,
   waitForElement,
   waitForDomChange,
   fireEvent,
@@ -203,12 +204,16 @@ describe('Pagination', () => {
     await waitForElement(() => getByTestId(`current-page`));
 
     // Called once after the pagination has loaded
-    expect(mockFunc).toHaveBeenCalledTimes(1);
+    await wait(() => {
+      expect(mockFunc).toHaveBeenCalledTimes(1);
+    });
 
     // Clicking the button will trigger a state update
     fireEvent.click(getByTestId('hello-btn'));
 
-    expect(mockFunc).toHaveBeenCalledTimes(3);
+    await wait(() => {
+      expect(mockFunc).toHaveBeenCalledTimes(3);
+    });
   });
 
   test('should reset page to 1 if resetParams updates', async () => {

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -513,7 +513,7 @@ describe('Pagination', () => {
     );
   });
 
-  it('does not fetch page data when shouldGetPageData is false', async () => {
+  it('does not fetch page data when shouldReturnPrevious is true', async () => {
     const getItems = jest.fn().mockResolvedValue({
       totalCount: 3,
       items: [
@@ -524,14 +524,17 @@ describe('Pagination', () => {
     });
 
     const ComponentWrapper = () => {
-      const [shouldGetPageData, setShouldGetPageData] = useState(false);
+      const [shouldReturnPrevious, setShouldReturnPrevious] = useState(true);
       return (
         <>
-          <Pagination items={getItems} shouldGetPageData={shouldGetPageData}>
+          <Pagination
+            items={getItems}
+            shouldReturnPrevious={shouldReturnPrevious}
+          >
             <button
               type="button"
-              data-testid="toggle-get-page-data-btn"
-              onClick={() => setShouldGetPageData(!shouldGetPageData)}
+              data-testid="toggle-return-previous-btn"
+              onClick={() => setShouldReturnPrevious(!shouldReturnPrevious)}
             >
               Toggle
             </button>
@@ -544,24 +547,24 @@ describe('Pagination', () => {
 
     expect(getItems).not.toHaveBeenCalled();
 
-    // Set shouldGetPageData to true
-    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+    // Set shouldReturnPrevious to true
+    fireEvent.click(getByTestId('toggle-return-previous-btn'));
 
     // Check getItems was called
     await wait(() => {
       expect(getItems).toHaveBeenCalledTimes(1);
     });
 
-    // Set shouldGetPageData to false
-    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+    // Set shouldReturnPrevious to false
+    fireEvent.click(getByTestId('toggle-return-previous-btn'));
 
     // Check getItems has still only been called one time
     await wait(() => {
       expect(getItems).toHaveBeenCalledTimes(1);
     });
 
-    // Set shouldGetPageData to true
-    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+    // Set shouldReturnPrevious to true
+    fireEvent.click(getByTestId('toggle-return-previous-btn'));
 
     // Check getItems has still only been called one time
     await wait(() => {

--- a/packages/pagination/src/__test__/Pagination.test.js
+++ b/packages/pagination/src/__test__/Pagination.test.js
@@ -512,4 +512,60 @@ describe('Pagination', () => {
       })
     );
   });
+
+  it('does not fetch page data when shouldGetPageData is false', async () => {
+    const getItems = jest.fn().mockResolvedValue({
+      totalCount: 3,
+      items: [
+        { value: '1', key: 1 },
+        { value: '2', key: 2 },
+        { value: '3', key: 3 },
+      ],
+    });
+
+    const ComponentWrapper = () => {
+      const [shouldGetPageData, setShouldGetPageData] = useState(false);
+      return (
+        <>
+          <Pagination items={getItems} shouldGetPageData={shouldGetPageData}>
+            <button
+              type="button"
+              data-testid="toggle-get-page-data-btn"
+              onClick={() => setShouldGetPageData(!shouldGetPageData)}
+            >
+              Toggle
+            </button>
+          </Pagination>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<ComponentWrapper />);
+
+    expect(getItems).not.toHaveBeenCalled();
+
+    // Set shouldGetPageData to true
+    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+
+    // Check getItems was called
+    await wait(() => {
+      expect(getItems).toHaveBeenCalledTimes(1);
+    });
+
+    // Set shouldGetPageData to false
+    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+
+    // Check getItems has still only been called one time
+    await wait(() => {
+      expect(getItems).toHaveBeenCalledTimes(1);
+    });
+
+    // Set shouldGetPageData to true
+    fireEvent.click(getByTestId('toggle-get-page-data-btn'));
+
+    // Check getItems has still only been called one time
+    await wait(() => {
+      expect(getItems).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/pagination/src/__test__/PaginationContent.test.js
+++ b/packages/pagination/src/__test__/PaginationContent.test.js
@@ -4,6 +4,7 @@ import {
   render,
   waitForElement,
   waitForDomChange,
+  wait,
   cleanup,
 } from '@testing-library/react';
 import Pagination from '../Pagination';
@@ -41,9 +42,11 @@ describe('Pagination Content', () => {
 
     expect(paginationContent).not.toBe(null);
 
-    items.forEach(item =>
-      expect(getByTestId(`item-${item.value}`)).toBeDefined()
-    );
+    items.forEach(async item => {
+      await wait(() => {
+        expect(getByTestId(`item-${item.value}`)).toBeDefined();
+      });
+    });
   });
 
   test('should render loading message', async () => {

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitForElement, cleanup } from '@testing-library/react';
+import { render, wait, waitForElement, cleanup } from '@testing-library/react';
 import Pagination from '../Pagination';
 import PaginationControls from '../PaginationControls';
 
@@ -111,12 +111,13 @@ describe('Pagination Controls', () => {
       </Pagination>
     );
 
-    const previous = getByTestId('pagination-control-previous');
+    await wait(() => {
+      const previous = getByTestId('pagination-control-previous');
 
-    expect(previous.firstChild.textContent).toMatch('‹ Prev');
+      expect(previous.firstChild.textContent).toMatch('‹ Prev');
+      const next = getByTestId('pagination-control-next');
 
-    const next = getByTestId('pagination-control-next');
-
-    expect(next.firstChild.textContent).toContain('Next ›');
+      expect(next.firstChild.textContent).toContain('Next ›');
+    });
   });
 });

--- a/packages/pagination/types/Pagination.d.ts
+++ b/packages/pagination/types/Pagination.d.ts
@@ -7,6 +7,8 @@ export interface PaginationProps {
   watchList?: any[];
   resetParams?: any[];
   defaultPage?: number;
+  debounceTimeout?: number;
+  shouldReturnPrevious?: boolean;
 }
 
 export interface PaginationContext<Item> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,6 +3606,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.4.tgz#f79720b4755aa197c2e15e982e2f438f5748e348"
   integrity sha512-WTfSE1Eauak/Nrg6cA9FgPTFvVawejsai6zXoq0QYTQ3mxONeRtGhKxa7wMlUzWWmzrmTeV+rwLjHgsCntdrsA==
 
+"@types/js-cookie@2.2.5":
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.5.tgz#38dfaacae8623b37cc0b0d27398e574e3fc28b1e"
+  integrity sha512-cpmwBRcHJmmZx0OGU7aPVwGWGbs4iKwVYchk9iuMtxNCA2zorwdaTz4GkLgs2WGxiRZRFKnV1k6tRUHX7tBMxg==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -4038,6 +4043,11 @@
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.8.2.tgz#056946ac41ade4885c576619c8d70c46c77e9683"
   integrity sha512-RV6+4hR29oMaPCvSYFUvzOvlsrg2s2k5NE9tNERs+4nFIC9dRXxs+lL2CcaRTbl3yQxKwAZ8Cd+qMI8aUu9TFw==
+
+"@xobotyi/scrollbar-width@1.9.4":
+  version "1.9.4"
+  resolved "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.4.tgz#a7dce20b7465bcad29cd6bbb557695e4ea7863cb"
+  integrity sha512-o12FCQt/X5n3pgKEWGpt0f/7Eg4mfv3uRwPUrctiOT8ZuxbH3cNLGWfH/8y6KxVJg4L2885ucuXQ6XECZzUiJA==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -18176,6 +18186,25 @@ react-transition-group@^2.2.1, react-transition-group@^2.3.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-use@^13.27.0:
+  version "13.27.0"
+  resolved "https://registry.npmjs.org/react-use/-/react-use-13.27.0.tgz#53a619dc9213e2cbe65d6262e8b0e76641ade4aa"
+  integrity sha512-2lyTyqJWyvnaP/woVtDcFS4B5pUYz0FQWI9pVHk/6TBWom2x3/ziJthkEn/LbCA9Twv39xSQU7Dn0zdIWfsNTQ==
+  dependencies:
+    "@types/js-cookie" "2.2.5"
+    "@xobotyi/scrollbar-width" "1.9.4"
+    copy-to-clipboard "^3.2.0"
+    fast-deep-equal "^3.1.1"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.2.1"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^2.1.0"
+    ts-easing "^0.2.0"
+    tslib "^1.10.0"
 
 react-use@^13.8.0:
   version "13.24.0"


### PR DESCRIPTION
The usefulness of the `debounceTimeout` prop is self-explanatory. It does add `react-use` as a dependency of the pagination package. https://bundlephobia.com/result?p=react-use@13.27.0

The usefulness of `shouldGetPageData` is a little less clear. On one hand, we could leave it up to user-land for the `items` prop to be a function that returns an empty array when page data should not be fetched. However, `shouldGetPageData` allows for the _previous_ items to be rendered when `shouldGetPageData` is false. For example, say `<Pagination />` is rendering the results of a fuzzy search, and it should only search when the length of `q` is `0` or `>= 2`. As the user types, when `q` is of length `1`, the results from when `q` was length `0` should be returned. `shouldGetPageData` allows you to achieve this easily without having to call the `usePagination` hook. 
