### PR TITLE
fix(help): add FieldHelpIcon to export

### DIFF
--- a/packages/help/Help.js
+++ b/packages/help/Help.js
@@ -102,6 +102,7 @@ export const Help = ({ type, id, children }) => {
 
   return children;
 };
+
 export const triggerFieldHelp = id => {
   avMessages.send({
     event: constants.OPEN_FIELD_HELP,
@@ -131,6 +132,7 @@ FieldHelpIcon.defaultProps = {
   size: '1x',
   color: 'primary',
 };
+
 Help.propTypes = {
   type: PropTypes.string,
   id: PropTypes.string.isRequired,

--- a/packages/help/index.d.ts
+++ b/packages/help/index.d.ts
@@ -16,12 +16,20 @@ export interface HelpContext {
 
 declare const constants: TopNavConstants;
 
-declare const HelpProvider: React.Provider<HelpContext>;
+declare const HelpProvider: React.FC;
 
 declare const Help: React.StatelessComponent<HelpObj>;
 
+declare const FieldHelpIcon: (props: {
+  color: string;
+  size: string;
+  id: string;
+}) => JSX.Element;
+
 declare function useHelp(data: HelpObj): HelpContext;
 
-export { Help, useHelp, constants };
+declare function triggerFieldHelp(id: string): void;
+
+export { constants, FieldHelpIcon, Help, triggerFieldHelp, useHelp };
 
 export default HelpProvider;


### PR DESCRIPTION
I updated the types by adding the `FieldHelpIcon` to the exports, and I changed the type of `HelpProvider` to be a Function Component (FC). The previous type of `React.Provider` expected a value to be passed in to `HelpProvider`. The FC type only expects children to be passed in.
