### PR TITLE
adds disabled prop to upload and form-upload packages

### DIFF
--- a/docs/source/form/upload/file-picker-btn.md
+++ b/docs/source/form/upload/file-picker-btn.md
@@ -38,6 +38,10 @@ Callback when the user has selected a file or multiple files.
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt.
 
+### `disabled?: boolean`
+
+Disable the file input **Default:** `false`.
+
 ### `allowedFileTypes?: Array<string>`
 
 The file types you want to restrict uploading to. eg: `['.jpeg', '.jpg']`.
@@ -45,3 +49,4 @@ The file types you want to restrict uploading to. eg: `['.jpeg', '.jpg']`.
 ### `maxSize?: number`
 
 The maximum file size (in bytes) for a file to be uploaded.
+

--- a/docs/source/form/upload/upload.md
+++ b/docs/source/form/upload/upload.md
@@ -66,6 +66,10 @@ The maximum number of files allowed to be uploaded. `0` (or a falsey value) mean
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt. **Default:** `true`.
 
+### `disabled?: boolean`
+
+Disable the file input **Default:** `false`.
+
 ### `showFileDrop?: boolean`
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).

--- a/packages/form-upload/Upload.js
+++ b/packages/form-upload/Upload.js
@@ -150,6 +150,7 @@ const Upload = ({
           allowedFileTypes={allowedFileTypes}
           maxSize={maxSize}
           name={name}
+          disabled={rest.disabled}
         >
           {text}
         </FilePickerBtn>
@@ -184,10 +185,12 @@ Upload.propTypes = {
   showFileDrop: PropTypes.bool,
   feedbackClass: PropTypes.string,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 Upload.defaultProps = {
   multiple: true,
+  disabled: false,
   showFileDrop: false,
 };
 

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -67,6 +67,10 @@ The maximum number of files allowed to be uploaded. `0` (or a falsey value) mean
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt. **Default:** `true`.
 
+### `disabled?: boolean`
+
+Disable the file input **Default:** `false`.
+
 ### `showFileDrop?: boolean`
 
 Set as true to show a drag and drop file upload option instead of a button (file explorer still available on click).
@@ -155,6 +159,10 @@ Callback when the user has selected a file or multiple files.
 ### `multiple?: boolean`
 
 Indicates that the user will be allowed to select multiple files when selecting files from the OS prompt.
+
+### `disabled?: boolean`
+
+Disable the file input **Default:** `false`.
 
 ### `allowedFileTypes?: Array<string>`
 

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -2,6 +2,7 @@ import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import UploadCore from '@availity/upload-core';
 import Dropzone from 'react-dropzone';
+import { InputGroup } from 'reactstrap';
 import uuid from 'uuid/v4';
 import FilePickerBtn from './FilePickerBtn';
 import FileList from './FileList';
@@ -146,6 +147,7 @@ class Upload extends Component {
       maxSize,
       children,
       showFileDrop,
+      disabled,
     } = this.props;
     const { files } = this.state;
 
@@ -161,26 +163,28 @@ class Upload extends Component {
       if (showFileDrop) {
         fileAddArea = (
           <div>
-            <Dropzone
-              onDrop={this.onDrop}
-              multiple={multiple}
-              maxSize={maxSize}
-              className="file-drop"
-              activeClassName="file-drop-active"
-              accept={allowedFileTypes}
-            >
-              {({ getRootProps, getInputProps }) => (
-                <section>
-                  <div {...getRootProps()}>
-                    <input data-testid="file-picker" {...getInputProps()} />
-                    <p>
-                      <strong>Drag and Drop</strong>
-                    </p>
-                    {text}
-                  </div>
-                </section>
-              )}
-            </Dropzone>
+            <InputGroup disabled={disabled}>
+              <Dropzone
+                onDrop={this.onDrop}
+                multiple={multiple}
+                maxSize={maxSize}
+                className="file-drop"
+                activeClassName="file-drop-active"
+                accept={allowedFileTypes}
+              >
+                {({ getRootProps, getInputProps }) => (
+                  <section>
+                    <div {...getRootProps()}>
+                      <input data-testid="file-picker" {...getInputProps()} />
+                      <p>
+                        <strong>Drag and Drop</strong>
+                      </p>
+                      {text}
+                    </div>
+                  </section>
+                )}
+              </Dropzone>
+            </InputGroup>
           </div>
         );
       } else {
@@ -192,6 +196,7 @@ class Upload extends Component {
             multiple={multiple}
             allowedFileTypes={allowedFileTypes}
             maxSize={maxSize}
+            disabled={disabled}
           >
             {text}
           </FilePickerBtn>
@@ -226,11 +231,13 @@ Upload.propTypes = {
   name: PropTypes.string,
   showFileDrop: PropTypes.bool,
   getDropRejectionMessage: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 Upload.defaultProps = {
   multiple: true,
   showFileDrop: false,
+  disabled: false,
 };
 
 export default Upload;

--- a/storybook/stories/upload.stories.js
+++ b/storybook/stories/upload.stories.js
@@ -89,6 +89,7 @@ storiesOf('Components|Upload', module)
         bucketId="b"
         customerId="c"
         multiple={boolean('Multiple File Select', Upload.defaultProps.multiple)}
+        disabled={boolean('Disabled', Upload.defaultProps.disabled)}
         max={number('Max number of files', 0)}
         allowedFileTypes={array(
           'Allowed File Types',
@@ -102,13 +103,14 @@ storiesOf('Components|Upload', module)
   .add('picker button', () => (
     <div className="py-3">
       <p>
-        This component does not do much out-of-the-box, it mostly just button
-        that triggers a file input which ensures the value gets reset after a
-        file is chosen so that the user can chose the same file again.
+        This component does not do much out-of-the-box, it is mostly just a
+        button that triggers a file input which ensures the value gets reset
+        after a file is chosen so that the user can choose the same file again.
       </p>
       <FilePickerBtn
         allowedFileTypes={array('Allowed File Types', [], ',')}
         maxSize={number('Max File Size', 0, { min: 0 }) || undefined}
+        disabled={boolean('Disabled', Upload.defaultProps.disabled)}
       />
     </div>
   ))
@@ -135,6 +137,7 @@ storiesOf('Components|Upload', module)
         bucketId="b"
         customerId="c"
         multiple={boolean('Multiple File Select', Upload.defaultProps.multiple)}
+        disabled={boolean('Disabled', Upload.defaultProps.disabled)}
         max={number('Max number of files', 0)}
         allowedFileTypes={array(
           'Allowed File Types',
@@ -160,6 +163,7 @@ storiesOf('Components|Upload', module)
         bucketId="b"
         customerId="c"
         allowedFileNameCharacters={text('REGEX', '-_a-zA-z0-9')}
+        disabled={boolean('Disabled', Upload.defaultProps.disabled)}
       />
     </div>
   ))

--- a/yarn.lock
+++ b/yarn.lock
@@ -18558,7 +18558,7 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^11.0.1:
+react-dropzone@^11.0.0, react-dropzone@^11.0.1:
   version "11.0.1"
   resolved "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.0.1.tgz#c8b6a6ed02576e5365af2e2a3f3b31df31feb213"
   integrity sha512-x/6wqRHaR8jsrNiu/boVMIPYuoxb83Vyfv77hO7/3ZRn8Pr+KH5onsCsB8MLBa3zdJl410C5FXPUINbu16XIzw==


### PR DESCRIPTION
gives the developer the ability to disable the file input. no changes are required to `FilePickerBtn` as we already spread `rest` onto the `<Button />`. 