### PR TITLE
feat(select): add selectByValue prop to autopopulate an option

### DIFF
--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -122,3 +122,13 @@ For example, if the new value is `{ "payer": { "name": "Availity", "id": "1" } }
   payerNameAndId: opt => `${opt.payer.id} - ${opt.payer.name}`,
 }
 ```
+
+### `selectByValue?: SelectByValue`
+
+Allows the value passed to be automatically selected in the dropdown. If the options are strings, pass the `value` property as the value to match on. If the dropdown options are objects, pass a `key` and `value` property to match the unique option where the `option[key]` value is equal to `value`.
+
+For example, to match an organization on the AvOrganizationSelect (the options are the entire organization object), you can match the `customerId` as the `key` to the `value` of `1234`
+
+```js
+selectByValue={{key: 'customerId', value: '1234'}}
+```

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -29,6 +29,13 @@ const options = [
   { label: 'Option 4', value: 'value for option 4' },
 ];
 
+const objectOptions = [
+  { label: 'Option 1', value: { id: 1, someKey: 'value for option 1' } },
+  { label: 'Option 2', value: { id: 2, someKey: 'value for option 2' } },
+  { label: 'Option 3', value: { id: 3, someKey: 'value for option 3' } },
+  { label: 'Option 4', value: { id: 4, someKey: 'value for option 4' } },
+];
+
 const groupedOptions = [
   {
     label: 'options',
@@ -698,6 +705,100 @@ describe('Select', () => {
     // Check the loadOptions is called only after the input has been focused
     await waitFor(() => {
       expect(loadOptions).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('selectByValue from string option is autoselected', async () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        validationSchema={singleValueSchema('singleSelect')}
+        onSubmit={onSubmit}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          selectByValue={{ value: 'value for option 3' }}
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await waitFor(() => {
+      fireEvent.click(getByText('Submit'));
+      waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            singleSelect: 'value for option 3',
+          }),
+          expect.anything()
+        );
+      });
+    });
+  });
+
+  test('selectByValue from object option is autoselected', async () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={objectOptions}
+          data-testid="single-select"
+          selectByValue={{ key: 'id', value: 3 }}
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await waitFor(() => {
+      fireEvent.click(getByText('Submit'));
+      waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            singleSelect: { id: 3, someKey: 'value for option 3' },
+          }),
+          expect.anything()
+        );
+      });
+    });
+  });
+
+  test('selectByValue is not autoselected if no option is found', async () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={objectOptions}
+          data-testid="single-select"
+          selectByValue={{ key: 'id', value: 88 }}
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await waitFor(() => {
+      fireEvent.click(getByText('Submit'));
+      waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/select/typings/ResourceSelect.d.ts
+++ b/packages/select/typings/ResourceSelect.d.ts
@@ -12,6 +12,11 @@ interface GraphQLConfigType {
   query?: string;
 }
 
+interface SelectByValue {
+  value: string;
+  key?: string;
+}
+
 export type OptionType = Record<string, any>;
 
 export type Additional = any;
@@ -47,6 +52,7 @@ export interface ResourceSelectProps<T> extends SelectFieldProps<T> {
   pageAll?: boolean;
   pageAllSearchBy?: (previousOptions: any[], inputValue: string) => any[];
   onError?: (error: Error) => void;
+  selectByValue: SelectByValue;
 }
 
 declare class ResourceSelect<T> extends React.Component<

--- a/packages/select/typings/Select.d.ts
+++ b/packages/select/typings/Select.d.ts
@@ -8,6 +8,11 @@ interface GroupedOptions {
   type: 'group';
 }
 
+interface SelectByValue {
+  value: string;
+  key?: string;
+}
+
 export interface SelectProps<T> extends Props<{}> {
   loadOptions?: Function;
   raw?: boolean;
@@ -21,6 +26,7 @@ export interface SelectProps<T> extends Props<{}> {
   validate?: FieldValidator;
   autofill?: boolean | object;
   creatable?: boolean;
+  selectByValue?: SelectByValue;
 }
 
 declare class Select<T> extends React.Component<SelectProps<T>> {}


### PR DESCRIPTION
pass a prop to autoselect an option based on the value or specific key of the value. Useful for when you want to autopopulate the select w/o having the entire option data for `initialValues`