### PR TITLE
feat(feedback): allow for overriding zindex value

### DIFF
--- a/docs/source/components/feedback/feedback.md
+++ b/docs/source/components/feedback/feedback.md
@@ -52,6 +52,10 @@ Callback for when the feedback is submitted. It is called with the feedback obje
 
 Whether to open the `FeedbackForm` in a modal
 
+### `zIndex?: number | string`
+
+Allows for overriding the `z-index`value from react-strap `Modal`component.
+
 ### `analytics?: AnalyticsType`
 
 Override the analytics instance that is passed in. **Default** [avLogMessagesApi](https://availity.github.io/sdk-js/api/definitions/logs/)

--- a/packages/feedback/src/Feedback.js
+++ b/packages/feedback/src/Feedback.js
@@ -9,6 +9,7 @@ import FeedbackModal from './FeedbackModal';
 const Feedback = ({
   appName,
   modal,
+  zIndex,
   children,
   analytics,
   className,
@@ -36,6 +37,7 @@ const Feedback = ({
           onFeedbackSent={onFeedbackSent}
           prompt={prompt}
           isOpen={isOpen}
+          zIndex={zIndex}
           toggle={() => toggle()}
           name={appName}
           analytics={analytics}
@@ -58,6 +60,7 @@ const Feedback = ({
 Feedback.propTypes = {
   appName: PropTypes.string,
   modal: PropTypes.bool,
+  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   children: PropTypes.node,
   className: PropTypes.string,
   outline: PropTypes.bool,

--- a/packages/feedback/src/FeedbackModal.js
+++ b/packages/feedback/src/FeedbackModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Modal } from 'reactstrap';
 import FeedbackForm from './FeedbackForm';
 
-const FeedbackModal = ({ isOpen, toggle, ...formOptions }) => (
+const FeedbackModal = ({ isOpen, toggle, zIndex, ...formOptions }) => (
   <Modal
     fade
     id="feedbackModal"
@@ -14,6 +14,7 @@ const FeedbackModal = ({ isOpen, toggle, ...formOptions }) => (
     aria-hidden="true"
     isOpen={isOpen}
     toggle={toggle}
+    zIndex={zIndex}
   >
     <FeedbackForm onClose={toggle} {...formOptions} />
   </Modal>
@@ -22,6 +23,7 @@ const FeedbackModal = ({ isOpen, toggle, ...formOptions }) => (
 FeedbackModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
+  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default FeedbackModal;

--- a/packages/feedback/typings/Feedback.d.ts
+++ b/packages/feedback/typings/Feedback.d.ts
@@ -8,6 +8,7 @@ export interface AnalyticsType {
 export interface FeedbackProps extends DropdownProps {
   appName?: string;
   modal?: boolean;
+  zIndex?: number | string;
   outline?: boolean;
   color?: string;
   analytics?: AnalyticsType;

--- a/packages/feedback/typings/FeedbackModal.d.ts
+++ b/packages/feedback/typings/FeedbackModal.d.ts
@@ -1,8 +1,8 @@
 export interface FeedbackModalProps {
-    isOpen: boolean;
-    toggle: Function;
+  isOpen: boolean;
+  toggle: Function;
+  zIndex?: number | string;
 }
-
 
 declare const FeedbackModal: React.FunctionComponent<FeedbackModalProps>;
 


### PR DESCRIPTION
I was able to add `zIndex` directly onto `Feedback` and pass down to `FeedbackModal` to allow for overriding react-strap modal values.

Closes #553