### PR TITLE
feat: add onPasswordSubmit handler to upload

### DIFF
--- a/packages/upload/FileList.d.ts
+++ b/packages/upload/FileList.d.ts
@@ -2,6 +2,7 @@ export interface FileListProps {
     files?: Array<any>;
     children?: Function;
     onRemoveFile?: Function;
+    onPasswordSubmit?: Function;
 }
 
 declare const FileList: React.ComponentType<FileListProps>;

--- a/packages/upload/FileList.js
+++ b/packages/upload/FileList.js
@@ -3,15 +3,26 @@ import PropTypes from 'prop-types';
 import { Table } from 'reactstrap';
 import FileRow from './FileRow';
 
-const FileList = ({ files, children, onRemoveFile, ...rest }) => {
+const FileList = ({
+  files,
+  children,
+  onRemoveFile,
+  onPasswordSubmit,
+  ...rest
+}) => {
   const list = useMemo(
     () =>
       files.map((file) => (
-        <FileRow key={file.id} file={file} onRemove={onRemoveFile}>
+        <FileRow
+          key={file.id}
+          file={file}
+          onRemove={onRemoveFile}
+          onPasswordSubmit={onPasswordSubmit}
+        >
           {children}
         </FileRow>
       )),
-    [files, children, onRemoveFile]
+    [files, children, onRemoveFile, onPasswordSubmit]
   );
 
   if (typeof children === 'function') {
@@ -46,6 +57,7 @@ FileList.propTypes = {
   files: PropTypes.array,
   children: PropTypes.func,
   onRemoveFile: PropTypes.func,
+  onPasswordSubmit: PropTypes.func,
 };
 
 export default FileList;

--- a/packages/upload/FileRow.d.ts
+++ b/packages/upload/FileRow.d.ts
@@ -9,6 +9,7 @@ export interface FileRowProps {
     onRemove: Function;
     children?: Function;
     file?: File;
+    onPasswordSubmit?: Function;
 }
 
 declare const FileRow: React.ComponentType<FileRowProps>;

--- a/packages/upload/FileRow.js
+++ b/packages/upload/FileRow.js
@@ -23,7 +23,7 @@ const fileTypeIconMap = {
   pdf: 'file-pdf',
 };
 
-const FileRow = ({ onRemove, children, file }) => {
+const FileRow = ({ onRemove, children, file, onPasswordSubmit }) => {
   const remove = () => {
     onRemove(file.id);
   };
@@ -59,7 +59,7 @@ const FileRow = ({ onRemove, children, file }) => {
         </div>
       </td>
       <td className="align-middle" style={{ width: '45%' }}>
-        <UploadProgressBar upload={file} />
+        <UploadProgressBar upload={file} onPasswordSubmit={onPasswordSubmit} />
       </td>
       <td className="align-middle" style={{ width: '10%' }}>
         <Button
@@ -90,6 +90,7 @@ FileRow.propTypes = {
     }).isRequired,
     options: PropTypes.object,
   }),
+  onPasswordSubmit: PropTypes.func,
 };
 
 export default FileRow;

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -79,6 +79,10 @@ Set as true to show a drag and drop file upload option instead of a button (file
 
 Override the default error message for files rejected when `showFileDrop` is `true`.
 
+### `onPasswordSubmit?: (event) => void`
+
+When a user uploads an encrypted file, they are prompted to input a password. This function is called when the password form is submitted. By default, the event bubbles and will submit a form if the upload component is a child element of that form. Useful for adding event.stopPropagation() if this behavior is not desired.
+
 ### Example
 
 ```jsx

--- a/packages/upload/Upload.d.ts
+++ b/packages/upload/Upload.d.ts
@@ -16,6 +16,7 @@ export interface UploadProps {
     name?: string;
     showFileDrop?: boolean;
     getDropRejectionMessage?: ((errors: FileError[], file: File) => string);
+    onPasswordSubmit?: Function;
 }
 
 declare const Upload: React.ComponentType<UploadProps>;

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -149,6 +149,7 @@ class Upload extends Component {
       children,
       showFileDrop,
       disabled,
+      onPasswordSubmit,
     } = this.props;
     const { files } = this.state;
 
@@ -207,7 +208,11 @@ class Upload extends Component {
 
     return (
       <>
-        <FileList files={files} onRemoveFile={this.removeFile}>
+        <FileList
+          files={files}
+          onRemoveFile={this.removeFile}
+          onPasswordSubmit={onPasswordSubmit}
+        >
           {children}
         </FileList>
         {fileAddArea}
@@ -233,6 +238,7 @@ Upload.propTypes = {
   showFileDrop: PropTypes.bool,
   getDropRejectionMessage: PropTypes.func,
   disabled: PropTypes.bool,
+  onPasswordSubmit: PropTypes.func,
 };
 
 Upload.defaultProps = {

--- a/packages/upload/UploadProgressBar.d.ts
+++ b/packages/upload/UploadProgressBar.d.ts
@@ -18,6 +18,7 @@ export interface UploadProgressBarProps {
     className?: string;
     tag?: React.ReactType | string;
     striped?: boolean;
+    onPasswordSubmit?: Function;
 }
 
 

--- a/packages/upload/UploadProgressBar.js
+++ b/packages/upload/UploadProgressBar.js
@@ -13,6 +13,8 @@ import {
 } from 'reactstrap';
 
 class UploadProgressBar extends Component {
+  _isMounted = false;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -23,29 +25,46 @@ class UploadProgressBar extends Component {
     props.upload.onError.push(this.onError);
   }
 
+  componentDidMount = () => {
+    this._isMounted = true;
+  };
+
+  componentWillUnmount = () => {
+    this._isMounted = false;
+  };
+
   onProgress = () => {
     const { upload, onProgress } = this.props;
-    this.setState({ percentage: upload.percentage, error: false });
+    if (this._isMounted) {
+      this.setState({ percentage: upload.percentage, error: false });
+    }
     if (onProgress) onProgress(upload);
   };
 
   onSuccess = () => {
     const { onSuccess, upload } = this.props;
-    this.setState({ percentage: 100, error: false });
+    if (this._isMounted) {
+      this.setState({ percentage: 100, error: false });
+    }
     if (onSuccess) onSuccess(upload);
   };
 
   onError = () => {
     const { onError, upload } = this.props;
-    this.setState({ error: true });
+    if (this._isMounted) {
+      this.setState({ error: true });
+    }
     if (onError) onError(upload);
   };
 
   verifyPassword = (event) => {
-    const { upload } = this.props;
+    const { upload, onPasswordSubmit } = this.props;
     const { password } = this.state;
     event.preventDefault();
     upload.sendPassword(password);
+    if (typeof onPasswordSubmit === 'function') {
+      onPasswordSubmit(event);
+    }
     this.toggleModal();
   };
 
@@ -58,7 +77,7 @@ class UploadProgressBar extends Component {
   };
 
   render() {
-    const { upload, ...rest } = this.props;
+    const { upload, onPasswordSubmit, ...rest } = this.props;
     const { percentage, error, modalOpen } = this.state;
     return upload.errorMessage ? (
       <>
@@ -67,7 +86,12 @@ class UploadProgressBar extends Component {
         </span>
         {upload.status === 'encrypted' && (
           <div className="pwRequired" data-testid="password-form-encrypted">
-            <Button size="sm" color="primary" onClick={this.toggleModal}>
+            <Button
+              data-testid=" password-form-button"
+              size="sm"
+              color="primary"
+              onClick={this.toggleModal}
+            >
               Enter password
             </Button>
             <Modal isOpen={modalOpen} toggle={this.toggleModal}>
@@ -126,6 +150,7 @@ UploadProgressBar.propTypes = {
   animated: PropTypes.bool,
   className: PropTypes.string,
   striped: PropTypes.bool,
+  onPasswordSubmit: PropTypes.func,
 };
 
 UploadProgressBar.defaultProps = {};


### PR DESCRIPTION
Added this optional prop to the upload component so that i can use it inside of a form and prevent the nested form submission from bubbling up and submitting my parent form.

Added some tests to demo its functionality and updated the readme.

I added an isMounted check for the UploadProgressBar component because setState is passed as a callback to the upload instance in the onSuccess, onError, onProgress functions and calling setState in these callbacks will throw memory leak warnings in tests and in dev when the component unmounts (but i know this is an ugly pattern that some people don't like so i'm open to other suggestions).
