### PR TITLE
docs(form): added links to useFormikContext and note about yup pin

### DIFF
--- a/docusaurus/docs/form/date/index.mdx
+++ b/docusaurus/docs/form/date/index.mdx
@@ -2,7 +2,9 @@
 title: Getting Started
 ---
 
-Wrapper for react-dates to work with formik.
+Wrapper for react-dates to work with `formik`.
+
+It can be helpful to understand the `formik` hook `useFormikContext()` for accessing values from the form. The documentation can be found [here](https://formik.org/docs/api/useFormikContext).
 
 ### Installation
 
@@ -12,7 +14,9 @@ npm install @availity/date @availity/form formik@^2.0.1-rc.5 react reactstrap --
 
 ### Validation
 
-See [yup](https://github.com/jquense/yup) and [@availity/yup](https://github.com/Availity/sdk-js/tree/master/packages/yup). Note to use this package with `@availity/yup` you will need to import the `moment` version as noted in the example below.
+See [yup](https://github.com/jquense/yup) and [@availity/yup](https://github.com/Availity/sdk-js/tree/master/packages/yup). Note: to use this package with `@availity/yup` you will need to import the `moment` version as noted in the example below.
+
+Currently, we recommend pinning the `yup` version to `0.31.1` to avoid bringing in some breaking changes from that project.
 
 ### References
 

--- a/docusaurus/docs/form/index.mdx
+++ b/docusaurus/docs/form/index.mdx
@@ -1,4 +1,5 @@
 ---
+
 title: Getting Started
 ---Availity form components that are wired to be hooked up to formik
 
@@ -14,9 +15,15 @@ npx install-peerdeps @availity/form --save
 
 See [Formik documentation](https://jaredpalmer.com/formik/docs/api/formik)
 
+### Accessing form values using hooks
+
+It can be helpful to understand the `formik` hook `useFormikContext()` for accessing values from the form. The documentation can be found [here](https://formik.org/docs/api/useFormikContext).
+
 ### Validation
 
 See [yup](https://github.com/jquense/yup) and [@availity/yup](https://github.com/Availity/sdk-js/tree/master/packages/yup).
+
+Currently, we recommend pinning the `yup` version to `0.31.1` to avoid bringing in some breaking changes from that project.
 
 ### Browser Compatibility! ( Internet Explorer )
 


### PR DESCRIPTION
Added refs to useFormikContext() and pinning yup to 0.31.1 to avoid breaking changes. The need for these surfaced out of support channel questions.
