### PR TITLE
Perf/datepicker

### DIFF
--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -42,7 +42,6 @@
     "@availity/icon": "^0.7.0",
     "@availity/yup": "^2.0.0",
     "classnames": "^2.2.6",
-    "lodash.get": "^4.4.2",
     "lodash.pick": "^4.4.0",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -14,6 +14,10 @@ import { isOutsideRange, limitPropType, buildYearPickerOptions } from './utils';
 
 export const isoDateFormat = 'YYYY-MM-DD';
 
+const yearPickerStyles = {
+  minWidth: '100%', // 4 digit years not wide enough to fill column
+};
+
 const AvDate = ({
   className,
   name,
@@ -133,9 +137,7 @@ const AvDate = ({
           <select
             data-testid="yearPicker"
             aria-label="year picker"
-            style={{
-              minWidth: '100%', // 4 digit years not wide enough to fill column
-            }}
+            style={yearPickerStyles}
             value={month.year()}
             onChange={e => {
               onYearSelect(month, e.target.value);

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -50,14 +50,14 @@ const AvDate = ({
   )}-picker`;
 
   // For updating when we delete the current input
-  const onInputChange = async value => {
+  const onInputChange = value => {
     const date = moment(
       value,
       [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
       true
     );
 
-    await setFieldValue(
+    setFieldValue(
       name,
       date.isValid() ? date.format(isoDateFormat) : '',
       metadata.touched
@@ -70,7 +70,7 @@ const AvDate = ({
     }
   };
 
-  const onPickerChange = async value => {
+  const onPickerChange = value => {
     if (value === null) return;
 
     let val = value;
@@ -78,18 +78,18 @@ const AvDate = ({
       val = val.format(isoDateFormat);
     }
 
-    await setFieldValue(name, val, true);
+    setFieldValue(name, val, true);
 
-    await setFieldTouched(name, true);
+    setFieldTouched(name, true);
 
     if (onChange) {
       onChange(val);
     }
   };
 
-  const onFocusChange = async ({ focused }) => {
+  const onFocusChange = ({ focused }) => {
     if (!focused) {
-      await setFieldTouched(name, true);
+      setFieldTouched(name, true);
     }
 
     if (focused !== undefined && isFocused !== focused) {

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -91,7 +91,7 @@ const DateRange = ({
   );
 
   // For updating when we delete the current input
-  const onInputChange = async val => {
+  const onInputChange = val => {
     const isStart = focusedInput === 'startDate';
     const date = moment(
       val,
@@ -101,7 +101,7 @@ const DateRange = ({
 
     const valueToSet = date.isValid() ? date.format(format) : null;
 
-    await setFieldValue(
+    setFieldValue(
       name,
       {
         [startKey]: isStart ? valueToSet : startValue,
@@ -117,10 +117,10 @@ const DateRange = ({
     }
   };
 
-  const onDatesChange = async ({ startDate, endDate }) => {
+  const onDatesChange = ({ startDate, endDate }) => {
     const _startDate = (startDate && startDate.format(format)) || startValue;
     const _endDate = (endDate && endDate.format(format)) || endValue;
-    await setFieldValue(
+    setFieldValue(
       name,
       {
         [startKey]: _startDate,
@@ -130,7 +130,7 @@ const DateRange = ({
     );
 
     if (_startDate && _endDate) {
-      await setFieldTouched(name, true);
+      setFieldTouched(name, true);
     }
 
     if (onChange) {
@@ -141,7 +141,7 @@ const DateRange = ({
     }
   };
 
-  const syncDates = async () => {
+  const syncDates = () => {
     if (!metadata.touched) {
       let value;
 
@@ -150,7 +150,7 @@ const DateRange = ({
       }
 
       if (value) {
-        await setFieldValue(
+        setFieldValue(
           name,
           {
             [startKey]: value,
@@ -158,14 +158,14 @@ const DateRange = ({
           },
           true
         );
-        await setFieldTouched(name, true);
+        setFieldTouched(name, true);
       }
     }
   };
 
-  const onFocusChange = async input => {
-    if (!input && !autoSync) await setFieldTouched(name, true);
-    if (autoSync) await syncDates();
+  const onFocusChange = input => {
+    if (!input && !autoSync) setFieldTouched(name, true);
+    if (autoSync) syncDates();
     if (focusedInput !== input) setFocusedInput(input);
     if (onPickerFocusChange) onPickerFocusChange({ focusedInput: input });
   };

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -92,7 +92,7 @@ const DateRange = ({
 
   // For updating when we delete the current input
   const onInputChange = val => {
-    const isStart = focusedInput === 'startDate';
+    const isStart = focusedInput === startKey;
     const date = moment(
       val,
       [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
@@ -111,7 +111,7 @@ const DateRange = ({
     );
 
     if (focusedInput && isStart && date.isValid()) {
-      setFocusedInput('endDate');
+      setFocusedInput(endKey);
     } else if (focusedInput && !isStart && date.isValid()) {
       setFocusedInput();
     }

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -46,6 +46,14 @@ const relativeRanges = {
   },
 };
 
+const yearPickerStyles = {
+  minWidth: '100%', // 4 digit years not wide enough to fill column
+};
+
+const hiddenInputStyles = {
+  display: 'none',
+};
+
 const DateRange = ({
   id,
   min,
@@ -268,9 +276,7 @@ const DateRange = ({
           <select
             data-testid="yearPicker"
             aria-label="year picker"
-            style={{
-              minWidth: '100%', // 4 digit years not wide enough to fill column
-            }}
+            style={yearPickerStyles}
             value={month.year()}
             onChange={e => {
               onYearSelect(month, e.target.value);
@@ -295,7 +301,7 @@ const DateRange = ({
 
   return (
     <>
-      <Input name={name} style={{ display: 'none' }} className={classes} />
+      <Input name={name} style={hiddenInputStyles} className={classes} />
       <InputGroup
         disabled={attributes.disabled}
         className={classes}

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -5,7 +5,6 @@ import { InputGroup, Input, Button, Row, Col } from 'reactstrap';
 import { DateRangePicker } from 'react-dates';
 import classNames from 'classnames';
 import { useField, useFormikContext } from 'formik';
-import get from 'lodash.get';
 import pick from 'lodash.pick';
 import moment from 'moment';
 import '../polyfills';
@@ -80,8 +79,8 @@ const DateRange = ({
   const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
   const endId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-end`;
 
-  const startValue = get(value, startKey);
-  const endValue = get(value, endKey);
+  const startValue = value[startKey] || '';
+  const endValue = value[endKey] || '';
 
   const startValueMoment = useMemo(
     () => moment(startValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD']),

--- a/packages/date/src/utils.js
+++ b/packages/date/src/utils.js
@@ -57,15 +57,6 @@ export const limitPropType = PropTypes.oneOfType([
   PropTypes.shape({ _d: PropTypes.string, _isValid: PropTypes.func }), // moment prop type
 ]);
 
-export const isSameDay = (a, b) => {
-  if (!moment.isMoment(a) || !moment(b)) return false;
-  // Compare least significant, most likely to change units first
-  // Moment's isSame clones moment inputs and is a tad slow
-  return (
-    a.date() === b.date() && a.month() === b.month() && a.year() === b.year()
-  );
-};
-
 export const buildYearPickerOptions = (
   min,
   max,

--- a/packages/date/tests/DateRange.test.js
+++ b/packages/date/tests/DateRange.test.js
@@ -496,7 +496,7 @@ describe('DateRange', () => {
 
     await wait(() => {
       expect(onChange.mock.calls[0][0]).toStrictEqual({
-        endDate: undefined,
+        endDate: '',
         startDate: `${max.year()}-12-25`,
       });
 


### PR DESCRIPTION
- remove async/await from synchronous functions
- fix bug where custom `startKey` and `endKey` couldn't set `focusedInput`
- use style objects to avoid them getting recreated on every render (even if props are the same)
- refactor `relativeRanges` for fewer and faster comparisons
- batch validation updates for Date - validation runs once in a `useEffect`
- batch validation updates for DateRange - validation runs once in a `useEffect`
- memoize current start and end moments instead of computing multiple times per render
- remove `lodash.get` from package by using `value[key] || ''` instead