### PR TITLE
fix(date): removing custom keys for date range

### DIFF
--- a/docs/source/form/date/components/date-range-field.md
+++ b/docs/source/form/date/components/date-range-field.md
@@ -65,14 +65,6 @@ Extends [DateRange Props](/form/date/components/date-range/#props).
 
 The name of the field. Will be the key of the selected date that comes through in the values of the `onSubmit` callback.
 
-### `startKey: string`
-
-Key to return start date as on form submit. Should match the yup schema `startKey`.
-
-### `endKey: string`
-
-Key to return end date as on form submit. Should match the yup schema `endKey`.
-
 ### `label?: string`
 
 The text that renders inside the `Label` above the input.

--- a/docs/source/form/date/components/date-range.mdx
+++ b/docs/source/form/date/components/date-range.mdx
@@ -50,7 +50,7 @@ import * as yup from 'yup';
       Submit
     </Button>
   </Form>
-</div>
+</div>;
 ```
 
 ## Props
@@ -60,14 +60,6 @@ See [react-dates](https://github.com/airbnb/react-dates#daterangepicker) for add
 ### `name: string`
 
 The name of the field. Will be the key of the selected dates that come through in the values of the `onSubmit` callback.
-
-### `startKey: string`
-
-Key to return start date as on form submit. Should match the yup schema `startKey`.
-
-### `endKey: string`
-
-Key to return end date as on form submit. Should match the yup schema `endKey`.
 
 ### `min?: string | LimitType`
 

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -60,8 +60,6 @@ const DateRange = ({
   className,
   format,
   calendarIcon,
-  startKey,
-  endKey,
   datepickerProps,
   'data-testid': dataTestId,
   datepicker,
@@ -79,8 +77,8 @@ const DateRange = ({
   const startId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-start`;
   const endId = `${(id || name).replace(/[^a-zA-Z0-9]/gi, '')}-end`;
 
-  const startValue = value[startKey] || '';
-  const endValue = value[endKey] || '';
+  const startValue = value.startDate || '';
+  const endValue = value.endDate || '';
 
   const startValueMoment = useMemo(
     () => moment(startValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD']),
@@ -112,7 +110,7 @@ const DateRange = ({
 
   // For updating when we delete the current input
   const onInputChange = val => {
-    const isStart = focusedInput === startKey;
+    const isStart = focusedInput === 'startDate';
     const date = moment(
       val,
       [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
@@ -124,14 +122,14 @@ const DateRange = ({
     setFieldValue(
       name,
       {
-        [startKey]: isStart ? valueToSet : startValue,
-        [endKey]: !isStart ? valueToSet : endValue,
+        startDate: isStart ? valueToSet : startValue,
+        endDate: !isStart ? valueToSet : endValue,
       },
       false
     );
 
     if (focusedInput && isStart && date.isValid()) {
-      setFocusedInput(endKey);
+      setFocusedInput('endDate');
     } else if (focusedInput && !isStart && date.isValid()) {
       setFocusedInput();
     }
@@ -143,8 +141,8 @@ const DateRange = ({
     setFieldValue(
       name,
       {
-        [startKey]: _startDate,
-        [endKey]: _endDate,
+        startDate: _startDate,
+        endDate: _endDate,
       },
       false
     );
@@ -155,8 +153,8 @@ const DateRange = ({
 
     if (onChange) {
       onChange({
-        [startKey]: _startDate,
-        [endKey]: _endDate,
+        startDate: _startDate,
+        endDate: _endDate,
       });
     }
   };
@@ -173,8 +171,8 @@ const DateRange = ({
         setFieldValue(
           name,
           {
-            [startKey]: value,
-            [endKey]: value,
+            startDate: value,
+            endDate: value,
           },
           false
         );
@@ -362,8 +360,6 @@ DateRange.propTypes = {
   format: PropTypes.string,
   datepicker: PropTypes.bool,
   datepickerProps: PropTypes.object,
-  startKey: PropTypes.string,
-  endKey: PropTypes.string,
   'data-testid': PropTypes.string,
   autoSync: PropTypes.bool,
   ranges: PropTypes.oneOfType([
@@ -377,8 +373,6 @@ DateRange.propTypes = {
 DateRange.defaultProps = {
   calendarIcon: <Icon name="calendar" data-testid="calendar-icon" />,
   format: isoDateFormat,
-  startKey: 'startDate',
-  endKey: 'endDate',
   datepicker: true,
 };
 

--- a/packages/date/tests/DateRange.test.js
+++ b/packages/date/tests/DateRange.test.js
@@ -8,7 +8,6 @@ import {
 } from '@testing-library/react';
 import { Button } from 'reactstrap';
 import { Form } from '@availity/form';
-import { dateRange } from '@availity/yup';
 import { object, string } from 'yup';
 import moment from 'moment';
 import { DateRange } from '..';
@@ -274,68 +273,6 @@ describe('DateRange', () => {
           dateRange: {
             startDate: moment().format('YYYY-MM-DD'),
             endDate: moment().format('YYYY-MM-DD'),
-          },
-        }),
-        expect.anything()
-      );
-    });
-  });
-
-  test('works with custom start/end keys', async () => {
-    const onSubmit = jest.fn();
-    const schema = object().shape({
-      dateRange: dateRange({
-        startKey: 'customStartKey',
-        endKey: 'customEndKey',
-      }),
-    });
-
-    const { container, getByText } = render(
-      <Form
-        initialValues={{
-          dateRange: undefined,
-        }}
-        onSubmit={onSubmit}
-        validationSchema={schema}
-      >
-        <DateRange
-          id="dateRange"
-          name="dateRange"
-          startKey="customStartKey"
-          endKey="customEndKey"
-        />
-        <Button type="submit">Submit</Button>
-      </Form>
-    );
-
-    // Simulate user entering start date
-    const start = container.querySelector('#dateRange-start');
-
-    fireEvent.focus(start);
-
-    fireEvent.change(start, {
-      target: {
-        value: '01/04/1997',
-      },
-    });
-
-    // Simulate user entering end date
-    const end = container.querySelector('#dateRange-end');
-
-    fireEvent.change(end, {
-      target: {
-        value: '01/05/1997',
-      },
-    });
-
-    fireEvent.click(getByText('Submit'));
-
-    await wait(() => {
-      expect(onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dateRange: {
-            customStartKey: '1997-01-04',
-            customEndKey: '1997-01-05',
           },
         }),
         expect.anything()


### PR DESCRIPTION
team reported issue with date range not being able to have the values typed in. issue was due to custom keys in `DateRange`. determined that the custom keys were unneeded complexity and to remove them. 