### PR TITLE
fix(link): fix link target logic

### DIFF
--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -10,19 +10,20 @@ export const getUrl = (url = '', loadApp, absolute) => {
 };
 
 export const getTarget = (target) => {
-  if (
-    !target ||
-    target === 'BODY' || // Thanos
-    target === 'newBody' || // hardcoded in spaces ( Bad practice )
-    target === '_self' // Actual way of doing it
-  ) {
-    return '_self';
+  // should start with _, otherwise it is specifying a specific frame name
+  // _blank = new tab/window, _self = same frame, _parent = parent frame (use for home page from modals), _top = document body, framename = specific frame
+  if (target && !target.startsWith('_')) {
+    // Thanos uses BODY
+    // 'newBody' hard-coded in spaces -> should we keep this logic?
+    if (target === 'BODY' || target === 'newBody') {
+      return '_self';
+    }
+    if (target === 'TAB') {
+      return '_blank';
+    }
   }
 
-  if (target === 'TAB' || target === '_blank' || target === '_top') {
-    return '_blank';
-  }
-  return null;
+  return target || null;
 };
 
 // takes href and transforms it so that we can compare hostnames and other properties

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -23,7 +23,7 @@ export const getTarget = (target) => {
     }
   }
 
-  return target || null;
+  return target || '_self';
 };
 
 // takes href and transforms it so that we can compare hostnames and other properties

--- a/packages/link/test/Link.test.js
+++ b/packages/link/test/Link.test.js
@@ -91,14 +91,28 @@ describe('AvLink', () => {
   });
 
   test('should do getTarget transformation', () => {
-    const { getByTestId } = render(
+    const { getByTestId, rerender } = render(
       <AvLink loadApp={false} href="https://github.com/Availity" target="TAB">
         My App
       </AvLink>
     );
-
-    const tag = getByTestId('av-link-tag');
-
+    let tag = getByTestId('av-link-tag');
     expect(tag.getAttribute('target')).toBe('_blank');
+
+    rerender(
+      <AvLink loadApp={false} href="https://github.com/Availity" target="BODY">
+        My App
+      </AvLink>
+    );
+    tag = getByTestId('av-link-tag');
+    expect(tag.getAttribute('target')).toBe('_self');
+
+    rerender(
+      <AvLink href="https://github.com/Availity" target="_parent">
+        My App
+      </AvLink>
+    );
+    tag = getByTestId('av-link-tag');
+    expect(tag.getAttribute('target')).toBe('_parent');
   });
 });


### PR DESCRIPTION
Target values should start with "_" (_blank, _self, _top, or _parent), and account for some other hardcoded use cases

Specific use case for this fix is modals with a home page redirect do not work if "_parent" is not allowed or "newBody" is overwritten