### PR TITLE
feat(select): add permissionsIds to organizationSelect postGetArgs

### DIFF
--- a/docs/source/form/select/components/organization-select.md
+++ b/docs/source/form/select/components/organization-select.md
@@ -26,6 +26,7 @@ import '@availity/yup';
     parameters={{
       regionId: 'FL',
     }}
+    // permission 1111 with resource 1234 OR permission 2222 with resource 4321 is required
     permissionIds={['1111', '2222']}
     resourceIds={['1234', '4321']}
   />
@@ -42,4 +43,12 @@ Extends [ResourceSelect Props](/form/select/components/resource-select/#props).
 
 ### `resourceIds?: string | Array<string>`
 
-The `organizations` API from `sdk-js` accepts `permissionIds` and `resourceIds` props inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. If `additionalPostGetArgs.permissionsIds` exists, these values will be used over `parameters.permissionId`. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to.
+The `organizations` API from `sdk-js` accepts a `resourceIds` prop inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to. The location of `resourceIds` values must match the locations of the `permissionIds`
+
+Example: resource `A` or `B` are required under permission `C` -> permissionIds: ['C'], resourcesIds: ['A', 'B']
+
+### `permissionIds: string | Array<string>`
+
+The `organizations` API from `sdk-js` accepts a `permissionIds` prop inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When used with `resourceIds`, the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. If `additionalPostGetArgs.permissionsIds` exists, these values will be used over `parameters.permissionId`. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to. AND logic is enforced by putting permissions in an array together.
+
+Example: resource `A` under permission `C` AND resource `B` under permission `D` are required -> permissionIds: [ ['C', 'D'] ], resourceIds: [ ['A', 'B'] ]

--- a/docs/source/form/select/components/organization-select.md
+++ b/docs/source/form/select/components/organization-select.md
@@ -24,16 +24,16 @@ import '@availity/yup';
     id="organizations"
     name="organizations"
     parameters={{
-      permissionId: ['1111', '2222'],
       regionId: 'FL',
     }}
+    permissionIds={['1111', '2222']}
     resourceIds={['1234', '4321']}
   />
 
   <Button color="primary" type="submit">
     Submit
   </Button>
-</Form>
+</Form>;
 ```
 
 ## Props
@@ -42,4 +42,4 @@ Extends [ResourceSelect Props](/form/select/components/resource-select/#props).
 
 ### `resourceIds?: string | Array<string>`
 
-The `organizations` API from `sdk-js` accepts a `resourceIds` prop inside of `additionalPostGetArgs` that can be either a string or an array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, and the `parameters` object contains one or many permissions in `permissionId`, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionId` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to.
+The `organizations` API from `sdk-js` accepts `permissionIds` and `resourceIds` props inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. If `additionalPostGetArgs.permissionsIds` exists, these values will be used over `parameters.permissionId`. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to.

--- a/docs/source/form/select/components/organization-select.md
+++ b/docs/source/form/select/components/organization-select.md
@@ -25,6 +25,8 @@ import '@availity/yup';
     name="organizations"
     parameters={{
       regionId: 'FL',
+      // permissionId can still be used here if the additionalPostGetArgs logic is not being used
+      permissionId: ['1111', '2222'],
     }}
     // permission 1111 with resource 1234 OR permission 2222 with resource 4321 is required
     permissionIds={['1111', '2222']}

--- a/docs/source/form/select/components/organization-select.md
+++ b/docs/source/form/select/components/organization-select.md
@@ -28,7 +28,7 @@ import '@availity/yup';
       // permissionId can still be used here if the additionalPostGetArgs logic is not being used
       permissionId: ['1111', '2222'],
     }}
-    // permission 1111 with resource 1234 OR permission 2222 with resource 4321 is required
+    // permission 1111 OR 2222, with resource 1234 OR 4321 is required for each organization
     permissionIds={['1111', '2222']}
     resourceIds={['1234', '4321']}
   />
@@ -45,7 +45,7 @@ Extends [ResourceSelect Props](/form/select/components/resource-select/#props).
 
 ### `resourceIds?: string | Array<string>`
 
-The `organizations` API from `sdk-js` accepts a `resourceIds` prop inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to. The location of `resourceIds` values must match the locations of the `permissionIds`
+The `organizations` API from `sdk-js` accepts a `resourceIds` prop inside of `additionalPostGetArgs` that can be either a string or nested array of strings. When `AvOrganizationSelect` has a `resourceIds` prop, then the results of the `postGet` call to `organizations` will be filtered, containing only organizations that have the specified permissions and resources. This is useful when a payer space app is restricted to permission `A` and resource `B`, a user can pass `A` and `B` as `permissionIds` and `resourceIds` into `AvOrganizationSelect` and expect the dropdown to only contain authorized organizations for that user in that app, instead of all the organizations that user belongs to. AND logic is enforced by putting resources in an array together.
 
 Example: resource `A` or `B` are required under permission `C` -> permissionIds: ['C'], resourcesIds: ['A', 'B']
 

--- a/packages/select/custom-resources/AvOrganizationSelect.js
+++ b/packages/select/custom-resources/AvOrganizationSelect.js
@@ -29,20 +29,36 @@ const AvOrganizationSelect = ({
 
 AvOrganizationSelect.propTypes = {
   resourceIds: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.arrayOf(
+          PropTypes.oneOfType([
+            PropTypes.arrayOf(
+              PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+            ),
+            PropTypes.string,
+            PropTypes.number,
+          ])
+        ),
+        PropTypes.string,
+        PropTypes.number,
+      ])
+    ),
     PropTypes.string,
     PropTypes.number,
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.arrayOf(PropTypes.number),
-    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
-    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
   ]),
   permissionIds: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.arrayOf(
+          PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        ),
+        PropTypes.string,
+        PropTypes.number,
+      ])
+    ),
     PropTypes.string,
     PropTypes.number,
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.arrayOf(PropTypes.number),
-    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
-    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
   ]),
   name: PropTypes.string.isRequired,
 };

--- a/packages/select/custom-resources/AvOrganizationSelect.js
+++ b/packages/select/custom-resources/AvOrganizationSelect.js
@@ -30,13 +30,19 @@ const AvOrganizationSelect = ({
 AvOrganizationSelect.propTypes = {
   resourceIds: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.number),
     PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
   ]),
   permissionIds: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.number),
     PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
   ]),
   name: PropTypes.string.isRequired,
 };

--- a/packages/select/custom-resources/AvOrganizationSelect.js
+++ b/packages/select/custom-resources/AvOrganizationSelect.js
@@ -8,11 +8,16 @@ const OrganizationSelect = ResourceSelect.create({
   labelKey: 'name',
 });
 
-const AvOrganizationSelect = ({ name, resourceIds, ...props }) => {
+const AvOrganizationSelect = ({
+  name,
+  resourceIds,
+  permissionIds,
+  ...props
+}) => {
   return (
     <OrganizationSelect
       name={name}
-      additionalPostGetArgs={resourceIds ? { resourceIds } : undefined}
+      additionalPostGetArgs={{ resourceIds, permissionIds }}
       {...props}
     />
   );
@@ -22,6 +27,12 @@ AvOrganizationSelect.propTypes = {
   resourceIds: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+  ]),
+  permissionIds: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   ]),
   name: PropTypes.string.isRequired,
 };

--- a/packages/select/custom-resources/AvOrganizationSelect.js
+++ b/packages/select/custom-resources/AvOrganizationSelect.js
@@ -17,7 +17,11 @@ const AvOrganizationSelect = ({
   return (
     <OrganizationSelect
       name={name}
-      additionalPostGetArgs={{ resourceIds, permissionIds }}
+      additionalPostGetArgs={
+        resourceIds || permissionIds
+          ? { resourceIds, permissionIds }
+          : undefined
+      }
       {...props}
     />
   );

--- a/packages/select/custom-resources/AvOrganizationSelect.js
+++ b/packages/select/custom-resources/AvOrganizationSelect.js
@@ -32,13 +32,7 @@ AvOrganizationSelect.propTypes = {
     PropTypes.arrayOf(
       PropTypes.oneOfType([
         PropTypes.arrayOf(
-          PropTypes.oneOfType([
-            PropTypes.arrayOf(
-              PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-            ),
-            PropTypes.string,
-            PropTypes.number,
-          ])
+          PropTypes.oneOfType([PropTypes.string, PropTypes.number])
         ),
         PropTypes.string,
         PropTypes.number,

--- a/packages/select/resources.d.ts
+++ b/packages/select/resources.d.ts
@@ -12,6 +12,19 @@ declare class AvRegionSelect<T> extends React.Component<
   public static create<T>(defaults: AvRegionSelectProps<T>): AvRegionSelect<T>;
 }
 
+export interface AvOrganizationSelectProps<T> extends ResourceSelectProps<T> {
+  resourceIds?: [[string | number] | string | number] | string | number;
+  permissionIds?: [[string | number] | string | number] | string | number;
+}
+
+declare class AvOrganizationSelect<T> extends React.Component<
+  AvOrganizationSelectProps<T>
+> {
+  public static create<T>(
+    defaults: AvOrganizationSelectProps<T>
+  ): AvOrganizationSelect<T>;
+}
+
 interface PrebuiltSelectProps<T>
   extends Omit<ResourceSelectProps<T>, 'resource'> {}
 
@@ -21,7 +34,7 @@ export default ResourceSelect;
 
 export {
   PrebuiltSelect as AvProviderSelect,
-  PrebuiltSelect as AvOrganizationSelect,
+  AvOrganizationSelect,
   PrebuiltSelect as AvPermissionSelect,
   PrebuiltSelect as AvNavigationSelect,
   PrebuiltSelect as AvUserSelect,

--- a/packages/select/resources.d.ts
+++ b/packages/select/resources.d.ts
@@ -12,9 +12,11 @@ declare class AvRegionSelect<T> extends React.Component<
   public static create<T>(defaults: AvRegionSelectProps<T>): AvRegionSelect<T>;
 }
 
+export type StringOrNumber = string | number;
+
 export interface AvOrganizationSelectProps<T> extends ResourceSelectProps<T> {
-  resourceIds?: [[string | number] | string | number] | string | number;
-  permissionIds?: [[string | number] | string | number] | string | number;
+  resourceIds?: [[StringOrNumber] | StringOrNumber] | StringOrNumber;
+  permissionIds?: [[StringOrNumber] | StringOrNumber] | StringOrNumber;
 }
 
 declare class AvOrganizationSelect<T> extends React.Component<

--- a/packages/select/resources.d.ts
+++ b/packages/select/resources.d.ts
@@ -12,7 +12,7 @@ declare class AvRegionSelect<T> extends React.Component<
   public static create<T>(defaults: AvRegionSelectProps<T>): AvRegionSelect<T>;
 }
 
-export type StringOrNumber = string | number;
+type StringOrNumber = string | number;
 
 export interface AvOrganizationSelectProps<T> extends ResourceSelectProps<T> {
   resourceIds?: [[StringOrNumber] | StringOrNumber] | StringOrNumber;


### PR DESCRIPTION
allows moving the `permissionId`s used for additional filtering to the `additionalPostGetArgs` where the `resourceIds` are already located. `additionalPostGetArgs.permissionIds` will be used over `parameters.permissionId`