### PR TITLE
fix(pagination): allow custom getResult for AvResourcePagination

### DIFF
--- a/packages/pagination/src/AvResourcePagination.js
+++ b/packages/pagination/src/AvResourcePagination.js
@@ -28,7 +28,7 @@ const AvResourcePagination = ({
 
     const resp = await resource.postGet(params, parameters || {});
 
-    const useGetResult = resource.getResult || getResult;
+    const useGetResult = getResult || resource.getResult;
 
     const items =
       (typeof useGetResult === 'function'

--- a/packages/pagination/src/__test__/AvResourcePagination.test.js
+++ b/packages/pagination/src/__test__/AvResourcePagination.test.js
@@ -189,4 +189,32 @@ describe('AvResourcePagination', () => {
       );
     }); */
   });
+
+  test('should use custom getResult when provided', async () => {
+    const { getByTestId } = render(
+      <AvResourcePagination
+        resource={resource}
+        itemsPerPage={50}
+        getResult={data => {
+          return data.notifications.filter(
+            notification => notification.id === paginationData[0].id
+          );
+        }}
+      >
+        <PaginationJson />
+      </AvResourcePagination>
+    );
+
+    const paginationCon = await waitForElement(() =>
+      getByTestId('pagination-con')
+    );
+
+    expect(paginationCon).toBeDefined();
+
+    expect(JSON.parse(paginationCon.textContent)).toEqual(
+      expect.objectContaining({
+        page: data.slice(0, 1),
+      })
+    );
+  });
 });


### PR DESCRIPTION
Switching `useGetResult` to `getResult || resource.getResult` allows user to pass in custom `getResult`. Before, all resources that extended `AvApi` would have their own `getResult`.