### PR TITLE
feat: add passwordModalzIndex prop

### DIFF
--- a/packages/upload/FileList.d.ts
+++ b/packages/upload/FileList.d.ts
@@ -3,7 +3,7 @@ export interface FileListProps {
     children?: Function;
     onRemoveFile?: Function;
     onPasswordSubmit?: Function;
-    passwordModalzIndex?: number | string;
+    passwordModalZIndex?: number | string;
 }
 
 declare const FileList: React.ComponentType<FileListProps>;

--- a/packages/upload/FileList.d.ts
+++ b/packages/upload/FileList.d.ts
@@ -3,6 +3,7 @@ export interface FileListProps {
     children?: Function;
     onRemoveFile?: Function;
     onPasswordSubmit?: Function;
+    passwordModalzIndex?: number | string;
 }
 
 declare const FileList: React.ComponentType<FileListProps>;

--- a/packages/upload/FileList.js
+++ b/packages/upload/FileList.js
@@ -8,7 +8,7 @@ const FileList = ({
   children,
   onRemoveFile,
   onPasswordSubmit,
-  passwordModalzIndex,
+  passwordModalZIndex,
   ...rest
 }) => {
   const list = useMemo(
@@ -19,12 +19,12 @@ const FileList = ({
           file={file}
           onRemove={onRemoveFile}
           onPasswordSubmit={onPasswordSubmit}
-          passwordModalzIndex={passwordModalzIndex}
+          passwordModalZIndex={passwordModalZIndex}
         >
           {children}
         </FileRow>
       )),
-    [files, children, onRemoveFile, onPasswordSubmit, passwordModalzIndex]
+    [files, children, onRemoveFile, onPasswordSubmit, passwordModalZIndex]
   );
 
   if (typeof children === 'function') {
@@ -60,7 +60,7 @@ FileList.propTypes = {
   children: PropTypes.func,
   onRemoveFile: PropTypes.func,
   onPasswordSubmit: PropTypes.func,
-  passwordModalzIndex: PropTypes.oneOfType([
+  passwordModalZIndex: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
   ]),

--- a/packages/upload/FileList.js
+++ b/packages/upload/FileList.js
@@ -8,6 +8,7 @@ const FileList = ({
   children,
   onRemoveFile,
   onPasswordSubmit,
+  passwordModalzIndex,
   ...rest
 }) => {
   const list = useMemo(
@@ -18,11 +19,12 @@ const FileList = ({
           file={file}
           onRemove={onRemoveFile}
           onPasswordSubmit={onPasswordSubmit}
+          passwordModalzIndex={passwordModalzIndex}
         >
           {children}
         </FileRow>
       )),
-    [files, children, onRemoveFile, onPasswordSubmit]
+    [files, children, onRemoveFile, onPasswordSubmit, passwordModalzIndex]
   );
 
   if (typeof children === 'function') {
@@ -58,6 +60,10 @@ FileList.propTypes = {
   children: PropTypes.func,
   onRemoveFile: PropTypes.func,
   onPasswordSubmit: PropTypes.func,
+  passwordModalzIndex: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 export default FileList;

--- a/packages/upload/FileRow.d.ts
+++ b/packages/upload/FileRow.d.ts
@@ -10,6 +10,7 @@ export interface FileRowProps {
     children?: Function;
     file?: File;
     onPasswordSubmit?: Function;
+    passwordModalzIndex?: number | string;
 }
 
 declare const FileRow: React.ComponentType<FileRowProps>;

--- a/packages/upload/FileRow.d.ts
+++ b/packages/upload/FileRow.d.ts
@@ -10,7 +10,7 @@ export interface FileRowProps {
     children?: Function;
     file?: File;
     onPasswordSubmit?: Function;
-    passwordModalzIndex?: number | string;
+    passwordModalZIndex?: number | string;
 }
 
 declare const FileRow: React.ComponentType<FileRowProps>;

--- a/packages/upload/FileRow.js
+++ b/packages/upload/FileRow.js
@@ -28,7 +28,7 @@ const FileRow = ({
   children,
   file,
   onPasswordSubmit,
-  passwordModalzIndex,
+  passwordModalZIndex,
 }) => {
   const remove = () => {
     onRemove(file.id);
@@ -68,7 +68,7 @@ const FileRow = ({
         <UploadProgressBar
           upload={file}
           onPasswordSubmit={onPasswordSubmit}
-          passwordModalzIndex={passwordModalzIndex}
+          passwordModalZIndex={passwordModalZIndex}
         />
       </td>
       <td className="align-middle" style={{ width: '10%' }}>
@@ -101,7 +101,7 @@ FileRow.propTypes = {
     options: PropTypes.object,
   }),
   onPasswordSubmit: PropTypes.func,
-  passwordModalzIndex: PropTypes.oneOfType([
+  passwordModalZIndex: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
   ]),

--- a/packages/upload/FileRow.js
+++ b/packages/upload/FileRow.js
@@ -23,7 +23,13 @@ const fileTypeIconMap = {
   pdf: 'file-pdf',
 };
 
-const FileRow = ({ onRemove, children, file, onPasswordSubmit }) => {
+const FileRow = ({
+  onRemove,
+  children,
+  file,
+  onPasswordSubmit,
+  passwordModalzIndex,
+}) => {
   const remove = () => {
     onRemove(file.id);
   };
@@ -59,7 +65,11 @@ const FileRow = ({ onRemove, children, file, onPasswordSubmit }) => {
         </div>
       </td>
       <td className="align-middle" style={{ width: '45%' }}>
-        <UploadProgressBar upload={file} onPasswordSubmit={onPasswordSubmit} />
+        <UploadProgressBar
+          upload={file}
+          onPasswordSubmit={onPasswordSubmit}
+          passwordModalzIndex={passwordModalzIndex}
+        />
       </td>
       <td className="align-middle" style={{ width: '10%' }}>
         <Button
@@ -91,6 +101,10 @@ FileRow.propTypes = {
     options: PropTypes.object,
   }),
   onPasswordSubmit: PropTypes.func,
+  passwordModalzIndex: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 export default FileRow;

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -88,6 +88,10 @@ Override the default error message for files rejected when `showFileDrop` is `tr
 
 When a user uploads an encrypted file, they are prompted to input a password. This function is called when the password form is submitted. By default, the event bubbles and will submit a form if the upload component is a child element of that form. Useful for adding event.stopPropagation() if this behavior is not desired.
 
+### `passwordModalzIndex?: number | string`
+
+Override the default z-index for the password prompt modal. Useful for squashing IE11 bugs by setting to auto if your upload component is already inside another modal.
+
 ### Example
 
 ```jsx

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -88,7 +88,7 @@ Override the default error message for files rejected when `showFileDrop` is `tr
 
 When a user uploads an encrypted file, they are prompted to input a password. This function is called when the password form is submitted. By default, the event bubbles and will submit a form if the upload component is a child element of that form. Useful for adding event.stopPropagation() if this behavior is not desired.
 
-### `passwordModalzIndex?: number | string`
+### `passwordModalZIndex?: number | string`
 
 Override the default z-index for the password prompt modal. Useful for squashing IE11 bugs by setting to auto if your upload component is already inside another modal.
 

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -152,7 +152,7 @@ class Upload extends Component {
       showFileDrop,
       disabled,
       onPasswordSubmit,
-      passwordModalzIndex,
+      passwordModalZIndex,
     } = this.props;
     const { files } = this.state;
 
@@ -215,7 +215,7 @@ class Upload extends Component {
           files={files}
           onRemoveFile={this.removeFile}
           onPasswordSubmit={onPasswordSubmit}
-          passwordModalzIndex={passwordModalzIndex}
+          passwordModalZIndex={passwordModalZIndex}
         >
           {children}
         </FileList>
@@ -244,7 +244,7 @@ Upload.propTypes = {
   getDropRejectionMessage: PropTypes.func,
   disabled: PropTypes.bool,
   onPasswordSubmit: PropTypes.func,
-  passwordModalzIndex: PropTypes.oneOfType([
+  passwordModalZIndex: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
   ]),

--- a/packages/upload/Upload.js
+++ b/packages/upload/Upload.js
@@ -152,6 +152,7 @@ class Upload extends Component {
       showFileDrop,
       disabled,
       onPasswordSubmit,
+      passwordModalzIndex,
     } = this.props;
     const { files } = this.state;
 
@@ -214,6 +215,7 @@ class Upload extends Component {
           files={files}
           onRemoveFile={this.removeFile}
           onPasswordSubmit={onPasswordSubmit}
+          passwordModalzIndex={passwordModalzIndex}
         >
           {children}
         </FileList>
@@ -242,6 +244,10 @@ Upload.propTypes = {
   getDropRejectionMessage: PropTypes.func,
   disabled: PropTypes.bool,
   onPasswordSubmit: PropTypes.func,
+  passwordModalzIndex: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 Upload.defaultProps = {

--- a/packages/upload/UploadProgressBar.d.ts
+++ b/packages/upload/UploadProgressBar.d.ts
@@ -19,6 +19,7 @@ export interface UploadProgressBarProps {
     tag?: React.ReactType | string;
     striped?: boolean;
     onPasswordSubmit?: Function;
+    passwordModalzIndex?: number | string;
 }
 
 

--- a/packages/upload/UploadProgressBar.d.ts
+++ b/packages/upload/UploadProgressBar.d.ts
@@ -19,7 +19,7 @@ export interface UploadProgressBarProps {
     tag?: React.ReactType | string;
     striped?: boolean;
     onPasswordSubmit?: Function;
-    passwordModalzIndex?: number | string;
+    passwordModalZIndex?: number | string;
 }
 
 

--- a/packages/upload/UploadProgressBar.js
+++ b/packages/upload/UploadProgressBar.js
@@ -77,7 +77,7 @@ class UploadProgressBar extends Component {
   };
 
   render() {
-    const { upload, onPasswordSubmit, passwordModalzIndex, ...rest } =
+    const { upload, onPasswordSubmit, passwordModalZIndex, ...rest } =
       this.props;
     const { percentage, error, modalOpen } = this.state;
     return upload.errorMessage ? (
@@ -98,7 +98,7 @@ class UploadProgressBar extends Component {
             <Modal
               isOpen={modalOpen}
               toggle={this.toggleModal}
-              zIndex={passwordModalzIndex}
+              zIndex={passwordModalZIndex}
             >
               <form
                 onSubmit={this.verifyPassword}
@@ -156,7 +156,7 @@ UploadProgressBar.propTypes = {
   className: PropTypes.string,
   striped: PropTypes.bool,
   onPasswordSubmit: PropTypes.func,
-  passwordModalzIndex: PropTypes.oneOfType([
+  passwordModalZIndex: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
   ]),

--- a/packages/upload/UploadProgressBar.js
+++ b/packages/upload/UploadProgressBar.js
@@ -77,7 +77,8 @@ class UploadProgressBar extends Component {
   };
 
   render() {
-    const { upload, onPasswordSubmit, ...rest } = this.props;
+    const { upload, onPasswordSubmit, passwordModalzIndex, ...rest } =
+      this.props;
     const { percentage, error, modalOpen } = this.state;
     return upload.errorMessage ? (
       <>
@@ -94,7 +95,11 @@ class UploadProgressBar extends Component {
             >
               Enter password
             </Button>
-            <Modal isOpen={modalOpen} toggle={this.toggleModal}>
+            <Modal
+              isOpen={modalOpen}
+              toggle={this.toggleModal}
+              zIndex={passwordModalzIndex}
+            >
               <form
                 onSubmit={this.verifyPassword}
                 data-testid="password-form-modal"
@@ -151,6 +156,10 @@ UploadProgressBar.propTypes = {
   className: PropTypes.string,
   striped: PropTypes.bool,
   onPasswordSubmit: PropTypes.func,
+  passwordModalzIndex: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 UploadProgressBar.defaultProps = {};

--- a/packages/upload/tests/UploadProgressBar.test.js
+++ b/packages/upload/tests/UploadProgressBar.test.js
@@ -95,6 +95,34 @@ describe('UploadProgressBar', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
+  test('an undefined passwordModalzIndex should leave the modals zIndex as the default 1050', async () => {
+    const { getByTestId, findByTestId } = render(
+      <UploadProgressBar upload={instance} />
+    );
+    instance.error('Encrypted files require a password', 'encrypted');
+    fireEvent.click(getByTestId('password-form-button'));
+    const form = await findByTestId('password-form-modal');
+    const container =
+      form.parentElement.parentElement.parentElement.parentElement
+        .parentElement;
+
+    expect(container.style.zIndex).toBe('1050');
+  });
+
+  test('setting passwordModalzIndex should change the modals zIndex as the default 1050', async () => {
+    const { getByTestId, findByTestId } = render(
+      <UploadProgressBar upload={instance} passwordModalzIndex="auto" />
+    );
+    instance.error('Encrypted files require a password', 'encrypted');
+    fireEvent.click(getByTestId('password-form-button'));
+    const form = await findByTestId('password-form-modal');
+    const container =
+      form.parentElement.parentElement.parentElement.parentElement
+        .parentElement;
+
+    expect(container.style.zIndex).toBe('auto');
+  });
+
   // 1 Test for striped and animated
   // striped
   // animated

--- a/packages/upload/tests/UploadProgressBar.test.js
+++ b/packages/upload/tests/UploadProgressBar.test.js
@@ -95,7 +95,7 @@ describe('UploadProgressBar', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
-  test('an undefined passwordModalzIndex should leave the modals zIndex as the default 1050', async () => {
+  test('an undefined passwordModalZIndex should leave the modals zIndex as the default 1050', async () => {
     const { getByTestId, findByTestId } = render(
       <UploadProgressBar upload={instance} />
     );
@@ -109,9 +109,9 @@ describe('UploadProgressBar', () => {
     expect(container.style.zIndex).toBe('1050');
   });
 
-  test('setting passwordModalzIndex should change the modals zIndex as the default 1050', async () => {
+  test('setting passwordModalZIndex should change the modals zIndex as the default 1050', async () => {
     const { getByTestId, findByTestId } = render(
-      <UploadProgressBar upload={instance} passwordModalzIndex="auto" />
+      <UploadProgressBar upload={instance} passwordModalZIndex="auto" />
     );
     instance.error('Encrypted files require a password', 'encrypted');
     fireEvent.click(getByTestId('password-form-button'));


### PR DESCRIPTION
I want to add an optional prop to modify the UploadProgressBar password prompt modal in my never ending quest to fix IE11 compatibility issues for this password protected file workflow and then throw away all this work in 6 weeks when IE11 is no longer supported.

There is a longstanding bug with nested modals in Reactstrap for IE11 - see https://github.com/reactstrap/reactstrap/issues/1422 however i discovered in my testing that by setting the z-index for both my userland Reactstrap modal and the Upload password modal to auto I could get IE11 to display the nested password modal in a functional yet suboptimal way.

I tried several other userland fixes but nothing except this appears to work for IE11's non-conforming stacking context algorithm. 


