### PR TITLE
feat(hooks): upgrade to react-query v3

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.8",
-    "react-query": "^2.26.2"
+    "react-query": "^3.0.0"
   },
   "devDependencies": {
     "@availity/api-axios": "^5.4.0",

--- a/packages/hooks/src/useOrganizations.js
+++ b/packages/hooks/src/useOrganizations.js
@@ -1,9 +1,13 @@
 import { useQuery } from 'react-query';
 import { avOrganizationsApi } from '@availity/api-axios';
 
-const fetchOrganization = async (_key, config) =>
+const fetchOrganization = async (config) =>
   avOrganizationsApi.getOrganizations(config);
 
 export default function useOrganization(config, options) {
-  return useQuery(['organizations', config], fetchOrganization, options);
+  return useQuery(
+    ['organizations', config],
+    () => fetchOrganization(config),
+    options
+  );
 }

--- a/packages/hooks/src/usePermissions.js
+++ b/packages/hooks/src/usePermissions.js
@@ -1,9 +1,13 @@
 import { useQuery } from 'react-query';
 import { avPermissionsApi } from '@availity/api-axios';
 
-const fetchPermissions = async (_key, config) =>
+const fetchPermissions = async (config) =>
   avPermissionsApi.getPermissions(config);
 
 export default function usePermissions(config, options) {
-  return useQuery(['permissions', config], fetchPermissions, options);
+  return useQuery(
+    ['permissions', config],
+    () => fetchPermissions(config),
+    options
+  );
 }

--- a/packages/hooks/src/useProviders.js
+++ b/packages/hooks/src/useProviders.js
@@ -1,9 +1,9 @@
 import { useQuery } from 'react-query';
 import { avProvidersApi } from '@availity/api-axios';
 
-const fetchProviders = async (_key, config) =>
+const fetchProviders = async (config) =>
   avProvidersApi.getProviders(config.customerId, config);
 
 export default function useProviders(config, options) {
-  return useQuery(['providers', config], fetchProviders, options);
+  return useQuery(['providers', config], () => fetchProviders(config), options);
 }

--- a/packages/hooks/tests/useCurrentRegion.test.js
+++ b/packages/hooks/tests/useCurrentRegion.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import { avRegionsApi } from '@availity/api-axios';
-import { queryCache } from 'react-query';
+import { QueryClient } from 'react-query';
 import { useCurrentRegion } from '..';
+import renderWithClient from './util';
 
 jest.mock('@availity/api-axios');
 
@@ -12,10 +13,12 @@ beforeEach(() => {
   queryStates = [];
 });
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
-  queryCache.clear();
+  queryClient.clear();
   queryStates = [];
 });
 
@@ -49,7 +52,10 @@ Component.propTypes = {
 describe('useCurrentRegion', () => {
   test('handle error', async () => {
     avRegionsApi.getCurrentRegion.mockRejectedValueOnce('An error occurred');
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {
@@ -77,7 +83,10 @@ describe('useCurrentRegion', () => {
       statusText: 'Ok',
     });
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {

--- a/packages/hooks/tests/useCurrentUser.test.js
+++ b/packages/hooks/tests/useCurrentUser.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import { avUserApi } from '@availity/api-axios';
-import { queryCache } from 'react-query';
+import { QueryClient } from 'react-query';
 import { useCurrentUser } from '..';
+import renderWithClient from './util';
 
 jest.mock('@availity/api-axios');
 
@@ -12,10 +13,12 @@ beforeEach(() => {
   queryStates = [];
 });
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
-  queryCache.clear();
+  queryClient.clear();
   queryStates = [];
 });
 
@@ -50,7 +53,10 @@ describe('useCurrentUser', () => {
   test('should set error on rejected promise', async () => {
     avUserApi.me.mockRejectedValueOnce('An error occurred');
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {
@@ -72,7 +78,10 @@ describe('useCurrentUser', () => {
       firstName: 'First',
     });
 
-    const { getByText } = render(<Component />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {

--- a/packages/hooks/tests/useOrganizations.test.js
+++ b/packages/hooks/tests/useOrganizations.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import { avOrganizationsApi } from '@availity/api-axios';
-import { queryCache } from 'react-query';
+import { QueryClient } from 'react-query';
+import renderWithClient from './util';
 import { useOrganizations } from '..';
 
 jest.mock('@availity/api-axios');
@@ -12,10 +13,12 @@ beforeEach(() => {
   queryStates = [];
 });
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
-  queryCache.clear();
+  queryClient.clear();
   queryStates = [];
 });
 
@@ -52,7 +55,10 @@ describe('useOrganizations', () => {
       'An error occurred'
     );
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {
@@ -83,7 +89,10 @@ describe('useOrganizations', () => {
       },
     });
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {

--- a/packages/hooks/tests/usePermissions.test.js
+++ b/packages/hooks/tests/usePermissions.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import { avPermissionsApi } from '@availity/api-axios';
-import { queryCache } from 'react-query';
+import { QueryClient } from 'react-query';
+import renderWithClient from './util';
 import { usePermissions } from '..';
 
 jest.mock('@availity/api-axios');
@@ -12,10 +13,12 @@ beforeEach(() => {
   queryStates = [];
 });
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
-  queryCache.clear();
+  queryClient.clear();
   queryStates = [];
 });
 
@@ -50,7 +53,10 @@ describe('usePermissions', () => {
   test('should return an error', async () => {
     avPermissionsApi.getPermissions.mockRejectedValueOnce('An error occurred');
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {
@@ -70,7 +76,10 @@ describe('usePermissions', () => {
       links: { self: { href: 'test.com' } },
     });
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {

--- a/packages/hooks/tests/useProviders.test.js
+++ b/packages/hooks/tests/useProviders.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { waitFor, cleanup } from '@testing-library/react';
 import { avProvidersApi } from '@availity/api-axios';
-import { queryCache } from 'react-query';
+import { QueryClient } from 'react-query';
+import renderWithClient from './util';
 import { useProviders } from '..';
 
 jest.mock('@availity/api-axios');
@@ -12,10 +13,12 @@ beforeEach(() => {
   queryStates = [];
 });
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
-  queryCache.clear();
+  queryClient.clear();
   queryStates = [];
 });
 
@@ -50,7 +53,10 @@ describe('useProviders', () => {
   test('should return an error', async () => {
     avProvidersApi.getProviders.mockRejectedValueOnce('An error occurred');
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {
@@ -78,7 +84,10 @@ describe('useProviders', () => {
       },
     });
 
-    const { getByText } = render(<Component log={pushState} />);
+    const { getByText } = renderWithClient(
+      queryClient,
+      <Component log={pushState} />
+    );
 
     getByText('Status: loading');
     await waitFor(() => {

--- a/packages/hooks/tests/util.js
+++ b/packages/hooks/tests/util.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { QueryClientProvider } from 'react-query';
+
+// Taken from https://github.com/tannerlinsley/react-query/blob/master/src/react/tests/utils.tsx#L6
+export default function renderWithClient(client, ui) {
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+  );
+}

--- a/packages/hooks/typings/useCurrentRegion.d.ts
+++ b/packages/hooks/typings/useCurrentRegion.d.ts
@@ -1,4 +1,4 @@
-import { QueryConfig, QueryResult } from 'react-query';
+import { UseQueryOptions, UseQueryResult } from 'react-query';
 
 export type CurrentRegion = {
   code: string;
@@ -6,7 +6,7 @@ export type CurrentRegion = {
 };
 
 declare function useCurrentRegion(
-  options?: QueryConfig<CurrentRegion, unknown>
-): QueryResult<CurrentRegion, unknown>;
+  options?: UseQueryOptions<CurrentRegion, unknown>
+): UseQueryResult<CurrentRegion, unknown>;
 
 export default useCurrentRegion;

--- a/packages/hooks/typings/useCurrentUser.d.ts
+++ b/packages/hooks/typings/useCurrentUser.d.ts
@@ -1,4 +1,4 @@
-import { QueryConfig, QueryResult } from 'react-query';
+import { UseQueryOptions, UseQueryResult } from 'react-query';
 
 export type CurrentUser = {
   akaname: string;
@@ -15,7 +15,7 @@ export type CurrentUser = {
 };
 
 declare function useCurrentUser(
-  options?: QueryConfig<CurrentUser, unknown>
-): QueryResult<CurrentUser, unknown>;
+  options?: UseQueryOptions<CurrentUser, unknown>
+): UseQueryResult<CurrentUser, unknown>;
 
 export default useCurrentUser;

--- a/packages/hooks/typings/useOrganizations.d.ts
+++ b/packages/hooks/typings/useOrganizations.d.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { QueryConfig, QueryResult } from 'react-query';
+import { UseQueryOptions, UseQueryResult } from 'react-query';
 import { AriesHookBase } from './aries';
 
 interface OrganizationsBase {
@@ -69,7 +69,7 @@ type Organizations = AriesHookBase & OrganizationsBase;
 
 export declare function useOrganizations(
   config: AxiosRequestConfig,
-  options?: QueryConfig<Organizations, unknown>
-): QueryResult<Organizations, unknown>;
+  options?: UseQueryOptions<Organizations, unknown>
+): UseQueryResult<Organizations, unknown>;
 
 export default useOrganizations;

--- a/packages/hooks/typings/usePermissions.d.ts
+++ b/packages/hooks/typings/usePermissions.d.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { QueryConfig, QueryResult } from 'react-query';
+import { UseQueryOptions, UseQueryResult } from 'react-query';
 import { AriesHookBase } from './aries';
 
 export interface PermissionsBase {
@@ -16,7 +16,7 @@ type Permissions = AriesHookBase & PermissionsBase;
 
 declare function usePermissions(
   config: AxiosRequestConfig,
-  options?: QueryConfig<Permissions, unknown>
-): QueryResult<Permissions, unknown>;
+  options?: UseQueryOptions<Permissions, unknown>
+): UseQueryResult<Permissions, unknown>;
 
 export default usePermissions;

--- a/packages/hooks/typings/useProviders.d.ts
+++ b/packages/hooks/typings/useProviders.d.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { QueryConfig, QueryResult } from 'react-query';
+import { UseQueryOptions, UseQueryResult } from 'react-query';
 import { AriesHookBase } from './aries';
 
 interface ProvidersBase {
@@ -44,7 +44,7 @@ type AvConfig = { customerId: number } & AxiosRequestConfig;
 
 declare function useProviders(
   config: AvConfig,
-  options?: QueryConfig<Providers, unknown>
-): QueryResult<Providers, unknown>;
+  options?: UseQueryOptions<Providers, unknown>
+): UseQueryResult<Providers, unknown>;
 
 export default useProviders;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15285,6 +15285,14 @@ marksy@^8.0.0:
     he "^1.2.0"
     marked "^0.3.12"
 
+match-sorter@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/match-sorter/-/match-sorter-6.0.2.tgz#91bbab14c28a87f4a67755b7a194c0d11dedc080"
+  integrity sha512-SDRLNlWof9GnAUEyhKP0O5525MMGXUGt+ep4MrrqQ2StAh3zjvICVZseiwg7Zijn3GazpJDiwuRr/mFDHd92NQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
@@ -18847,12 +18855,13 @@ react-portal@^4.2.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-query@^2.26.2:
-  version "2.26.2"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.26.2.tgz#d6fb2dd0b54934f5d1f5cdd9f8d97808eb012eb7"
-  integrity sha512-tJ3oHifWtI3cwklOLx5jIIj1ZpmvuWpPBg5iaOoi3uuIe80l0t3QCDTEF+nXpE12pYxKMj29NQ5OkTsOOMdP4Q==
+react-query@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/react-query/-/react-query-3.3.2.tgz#9cc75962ec8f6f3b4468a46d1b0ef160b97ef37d"
+  integrity sha512-SeAtekP/D3Eaf/715LmAnneSufn9Q4eGQkuOzOQ08/UtCQ58P4pkAevHu/WIBwCjtffZDTHMJRMeCeeUyouubg==
   dependencies:
     "@babel/runtime" "^7.5.5"
+    match-sorter "^6.0.2"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -19637,6 +19646,11 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
BREAKING CHANGE: react-query ^3.0.0 is now required

I upgraded to `react-query` v3. This mainly required updating the types
- QueryConfig -> UseQueryOptions
- QueryResult -> UseQueryResult
- Remove usage of `_key`. See [here](https://react-query.tanstack.com/guides/migrating-to-react-query-3#query-key-partspieces-are-no-longer-automatically-spread-to-the-query-function)
