### PR TITLE
refactor(react-docs): update yup usage and MomentDateRange in docs

### DIFF
--- a/docs/source/form/date/components/date-field.md
+++ b/docs/source/form/date/components/date-field.md
@@ -9,8 +9,8 @@ The same as `FormikDate` but with a `Label` that appears above input and a `Feed
 ```jsx live=true viewCode=true
 import { Form } from '@availity/form';
 import FormikDate from '@availity/date';
-import { object } from 'yup';
 import { avDate } from '@availity/yup';
+import * as yup from 'yup';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">
   <Form
@@ -18,7 +18,7 @@ import { avDate } from '@availity/yup';
       dateOfService: '',
     }}
     onSubmit={values => console.log(values)}
-    validationSchema={object().shape({
+    validationSchema={yup.object().shape({
       dateOfService: avDate().required(),
     })}
   >

--- a/docs/source/form/date/components/date-range-field.md
+++ b/docs/source/form/date/components/date-range-field.md
@@ -9,17 +9,20 @@ The same as `DateRange` but with a `Label` that appears above the input and a `F
 ```jsx live=true viewCode=true
 import { Form } from '@availity/form';
 import { DateRange } from '@availity/date';
-import { object } from 'yup';
 import { dateRange } from '@availity/yup';
 import moment from 'moment';
+import * as yup from 'yup';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">
   <Form
     initialValues={{
-      dateOfService: '',
+      dateOfService: {
+        startDate: moment().format('YYYY-MM-DD'),
+        endDate: moment().format('YYYY-MM-DD')
+      },
     }}
     onSubmit={values => console.log(values)}
-    validationSchema={object().shape({
+    validationSchema={yup.object().shape({
       dateOfService: dateRange(
           {
             min: moment()

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -9,9 +9,9 @@ A date range, consisting of 2 fields, a start date and an end date, without a `L
 ```jsx live=true viewCode=true
 import { Form } from '@availity/form';
 import { DateRange } from '@availity/date';
-import { object } from 'yup';
 import { dateRange } from '@availity/yup';
 import moment from 'moment';
+import * as yup from 'yup';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">
   <Form
@@ -19,23 +19,23 @@ import moment from 'moment';
       dateOfService: undefined,
     }}
     onSubmit={values => console.log(values)}
-    validationSchema={object().shape({
+    validationSchema={yup.object().shape({
       dateOfService: dateRange(
-          {
-            min: moment()
-              .subtract(7, 'day')
-              .format('MM/DD/YYYY'),
-            max: moment()
-              .add(7, 'day')
-              .format('MM/DD/YYYY'),
-            format: 'MM/DD/YYYY',
-          },
-          `Date must be between ${moment()
+        {
+          min: moment()
             .subtract(7, 'day')
-            .format('MM/DD/YYYY')} and ${moment()
+            .format('MM/DD/YYYY'),
+          max: moment()
             .add(7, 'day')
-            .format('MM/DD/YYYY')}`
-        )
+            .format('MM/DD/YYYY'),
+          format: 'MM/DD/YYYY',
+        },
+        `Date must be between ${moment()
+          .subtract(7, 'day')
+          .format('MM/DD/YYYY')} and ${moment()
+          .add(7, 'day')
+          .format('MM/DD/YYYY')}`
+      )
         .typeError('This field is invalid.')
         .required('This field is required.'),
     })}
@@ -72,7 +72,6 @@ Key to return end date as on form submit. Should match the yup schema `endKey`.
 ### `min?: string | LimitType`
 
 Used in conjunction with `max` to derive `isOutsideRange` prop from `react-dates` and selectable year options in datepicker. Dates outside the allowed range will not be clickable in datepicker.
-
 
 ```json hideCopy=true
 {
@@ -120,10 +119,12 @@ How to format date value in `onSubmit` callback. Must be a format recognized by 
 
 Toggle whether the calendar is shown.
 
-### `datePickerProps?: SingleDatePickerShape`
+### `datepickerProps?: SingleDatePickerShape`
+
 Props to be spread onto the datepicker component from [react-dates](https://github.com/airbnb/react-dates#singledatepicker).
 
 ### `autoSync?: boolean`
+
 Toggle whether the other date should be automatically synced to the selected date when focus changes. Dates are only auto synced the first time the input is touched and if the date field to auto sync is empty
 
 Props to be spread onto the datepicker component from [react-dates](https://github.com/airbnb/react-dates#singledatepicker).
@@ -134,7 +135,7 @@ Show preset date ranges when calendar is visible. Accepts `boolean` to display d
 
 ```ts hideCopy=true
 interface MomentDateRange {
-  startDate: (moment: Moment) => Moment;
-  endDate: (moment: Moment) => Moment;
+  startDate: Moment;
+  endDate: Moment;
 }
 ```

--- a/docs/source/form/date/components/date.md
+++ b/docs/source/form/date/components/date.md
@@ -4,17 +4,17 @@ title: <Date /> ( Default Export )
 
 Date picker without a `Label` or `Feedback`
 
-## Example
+If `initialValues` need to be specified for a Date or DateRange, they should be in the format `"YYYY-MM-DD"` or `moment().format("YYYY-MM-DD")`, even though dates are displayed to the user as `MM/DD/YYYY`
 
-import '@availity/date/styles.scss';
+## Example
 
 ```jsx live=true viewCode=true
 import { Form } from '@availity/form';
-import { Button } from 'reactstrap';
 import { avDate } from '@availity/yup';
-import { object } from 'yup';
+import { Button } from 'reactstrap';
 import Date from '@availity/date';
 import moment from 'moment';
+import * as yup from 'yup';
 
 <div className="w-100 d-flex flex-row justify-content-around align-items-center">
   <Form
@@ -22,7 +22,7 @@ import moment from 'moment';
       dateOfService: '',
     }}
     onSubmit={values => console.log(values)}
-    validationSchema={object().shape({
+    validationSchema={yup.object().shape({
       dateOfService: avDate().required(),
     })}
   >

--- a/docs/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
+++ b/docs/src/@availity/gatsby-theme-docs/components/LiveCodeScopes.js
@@ -33,7 +33,7 @@ import { Disclaimer, Agreement } from '@availity/typography';
 import * as yup from 'yup';
 import moment from 'moment';
 import '@availity/favorites/style.scss';
-import '@availity/yup';
+import { avDate, dateRange } from '@availity/yup';
 import { Phone, validatePhone } from '@availity/phone';
 
 const scopes = {
@@ -77,6 +77,8 @@ const scopes = {
   Input,
   Field,
   yup,
+  avDate,
+  dateRange,
   moment,
   Phone,
   validatePhone,

--- a/packages/date/typings/DateRange.d.ts
+++ b/packages/date/typings/DateRange.d.ts
@@ -4,8 +4,8 @@ import { Moment } from 'moment';
 import { limitType, limitTypeAlt, DateBaseProps } from './Date';
 
 interface MomentDateRange {
-  startDate: (moment: Moment) => Moment;
-  endDate: (moment: Moment) => Moment;
+  startDate: Moment;
+  endDate: Moment;
 }
 
 export interface DateRangeProps extends DateRangePicker, DateBaseProps {


### PR DESCRIPTION
Fixes Date components not rendering in docs. Clarifies how `initialValues` and date ranges should be specified.