### PR TITLE
Sets empty date field to undefined when you manually backspace

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -71,7 +71,7 @@ const AvDate = ({
       true
     );
     const isoFormatted = date.format(isoDateFormat);
-    const alternateValue = (value && value.length) ? date : undefined;
+    const alternateValue = (value && value.length > 0) ? date : undefined;
     setFieldValue(name, date.isValid() ? isoFormatted : alternateValue, false);
     setFieldTouched(name, true, false);
 

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -71,7 +71,8 @@ const AvDate = ({
       true
     );
     const isoFormatted = date.format(isoDateFormat);
-    setFieldValue(name, date.isValid() ? isoFormatted : date, false);
+    const alternateValue = (value && value.length) ? date : undefined;
+    setFieldValue(name, date.isValid() ? isoFormatted : alternateValue, false);
     setFieldTouched(name, true, false);
 
     if (date.isValid()) {


### PR DESCRIPTION
fix: sets empty datefield to undefined when you manually backspace