### PR TITLE
Fix/feedback support modal close

### DIFF
--- a/packages/feedback/src/Feedback.js
+++ b/packages/feedback/src/Feedback.js
@@ -45,11 +45,13 @@ const Feedback = ({
           analytics={analytics}
           showSupport={showSupport}
           supportZIndex={supportZIndex}
+          feedbackToggle={feedbackToggle}
           {...formProps}
         />
       ) : (
         <FeedbackDropdown
           onFeedbackSent={onFeedbackSent}
+          feedbackToggle={feedbackToggle}
           prompt={prompt}
           analytics={analytics}
           toggle={() => feedbackToggle()}

--- a/packages/feedback/src/Feedback.js
+++ b/packages/feedback/src/Feedback.js
@@ -23,7 +23,6 @@ const Feedback = ({
   ...props
 }) => {
   const [feedbackIsOpen, feedbackToggle] = useToggle(false);
-  const [supportIsOpen, supportToggle] = useToggle(false);
 
   return (
     <Dropdown
@@ -56,8 +55,6 @@ const Feedback = ({
           toggle={() => feedbackToggle()}
           name={appName}
           showSupport={showSupport}
-          supportIsOpen={supportIsOpen}
-          supportToggle={supportToggle}
           supportZIndex={supportZIndex}
           modal={modal}
           {...formProps}

--- a/packages/feedback/src/FeedbackDropdown.js
+++ b/packages/feedback/src/FeedbackDropdown.js
@@ -13,6 +13,7 @@ const FeedbackDropdown = ({
   supportToggle,
   supportZIndex,
   modal,
+  feedbackToggle,
   ...formProps
 }) => {
   const [supportIsActive, setSupportIsActive] = React.useState(false);
@@ -25,11 +26,13 @@ const FeedbackDropdown = ({
         isOpen={supportIsActive}
         setSupportIsActive={setSupportIsActive}
         supportZIndex={supportZIndex}
+        feedbackToggle={feedbackToggle}
       />
     ) : (
       <SupportDropdown
         toggle={supportToggle}
         setSupportIsActive={setSupportIsActive}
+        feedbackToggle={feedbackToggle}
       />
     );
   }
@@ -60,6 +63,7 @@ FeedbackDropdown.propTypes = {
   supportToggle: PropTypes.func,
   supportZIndex: PropTypes.string,
   modal: PropTypes.bool,
+  feedbackToggle: PropTypes.func,
 };
 
 export default FeedbackDropdown;

--- a/packages/feedback/src/FeedbackForm.js
+++ b/packages/feedback/src/FeedbackForm.js
@@ -41,7 +41,6 @@ const FeedbackForm = ({
   modalHeaderProps,
   showSupport,
   setSupportIsActive,
-  supportIsOpen,
   ...formProps
 }) => {
   const [active, setActive] = useState(null);
@@ -253,7 +252,6 @@ FeedbackForm.propTypes = {
   }),
   showSupport: PropTypes.bool,
   setSupportIsActive: PropTypes.func,
-  supportIsOpen: PropTypes.bool,
 };
 
 FeedbackForm.defaultProps = {

--- a/packages/feedback/src/FeedbackModal.js
+++ b/packages/feedback/src/FeedbackModal.js
@@ -10,6 +10,7 @@ const FeedbackModal = ({
   zIndex,
   showSupport,
   supportZIndex,
+  feedbackToggle,
   ...formOptions
 }) => {
   const [supportIsActive, setSupportIsActive] = React.useState(false);
@@ -20,6 +21,7 @@ const FeedbackModal = ({
       setSupportIsActive={setSupportIsActive}
       zIndex={supportZIndex}
       toggle={toggle}
+      feedbackToggle={feedbackToggle}
     />
   ) : (
     <Modal
@@ -51,6 +53,7 @@ FeedbackModal.propTypes = {
   showSupport: PropTypes.bool,
   zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   supportZIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  feedbackToggle: PropTypes.func,
 };
 
 export default FeedbackModal;

--- a/packages/feedback/src/SupportDropdown.js
+++ b/packages/feedback/src/SupportDropdown.js
@@ -6,7 +6,7 @@ import 'react-block-ui/style.css';
 
 import SupportForm from './SupportForm';
 
-const SupportDropdown = ({ setSupportIsActive }) => {
+const SupportDropdown = ({ setSupportIsActive, feedbackToggle }) => {
   const [blocking, setBlocking] = useState(null);
 
   return (
@@ -15,6 +15,7 @@ const SupportDropdown = ({ setSupportIsActive }) => {
         <SupportForm
           setSupportIsActive={setSupportIsActive}
           setBlocking={setBlocking}
+          feedbackToggle={feedbackToggle}
         />
       </BlockUi>
     </DropdownMenu>
@@ -23,6 +24,7 @@ const SupportDropdown = ({ setSupportIsActive }) => {
 
 SupportDropdown.propTypes = {
   setSupportIsActive: PropTypes.func,
+  feedbackToggle: PropTypes.func,
 };
 
 export default SupportDropdown;

--- a/packages/feedback/src/SupportForm.js
+++ b/packages/feedback/src/SupportForm.js
@@ -15,7 +15,12 @@ const getToken = () =>
     '$1'
   );
 
-const openSupport = async (values, setBlocking) => {
+const openSupport = async (
+  values,
+  setBlocking,
+  setSupportIsActive,
+  feedbackToggle
+) => {
   setBlocking(true);
   const orgsResp = await avOrganizationsApi.getOrganizations(
     SUPPORT_PERMISSION_ID
@@ -75,9 +80,11 @@ const openSupport = async (values, setBlocking) => {
   } else {
     window.open(href, target);
   }
+  setSupportIsActive(false);
+  feedbackToggle(false);
 };
 
-const SupportForm = ({ setSupportIsActive, setBlocking }) => (
+const SupportForm = ({ setSupportIsActive, setBlocking, feedbackToggle }) => (
   <>
     <ModalHeader aria-live="assertive" id="support-form-header">
       Open Support Ticket
@@ -98,7 +105,9 @@ const SupportForm = ({ setSupportIsActive, setBlocking }) => (
           })
           .required('This field is required.'),
       })}
-      onSubmit={(values) => openSupport(values, setBlocking)}
+      onSubmit={(values) =>
+        openSupport(values, setBlocking, setSupportIsActive, feedbackToggle)
+      }
     >
       <ModalBody>
         <AvOrganizationSelect
@@ -132,6 +141,7 @@ const SupportForm = ({ setSupportIsActive, setBlocking }) => (
 SupportForm.propTypes = {
   setSupportIsActive: PropTypes.func,
   setBlocking: PropTypes.func,
+  feedbackToggle: PropTypes.func,
 };
 
 export default SupportForm;

--- a/packages/feedback/src/SupportModal.js
+++ b/packages/feedback/src/SupportModal.js
@@ -11,6 +11,7 @@ const SupportModal = ({
   toggle,
   supportZIndex,
   setSupportIsActive,
+  feedbackToggle,
 }) => {
   const [blocking, setBlocking] = useState(null);
 
@@ -31,6 +32,7 @@ const SupportModal = ({
         <SupportForm
           setSupportIsActive={setSupportIsActive}
           setBlocking={setBlocking}
+          feedbackToggle={feedbackToggle}
         />
       </BlockUi>
     </Modal>
@@ -42,6 +44,7 @@ SupportModal.propTypes = {
   toggle: PropTypes.func.isRequired,
   supportZIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   setSupportIsActive: PropTypes.func,
+  feedbackToggle: PropTypes.func,
 };
 
 export default SupportModal;

--- a/packages/feedback/typings/FeedbackDropdown.d.ts
+++ b/packages/feedback/typings/FeedbackDropdown.d.ts
@@ -7,7 +7,6 @@ export interface FeedbackProps {
     formProps?: object;
     children?: React.ReactType;
     onFeedbackSent: Function;
-    supportIsOpen?: boolean;
 }
 
 declare const Feedback: React.StatelessComponent<FeedbackProps>;


### PR DESCRIPTION
Closes feedback and support modals on completion of support sso and removes unused supportIsOpen and supportToggle