### PR TITLE
fix(date): setFieldValue even when value is not valid as a date/moment

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -70,11 +70,7 @@ const AvDate = ({
       true
     );
     const isoFormatted = date.format(isoDateFormat);
-    setFieldValue(
-      name,
-      date.isValid() ? isoFormatted : '',
-      false
-    );
+    setFieldValue(name, date.isValid() ? isoFormatted : date, false);
     setFieldTouched(name, true, false);
 
     if (date.isValid()) {


### PR DESCRIPTION
Identified issue where if value was not a valid date/moment, it would never get set, instead '', which caused unexpected behavior from validation.