### PR TITLE
Feat/react query update

### DIFF
--- a/docs/source/components/hooks/use-current-user.md
+++ b/docs/source/components/hooks/use-current-user.md
@@ -6,13 +6,13 @@ summary: Hook that returns the current user.
 ## Example
 
 ```jsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useCurrentUser } from '@availity/hooks';
 
 const Component = () => {
   const { data: user, isFetching } = useCurrentUser();
 
-  return <div>{isFetching ? 'Loading...' : user.id}</div>;
+  return <div>{isFetching ? 'Loading...' : user?.id}</div>;
 };
 ```
 

--- a/docs/source/components/hooks/use-current-user.md
+++ b/docs/source/components/hooks/use-current-user.md
@@ -8,11 +8,18 @@ summary: Hook that returns the current user.
 ```jsx
 import React, { useState } from 'react';
 import { useCurrentUser } from '@availity/hooks';
-// ...
-const Component = () => {
-  const { data: user, status, error } = useCurrentUser();
 
-  return <div>{status === 'loading' ? 'Loading...' : user.id}</div>;
+const Component = () => {
+  const { data: user, isFetching } = useCurrentUser();
+
+  return <div>{isFetching ? 'Loading...' : user.id}</div>;
 };
-// ...
 ```
+
+## Props
+
+### `options?: QueryConfig
+
+Options to be passed to the `useQuery` hook such as `enabled`, `retry`, and `onSuccess`.
+
+> More information on the options can be found [here](https://react-query.tanstack.com/docs/api/#usequery)

--- a/docs/source/components/hooks/use-organizations.md
+++ b/docs/source/components/hooks/use-organizations.md
@@ -17,7 +17,11 @@ const Component = () => {
   );
 
   return (
-    <div>{isFetching ? 'Loading...' : data.data.organizations[0].name}</div>
+    <div>
+      {isFetching
+        ? 'Loading...'
+        : data?.data?.organizations?.[0]?.name || 'No organizations found'}
+    </div>
   );
 };
 ```

--- a/docs/source/components/hooks/use-organizations.md
+++ b/docs/source/components/hooks/use-organizations.md
@@ -28,9 +28,11 @@ const Component = () => {
 
 ## Props
 
-## `config: AxiosRequestConfig`
+### `config: AxiosRequestConfig`
 
 Config passed to the `getOrganizations` call from `@availity/api-axios`.
+
+> More information about this config can be found [here](https://availity.github.io/sdk-js/api/getting-started/#config-1)
 
 ### `options?: QueryConfig
 

--- a/docs/source/components/hooks/use-organizations.md
+++ b/docs/source/components/hooks/use-organizations.md
@@ -7,16 +7,29 @@ summary: Hook that returns organizations.
 
 ```jsx
 import React from 'react';
-import { useOrganizations } from '@availity/hooks';
-// ...
+import { useCurrentUser, useOrganizations } from '@availity/hooks';
+
 const Component = () => {
-  const { data, status, error } = useOrganizations();
+  const { data: user } = useCurrentUser();
+  const { data, isFetching } = useOrganizations(
+    { params: { permissionId: ['5'], userId: user?.id } },
+    { enabled: !!user?.id }
+  );
 
   return (
-    <div>
-      {status === 'loading' ? 'Loading...' : data.data.organizations[0].name}
-    </div>
+    <div>{isFetching ? 'Loading...' : data.data.organizations[0].name}</div>
   );
 };
-// ...
 ```
+
+## Props
+
+## `config: AxiosRequestConfig`
+
+Config passed to the `getOrganizations` call from `@availity/api-axios`.
+
+### `options?: QueryConfig
+
+Options to be passed to the `useQuery` hook such as `enabled`, `retry`, and `onSuccess`.
+
+> More information on the options can be found [here](https://react-query.tanstack.com/docs/api/#usequery)

--- a/docs/source/components/hooks/use-permissions.md
+++ b/docs/source/components/hooks/use-permissions.md
@@ -8,17 +8,26 @@ summary: Hook that returns user permissions.
 ```jsx
 import React from 'react';
 import { usePermissions } from '@availity/hooks';
-// ...
+
 const Component = () => {
-  const { data, status, error } = usePermissions();
+  const { data, isFetching } = usePermissions();
 
   return (
     <div>
-      {status === 'loading'
-        ? 'Loading...'
-        : data.data.permissions[0].description}
+      {isFetching ? 'Loading...' : data.data.permissions[0].description}
     </div>
   );
 };
-// ...
 ```
+
+## Props
+
+## `config: AxiosRequestConfig`
+
+Config passed to the `getPermissions` call from `@availity/api-axios`.
+
+### `options?: QueryConfig
+
+Options to be passed to the `useQuery` hook such as `enabled`, `retry`, and `onSuccess`.
+
+> More information on the options can be found [here](https://react-query.tanstack.com/docs/api/#usequery)

--- a/docs/source/components/hooks/use-permissions.md
+++ b/docs/source/components/hooks/use-permissions.md
@@ -24,9 +24,11 @@ const Component = () => {
 
 ## Props
 
-## `config: AxiosRequestConfig`
+### `config: AxiosRequestConfig`
 
 Config passed to the `getPermissions` call from `@availity/api-axios`.
+
+> More information about this config can be found [here](https://availity.github.io/sdk-js/api/getting-started/#config-1)
 
 ### `options?: QueryConfig
 

--- a/docs/source/components/hooks/use-permissions.md
+++ b/docs/source/components/hooks/use-permissions.md
@@ -14,7 +14,9 @@ const Component = () => {
 
   return (
     <div>
-      {isFetching ? 'Loading...' : data.data.permissions[0].description}
+      {isFetching
+        ? 'Loading...'
+        : data?.data?.permissions?.[0]?.description || '404'}
     </div>
   );
 };

--- a/docs/source/components/hooks/use-providers.md
+++ b/docs/source/components/hooks/use-providers.md
@@ -10,10 +10,14 @@ import React from 'react';
 import { useProviders } from '@availity/hooks';
 
 const Component = () => {
-  const { data, isFetching, error } = useProviders({ customerId: 01234 });
+  const { data, isFetching } = useProviders({ customerId: 01234 });
 
   return (
-    <div>{isFetching ? 'Loading...' : data.data.providers[0].lastName}</div>
+    <div>
+      {isFetching
+        ? 'Loading...'
+        : data?.data?.providers?.[0]?.lastName || 'Dr. Availity'}
+    </div>
   );
 };
 ```

--- a/docs/source/components/hooks/use-providers.md
+++ b/docs/source/components/hooks/use-providers.md
@@ -8,21 +8,24 @@ summary: Hook that returns providers.
 ```jsx
 import React from 'react';
 import { useProviders } from '@availity/hooks';
-// ...
+
 const Component = () => {
-  const { data, status, error } = usePermissions({ customerId: 01234 });
+  const { data, isFetching, error } = useProviders({ customerId: 01234 });
 
   return (
-    <div>
-      {status === 'loading' ? 'Loading...' : data.data.providers[0].lastName}
-    </div>
+    <div>{isFetching ? 'Loading...' : data.data.providers[0].lastName}</div>
   );
 };
-// ...
 ```
 
 ## Props
 
-### `config: {customerId: number}`
+### `config: {customerId: number} & AxiosRequestConfig`
 
-The customer id to retrieve the providers.
+The Customer ID to retrieve the providers and other config options that can be passed to `getProviders` from `@availity/api-axios`
+
+### `options?: QueryConfig
+
+Options to be passed to the `useQuery` hook such as `enabled`, `retry`, and `onSuccess`.
+
+> More information on the options can be found [here](https://react-query.tanstack.com/docs/api/#usequery)

--- a/docs/source/components/hooks/use-providers.md
+++ b/docs/source/components/hooks/use-providers.md
@@ -24,7 +24,7 @@ const Component = () => {
 
 ## Props
 
-#### `config: {customerId: number} & AxiosRequestConfig`
+### `config: {customerId: number} & AxiosRequestConfig`
 
 The Customer ID to retrieve the providers and other config options that can be passed to `getProviders` from `@availity/api-axios`
 

--- a/docs/source/components/hooks/use-providers.md
+++ b/docs/source/components/hooks/use-providers.md
@@ -24,9 +24,11 @@ const Component = () => {
 
 ## Props
 
-### `config: {customerId: number} & AxiosRequestConfig`
+#### `config: {customerId: number} & AxiosRequestConfig`
 
 The Customer ID to retrieve the providers and other config options that can be passed to `getProviders` from `@availity/api-axios`
+
+> More information about this config can be found [here](https://availity.github.io/sdk-js/api/getting-started/#config-1)
 
 ### `options?: QueryConfig
 

--- a/docs/source/components/hooks/use-region.md
+++ b/docs/source/components/hooks/use-region.md
@@ -12,7 +12,7 @@ import { useCurrentRegion } from '@availity/hooks';
 const Component = () => {
   const { data: region, isFetching } = useCurrentRegion();
 
-  return <div>{isFetching ? 'Loading...' : region.value}</div>;
+  return <div>{isFetching ? 'Loading...' : region?.value || 'Nowhere'}</div>;
 };
 ```
 

--- a/docs/source/components/hooks/use-region.md
+++ b/docs/source/components/hooks/use-region.md
@@ -6,13 +6,20 @@ summary: Hook that returns the user's current region.
 ## Example
 
 ```jsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useCurrentRegion } from '@availity/hooks';
-// ...
-const Component = () => {
-  const [region, loading] = useCurrentRegion();
 
-  return <div>{loading ? 'Loading...' : region.value}</div>;
+const Component = () => {
+  const { data: region, isFetching } = useCurrentRegion();
+
+  return <div>{isFetching ? 'Loading...' : region.value}</div>;
 };
-// ...
 ```
+
+## Props
+
+### `options?: QueryConfig
+
+Options to be passed to the `useQuery` hook such as `enabled`, `retry`, and `onSuccess`.
+
+> More information on the options can be found [here](https://react-query.tanstack.com/docs/api/#usequery)

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react-query": "^1.5.7"
+    "react-query": "^2.25.2"
   },
   "devDependencies": {
     "@availity/api-axios": "^5.4.0",

--- a/packages/hooks/src/useCurrentRegion.js
+++ b/packages/hooks/src/useCurrentRegion.js
@@ -11,11 +11,5 @@ async function fetchRegion() {
 }
 
 export default function useCurrentRegion(options) {
-  const { data = null, isFetching, error } = useQuery(
-    ['region'],
-    fetchRegion,
-    options
-  );
-
-  return [data, isFetching, error];
+  return useQuery(['region'], fetchRegion, options);
 }

--- a/packages/hooks/src/useCurrentRegion.js
+++ b/packages/hooks/src/useCurrentRegion.js
@@ -5,8 +5,8 @@ async function fetchRegion() {
   const response = await avRegionsApi.getCurrentRegion();
 
   return {
-    code: response.data.regions[0].id,
-    value: response.data.regions[0].value,
+    code: response?.data?.regions?.[0]?.id || '',
+    value: response?.data?.regions?.[0]?.value || '',
   };
 }
 

--- a/packages/hooks/src/useCurrentUser.js
+++ b/packages/hooks/src/useCurrentUser.js
@@ -3,4 +3,6 @@ import { useQuery } from 'react-query';
 
 const fetchUser = async () => avUserApi.me();
 
-export default options => useQuery(['user'], fetchUser, options);
+export default function useCurrentUser(options) {
+  return useQuery(['user'], fetchUser, options);
+}

--- a/packages/hooks/src/useOrganizations.js
+++ b/packages/hooks/src/useOrganizations.js
@@ -1,6 +1,9 @@
 import { useQuery } from 'react-query';
 import { avOrganizationsApi } from '@availity/api-axios';
 
-const fetchOrganization = async (_, config) =>
+const fetchOrganization = async (_key, config) =>
   avOrganizationsApi.getOrganizations(config);
-export default config => useQuery(['organizations', config], fetchOrganization);
+
+export default function useOrganization(config, options) {
+  return useQuery(['organizations', config], fetchOrganization, options);
+}

--- a/packages/hooks/src/usePermissions.js
+++ b/packages/hooks/src/usePermissions.js
@@ -1,6 +1,9 @@
 import { useQuery } from 'react-query';
 import { avPermissionsApi } from '@availity/api-axios';
 
-const fetchPermissions = async (_, config) =>
+const fetchPermissions = async (_key, config) =>
   avPermissionsApi.getPermissions(config);
-export default config => useQuery(['permissions', config], fetchPermissions);
+
+export default function usePermissions(config, options) {
+  return useQuery(['permissions', config], fetchPermissions, options);
+}

--- a/packages/hooks/src/useProviders.js
+++ b/packages/hooks/src/useProviders.js
@@ -1,6 +1,9 @@
 import { useQuery } from 'react-query';
 import { avProvidersApi } from '@availity/api-axios';
 
-const fetchProviders = async (_, config) =>
+const fetchProviders = async (_key, config) =>
   avProvidersApi.getProviders(config.customerId, config);
-export default config => useQuery(['providers', config], fetchProviders);
+
+export default function useProviders(config, options) {
+  return useQuery(['providers', config], fetchProviders, options);
+}

--- a/packages/hooks/tests/usePermissions.test.js
+++ b/packages/hooks/tests/usePermissions.test.js
@@ -24,15 +24,7 @@ const Component = () => {
 };
 
 describe('usePermissions', () => {
-  test('should set error on rejected promise', async () => {
-    avPermissionsApi.getPermissions.mockRejectedValueOnce('An error occurred');
-
-    const { getByTestId } = render(<Component />);
-
-    await waitForElement(() => getByTestId('invalid'));
-  });
-
-  test('should return loading', () => {
+  test('should return loading', async () => {
     avPermissionsApi.getPermissions.mockResolvedValueOnce({
       id: '44',
       description: 'test',
@@ -41,7 +33,15 @@ describe('usePermissions', () => {
 
     const { getByTestId } = render(<Component />);
 
-    getByTestId('loading');
+    await waitForElement(() => getByTestId('loading'));
+  });
+
+  test('should set error on rejected promise', async () => {
+    avPermissionsApi.getPermissions.mockRejectedValueOnce('An error occurred');
+
+    const { getByTestId } = render(<Component />);
+
+    await waitForElement(() => getByTestId('invalid'));
   });
 
   test('should return permissions', async () => {

--- a/packages/hooks/tests/useProviders.test.js
+++ b/packages/hooks/tests/useProviders.test.js
@@ -34,7 +34,7 @@ describe('useProviders', () => {
     await waitForElement(() => getByText('An error occurred'));
   });
 
-  test('should return loading', () => {
+  test('should return loading', async () => {
     avProvidersApi.getProviders.mockResolvedValueOnce({
       data: {
         providers: [
@@ -51,7 +51,7 @@ describe('useProviders', () => {
 
     const { getByTestId } = render(<Component />);
 
-    getByTestId('loading');
+    await waitForElement(() => getByTestId('loading'));
   });
 
   test('should return providers', async () => {

--- a/packages/hooks/tests/useProviders.test.js
+++ b/packages/hooks/tests/useProviders.test.js
@@ -1,57 +1,60 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { render, waitForElement, cleanup } from '@testing-library/react';
 import { avProvidersApi } from '@availity/api-axios';
+import { queryCache } from 'react-query';
 import { useProviders } from '..';
 
 jest.mock('@availity/api-axios');
 
+let queryStates = [];
+beforeEach(() => {
+  queryStates = [];
+});
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
+  queryCache.clear();
+  queryStates = [];
 });
 
-const Component = () => {
-  const { data, isFetching, error } = useProviders(
-    {
-      customerId: 264330,
-    },
-    { cacheTime: 0, retry: false }
+const pushState = state => {
+  queryStates.push(state);
+};
+
+const Component = ({ log }) => {
+  // Mirror testing methods from react-query instead of relying on timing or booleans
+  // https://github.com/tannerlinsley/react-query/blob/master/src/react/tests/useQuery.test.tsx
+  const state = useProviders({}, { cacheTime: 0, retry: false });
+
+  // not directly used in assertions here, but useful for debugging purposes
+  if (log) log(state);
+
+  const { data, error, status } = state;
+
+  return (
+    <div>
+      <h1>Status: {status}</h1>
+      <h1>Data: {JSON.stringify(data)}</h1>
+      <h1>Error: {error}</h1>
+    </div>
   );
+};
 
-  if (isFetching) return <span data-testid="loading" />;
-  if (data) return <span data-testid="valid">{JSON.stringify(data)}</span>;
-  if (error) return <span data-testid="invalid">An error occurred</span>;
-
-  return null;
+Component.propTypes = {
+  log: PropTypes.func,
 };
 
 describe('useProviders', () => {
-  test('should set error on rejected promise', async () => {
+  test('should return an error', async () => {
     avProvidersApi.getProviders.mockRejectedValueOnce('An error occurred');
 
-    const { getByText } = render(<Component />);
+    const { getByText } = render(<Component log={pushState} />);
 
-    await waitForElement(() => getByText('An error occurred'));
-  });
-
-  test('should return loading', async () => {
-    avProvidersApi.getProviders.mockResolvedValueOnce({
-      data: {
-        providers: [
-          {
-            id: 'test',
-            lastName: 'test',
-            firstName: 'test',
-            middleName: 'test',
-            uiDisplayName: 'test',
-          },
-        ],
-      },
-    });
-
-    const { getByTestId } = render(<Component />);
-
-    await waitForElement(() => getByTestId('loading'));
+    getByText('Status: loading');
+    await waitForElement(() => getByText('Status: error'));
+    await waitForElement(() => getByText('Error: An error occurred'));
   });
 
   test('should return providers', async () => {
@@ -69,11 +72,12 @@ describe('useProviders', () => {
       },
     });
 
-    const { getByText } = render(<Component />);
+    const { getByText } = render(<Component log={pushState} />);
 
+    getByText('Status: loading');
     await waitForElement(() =>
       getByText(
-        JSON.stringify({
+        `Data: ${JSON.stringify({
           data: {
             providers: [
               {
@@ -85,7 +89,7 @@ describe('useProviders', () => {
               },
             ],
           },
-        })
+        })}`
       )
     );
   });

--- a/packages/hooks/typings/useCurrentRegion.d.ts
+++ b/packages/hooks/typings/useCurrentRegion.d.ts
@@ -1,8 +1,12 @@
-export type CurrentRegionType = {
-    code: string;
-    value: string;
+import { QueryConfig, QueryResult } from 'react-query';
+
+export type CurrentRegion = {
+  code: string;
+  value: string;
 };
 
-declare function useCurrentRegion(): [CurrentRegionType, boolean, object];
+declare function useCurrentRegion(
+  options?: QueryConfig<CurrentRegion, unknown>
+): QueryResult<CurrentRegion, unknown>;
 
 export default useCurrentRegion;

--- a/packages/hooks/typings/useCurrentUser.d.ts
+++ b/packages/hooks/typings/useCurrentUser.d.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from 'react-query';
+import { QueryConfig, QueryResult } from 'react-query';
 
 export type CurrentUser = {
   akaname: string;
@@ -15,11 +15,7 @@ export type CurrentUser = {
 };
 
 declare function useCurrentUser(
-  options: QueryOptions<CurrentUser, object>
-): {
-  data: CurrentUser;
-  Status: string;
-  Error: object;
-};
+  options?: QueryConfig<CurrentUser, unknown>
+): QueryResult<CurrentUser, unknown>;
 
 export default useCurrentUser;

--- a/packages/hooks/typings/useOrganizations.d.ts
+++ b/packages/hooks/typings/useOrganizations.d.ts
@@ -1,6 +1,6 @@
-import { AriesHookBase } from './aries';
 import { AxiosRequestConfig } from 'axios';
-import { QueryResult } from 'react-query';
+import { QueryConfig, QueryResult } from 'react-query';
+import { AriesHookBase } from './aries';
 
 interface OrganizationsBase {
   data: {
@@ -49,9 +49,9 @@ interface OrganizationsBase {
           stateCode: string;
           zipCode: string;
         };
-        regions: Array<{ code: string; value: string }>;
-        npis: Array<{ number: string }>;
-        taxIds: Array<{ number: string; type: string }>;
+        regions: { code: string; value: string }[];
+        npis: { number: string }[];
+        taxIds: { number: string; type: string }[];
 
         phoneNumber: {
           areaCode: string;
@@ -67,6 +67,9 @@ interface OrganizationsBase {
 
 type Organizations = AriesHookBase & OrganizationsBase;
 
-export declare function useOrganizations(): QueryResult<Organizations>;
+export declare function useOrganizations(
+  config: AxiosRequestConfig,
+  options?: QueryConfig<Organizations, unknown>
+): QueryResult<Organizations, unknown>;
 
 export default useOrganizations;

--- a/packages/hooks/typings/usePermissions.d.ts
+++ b/packages/hooks/typings/usePermissions.d.ts
@@ -1,18 +1,22 @@
-import { AriesHookBase } from './aries';
 import { AxiosRequestConfig } from 'axios';
-import { QueryResult } from 'react-query';
+import { QueryConfig, QueryResult } from 'react-query';
+import { AriesHookBase } from './aries';
 
 export interface PermissionsBase {
   data: {
-    permissions: Array<{
+    permissions: {
       id: string;
       description: string;
       links: { self: { href: string } };
-    }>;
+    }[];
   };
 }
 
 type Permissions = AriesHookBase & PermissionsBase;
 
-declare function usePermissions(): QueryResult<Permissions>;
+declare function usePermissions(
+  config: AxiosRequestConfig,
+  options?: QueryConfig<Permissions, unknown>
+): QueryResult<Permissions, unknown>;
+
 export default usePermissions;

--- a/packages/hooks/typings/useProviders.d.ts
+++ b/packages/hooks/typings/useProviders.d.ts
@@ -1,6 +1,6 @@
-import { AriesHookBase } from './aries';
 import { AxiosRequestConfig } from 'axios';
-import { QueryResult } from 'react-query';
+import { QueryConfig, QueryResult } from 'react-query';
+import { AriesHookBase } from './aries';
 
 interface ProvidersBase {
   data: {
@@ -40,9 +40,11 @@ interface ProvidersBase {
 
 type Providers = AriesHookBase & ProvidersBase;
 
+type AvConfig = { customerId: number } & AxiosRequestConfig;
+
 declare function useProviders(
-  config: {
-    customerId: number;
-  } & AxiosRequestConfig
-): QueryResult<Providers>;
+  config: AvConfig,
+  options?: QueryConfig<Providers, unknown>
+): QueryResult<Providers, unknown>;
+
 export default useProviders;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,11 +2891,6 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@scarf/scarf@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.6.tgz#52011dfb19187b53b75b7b6eac20da0810ddd88f"
-  integrity sha512-y4+DuXrAd1W5UIY3zTcsosi/1GyYT8k5jGnZ/wG7UUHVrU+MHlH4Mp87KK2/lvMW4+H7HVcdB+aJhqywgXksjA==
-
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -17973,13 +17968,12 @@ react-portal@^4.2.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-query@^1.5.7:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-1.5.10.tgz#9b23af061e8171e95503e1932cc07d0cebe806eb"
-  integrity sha512-Kjgii5rK1g9kpLCUGBeGIqFG0IoAMe/oRKzpIfNQUyegJ/Lh5o9lmbmpTPMBWbP3gZDFfAC3081llqxg7QiqCg==
+react-query@^2.25.2:
+  version "2.25.2"
+  resolved "https://registry.npmjs.org/react-query/-/react-query-2.25.2.tgz#afefdf57a166bcbf08c93a26522a8c6cb1bdf849"
+  integrity sha512-GIz75WlRAzJ+wKos9VPw6PMAB3FqGmB2lHtRZlvKKByurlMNHa5rOFPz4WCYGWsPBSk7m6FHWrkK9aItDrP2mw==
   dependencies:
-    "@scarf/scarf" "^1.0.6"
-    ts-toolbelt "^6.9.4"
+    "@babel/runtime" "^7.5.5"
 
 react-reconciler@^0.24.0:
   version "0.24.0"
@@ -21036,11 +21030,6 @@ ts-pnp@^1.1.2, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
-
-ts-toolbelt@^6.9.4:
-  version "6.9.9"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.9.9.tgz#e6cfd8ec7d425d2a06bda3b4fe9577ceaf2abda8"
-  integrity sha512-5a8k6qfbrL54N4Dw+i7M6kldrbjgDWb5Vit8DnT+gwThhvqMg8KtxLE5Vmnft+geIgaSOfNJyAcnmmlflS+Vdg==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
This PR updates `react-query` to v2. It has a breaking change because some function signatures and return types changed.

I made sure each hook has the ability to pass in `options` that correspond to the `QueryConfig` from `react-query` which will allow users to have better control over how the hook behaves.

TypeScript types were updated as well.
