### PR TITLE
refactor: support grouped options

### DIFF
--- a/docs/source/form/select/components/select.md
+++ b/docs/source/form/select/components/select.md
@@ -16,7 +16,7 @@ import '@availity/yup';
   initialValues={{
     justTheInput: undefined,
   }}
-  onSubmit={values => window.alert(JSON.stringify(values))}
+  onSubmit={(values) => window.alert(JSON.stringify(values))}
   validationSchema={yup.object().shape({
     justTheInput: yup.string().required('This field is required.'),
   })}
@@ -45,6 +45,25 @@ See [react-select](https://github.com/JedWatson/react-select) and [react-select-
 ### `name: string`
 
 The name of the field. Will be the key of the selected option(s) that come through in the values of the `onSubmit` callback of the form.
+
+### `options: Array<object> = []`
+
+Array of options that populate the select menu. Grouped options are also supported, but must include the property `type: 'group'`.
+
+```
+const groupedOptions = [
+  {
+    label: 'options',
+    options: [
+      { label: 'Option 1', value: 'value for option 1' },
+      { label: 'Option 2', value: 'value for option 2' },
+      { label: 'Option 3', value: 'value for option 3' },
+      { label: 'Option 4', value: 'value for option 4' },
+    ],
+    type: 'group',
+  },
+];
+```
 
 ### `raw?: boolean`
 

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -110,11 +110,21 @@ const Select = ({
     return get(value, valueKey, value);
   };
 
-  const findOptionFromValue = (value, options) =>
-    Array.isArray(options) &&
-    [...options, ...newOptions].filter((option) =>
-      areValueAndOptionValueEqual(value, getOptionValue(option))
-    )[0];
+  const findOptionFromValue = (value, options) => {
+    if (Array.isArray(options)) {
+      const flattened = [...options, ...newOptions].reduce((prev, current) => {
+        if (current.options) {
+          return prev.concat(current.options);
+        }
+        return prev.concat(current);
+      }, []);
+      return flattened.filter((o) =>
+        areValueAndOptionValueEqual(value, getOptionValue(o))
+      )[0];
+    }
+
+    return null;
+  };
 
   const getViewValue = () => {
     if (attributes.raw || attributes.loadOptions || !options) return fieldValue;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -113,7 +113,7 @@ const Select = ({
   const findOptionFromValue = (value, options) => {
     if (Array.isArray(options)) {
       const flattened = [...options, ...newOptions].reduce((prev, current) => {
-        if (current.options) {
+        if (current.type === 'group') {
           return prev.concat(current.options);
         }
         return prev.concat(current);

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -29,6 +29,19 @@ const options = [
   { label: 'Option 4', value: 'value for option 4' },
 ];
 
+const groupedOptions = [
+  {
+    label: 'options',
+    options: [
+      { label: 'Option 1', value: 'value for option 1' },
+      { label: 'Option 2', value: 'value for option 2' },
+      { label: 'Option 3', value: 'value for option 3' },
+      { label: 'Option 4', value: 'value for option 4' },
+    ],
+    type: 'group',
+  },
+];
+
 // I know it's lame but this is the only way to test with react-select
 // https://stackoverflow.com/questions/55575843/how-to-test-react-select-with-react-testing-library
 const selectItem = async (container, getByText, name) => {
@@ -73,6 +86,73 @@ describe('Select', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           singleSelect: 'value for option 1',
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  test('single value grouped options submits', async () => {
+    const onSubmit = jest.fn();
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={groupedOptions}
+          data-testid="single-select"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await selectItem(container, getByText, 'Option 1');
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          singleSelect: 'value for option 1',
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  test('multi select grouped options submits', async () => {
+    const onSubmit = jest.fn();
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          isMulti
+          name="singleSelect"
+          options={groupedOptions}
+          data-testid="single-select"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await selectItem(container, getByText, 'Option 1');
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          singleSelect: ['value for option 1'],
         }),
         expect.anything()
       );

--- a/packages/select/typings/Select.d.ts
+++ b/packages/select/typings/Select.d.ts
@@ -2,10 +2,16 @@ import * as React from 'react';
 import { Props } from 'react-select/src/Select';
 import { FieldValidator } from 'formik';
 
+interface GroupedOptions {
+  label: string;
+  options: any[];
+  type: 'group';
+}
+
 export interface SelectProps<T> extends Props<{}> {
   loadOptions?: Function;
   raw?: boolean;
-  options?: any[];
+  options?: any[] | GroupedOptions[];
   labelKey?: any;
   className?: string;
   placeholder?: string;


### PR DESCRIPTION
Support for grouped options. Previously, grouped options displayed correctly in the dropdown and selected the correct value. However, it did not return a display value. So in the case of a multi-select, it displayed and empty badge. In the case of a single-select, it displayed an empty input. This code flattens the options before searching for the value.