### PR TITLE
fix(upload): multiple-same-file-upload-warining

### DIFF
--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -45,6 +45,7 @@ class Upload extends Component {
 
   setFiles = files => {
     let selectedFiles = [];
+    const id = uuid();
     for (let i = 0; i < files.length; i++) {
       selectedFiles[i] = files[i];
     }
@@ -67,7 +68,7 @@ class Upload extends Component {
           maxSize: this.props.maxSize,
           allowedFileNameCharacters: this.props.allowedFileNameCharacters,
         });
-        upload.id = `${upload.id}-${uuid()}`;
+        upload.id = `${upload.id}-${id}`;
         upload.start();
         if (this.props.onFileUpload) this.props.onFileUpload(upload);
         return upload;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

This should fix the warning 

```
Warning: Encountered two children with the same key, `tus-MedicalRecordTypeCodedocx-applicationvndopenxmlformats-officedocumentwordprocessingmldocument-13971-1585681556491-1340000741`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in tbody (at FileList.js:45)
    in table (created by Table)
    in Table (at FileList.js:27)
    in FileList (at Upload.js:210)
    in Upload (at Attachments.js:191)
    in div (at Attachments.js:190)
    in div (at Attachments.js:184)
    in div (created by FormGroup)
    in FormGroup (created by AvGroup)
    in AvGroup (at Attachments.js:169)
    in form (created by Form)
    in Form (created by AvForm)
    in AvForm (at Attachments.js:168)
    in Attachments (at Inquiry.js:112)
    in div (created by CardBody)
    in CardBody (at Inquiry.js:108)
    in div (created by Card)
    in Card (at Inquiry.js:88)
    in div (created by BlockUi)
    in BlockUi (at Inquiry.js:87)
    in Inquiry (created by Context.Consumer)
    in withRouter(Inquiry) (at layout/index.js:36)
    in Route (at layout/index.js:33)
    in Switch (at layout/index.js:17)
    in Route (at layout/index.js:51)
    in Router (created by BrowserRouter)
    in BrowserRouter (at layout/index.js:50)
    in div (at layout/index.js:48)
    in Layout (at App.js:138)
    in App (created by HotExportedApp)
    in AppContainer (created by HotExportedApp)
    in HotExportedApp (at app/index.js:9)
```

while uploading multiple of the same files. 

