### PR TITLE
feat(favorites): accessibility updates

### DIFF
--- a/docusaurus/docs/components/favorites/favorites.md
+++ b/docusaurus/docs/components/favorites/favorites.md
@@ -13,7 +13,7 @@ import '@availity/favorites/style.scss';
 
 const Example = () => (
   <Favorites>
-    <FavoriteHeart id="12345" />
+    <FavoriteHeart id="12345" name="My App" />
   </Favorites>
 );
 ```

--- a/docusaurus/docs/components/favorites/heart.md
+++ b/docusaurus/docs/components/favorites/heart.md
@@ -13,7 +13,7 @@ import '@availity/favorites/style.scss';
 
 const Example = () => (
   <Favorites>
-    <FavoriteHeart id="12345" />
+    <FavoriteHeart id="12345" name="My App" />
   </Favorites>
 );
 ```
@@ -23,6 +23,10 @@ const Example = () => (
 #### `id: string`
 
 The unique id of the favorite item to be fetched from API.
+
+#### `name: string`
+
+Name of item to be favorited. *Used to generate unique name of control, needed for accessibility.*
 
 #### `onChange?: (isFavorited: boolean, event?: Event) => void`
 

--- a/docusaurus/docs/components/favorites/index.md
+++ b/docusaurus/docs/components/favorites/index.md
@@ -23,7 +23,7 @@ const Example = () => (
   <Favorites>
     {({ default: FavoritesProvider, FavoriteHeart }) => (
       <FavoritesProvider>
-        <FavoriteHeart id="12345" />
+        <FavoriteHeart id="12345" name="My App" />
       </FavoritesProvider>
     )}
   </Favorites>

--- a/jest/setupTests.js
+++ b/jest/setupTests.js
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 // eslint-disable-next-line no-console
 const originalError = console.error;
 

--- a/packages/favorites/FavoriteHeart.js
+++ b/packages/favorites/FavoriteHeart.js
@@ -5,7 +5,7 @@ import { Tooltip } from 'reactstrap';
 import { useFavorites } from './FavoritesContext';
 
 // eslint-disable-next-line react-hooks/exhaustive-deps
-const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
+const FavoriteHeart = ({ id, name, onChange, onMouseDown, ...props }) => {
   const [isFavorite, toggleFavorite] = useFavorites(id);
   const [tooltipOpen, toggleTooltip] = useToggle(false);
   const [loading, toggleLoading] = useToggle(true);
@@ -22,9 +22,9 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
     return (
       <span
         id={`av-favorite-heart-${id}`}
-        role="button"
-        aria-label="Favorite"
-        aria-describedby={`av-favorite-heart-desc-${id}`}
+        role="checkbox"
+        aria-label={`Favorite ${name || ''}`}
+        aria-checked={isFavorite}
         {...props}
         tabIndex="0"
         className={`favorite-heart pt-4 ${isFavorite && 'active'}`}
@@ -34,21 +34,17 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
             onMouseDown(e);
           }
         }}
-        onKeyPress={(e) => e.charCode === 13 && onChangeHandler(e)}
+        onKeyPress={(e) =>
+          (e.key === ' ' || e.key === 'Enter') && onChangeHandler(e)
+        }
         onClick={onChangeHandler}
       >
-        <span className="sr-only">Favorite</span>
-        <span className="sr-only" id={`av-favorite-heart-desc-${id}`}>
-          {isFavorite
-            ? 'This item is favorited.'
-            : 'This item is not favorited.'}
-        </span>
-        <span className="icon outline" />
-        <span className="icon default-filled" />
-        <span className="icon selected-filled" />
+        <span aria-hidden className="icon outline" />
+        <span aria-hidden className="icon default-filled" />
+        <span aria-hidden className="icon selected-filled" />
       </span>
     );
-  }, [id, isFavorite, onMouseDown, props, onChange, toggleFavorite]);
+  }, [id, name, isFavorite, onMouseDown, props, onChange, toggleFavorite]);
 
   useEffectAsync(async () => {
     toggleLoading(false);
@@ -80,6 +76,7 @@ const FavoriteHeart = ({ id, onChange, onMouseDown, ...props }) => {
 
 FavoriteHeart.propTypes = {
   id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   onMouseDown: PropTypes.func,
 };

--- a/packages/favorites/README.md
+++ b/packages/favorites/README.md
@@ -4,4 +4,4 @@
 
 [![Version](https://img.shields.io/npm/v/@availity/favorites.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/favorites)
 
-## [Documentation](https://availity.github.io/availity-react/components/favorites)
+## [Documentation](https://availity.github.io/availity-react/components/favorites/index)

--- a/packages/favorites/__test__/FavoriteHeart.test.js
+++ b/packages/favorites/__test__/FavoriteHeart.test.js
@@ -111,6 +111,34 @@ describe('FavoriteHeart', () => {
     global.document.createRange = null;
   });
 
+  test('should render label with app name', async () => {
+    const { container } = render(
+      <Favorites>
+        <FavoriteHeart id="123" name="Test App" />
+      </Favorites>
+    );
+
+    const heart = container.querySelector('#av-favorite-heart-123');
+
+    expect(heart).toBeDefined();
+
+    expect(heart).toHaveAttribute('aria-label', 'Favorite Test App');
+  });
+
+  test('should not render with undefined in label if no app name given', async () => {
+    const { container } = render(
+      <Favorites>
+        <FavoriteHeart id="123" />
+      </Favorites>
+    );
+
+    const heart = container.querySelector('#av-favorite-heart-123');
+
+    expect(heart).toBeDefined();
+
+    expect(heart).toHaveAttribute('aria-label', 'Favorite ');
+  });
+
   test('should add favorite and send post message with updated favorites', async () => {
     avSettingsApi.getApplication = getApplicationMock;
     avSettingsApi.setApplication = jest.fn().mockResolvedValue({
@@ -141,8 +169,6 @@ describe('FavoriteHeart', () => {
     const heart = container.querySelector('#av-favorite-heart-789');
 
     expect(heart).toBeDefined();
-
-    expect(heart).toHaveAttribute('aria-label', 'Favorite ');
 
     await waitFor(() => expect(heart).not.toBeChecked());
 
@@ -180,15 +206,13 @@ describe('FavoriteHeart', () => {
   test('should render favorited', async () => {
     const { container } = render(
       <Favorites>
-        <FavoriteHeart id="123" name="Test App" />
+        <FavoriteHeart id="123" />
       </Favorites>
     );
 
     const heart = container.querySelector('#av-favorite-heart-123');
 
     expect(heart).toBeDefined();
-
-    expect(heart).toHaveAttribute('aria-label', 'Favorite Test App');
 
     await waitFor(() => expect(heart).toBeChecked());
   });

--- a/packages/favorites/__test__/FavoriteHeart.test.js
+++ b/packages/favorites/__test__/FavoriteHeart.test.js
@@ -132,7 +132,7 @@ describe('FavoriteHeart', () => {
       },
     });
 
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="789" />
       </Favorites>
@@ -142,12 +142,14 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    expect(heart).toHaveAttribute('aria-label', 'Favorite ');
+
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     // Simulate user favoriting item
     await fireEvent.click(heart);
 
-    await waitFor(() => getByText('This item is favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
 
     expect(avSettingsApi.setApplication).toHaveBeenCalledTimes(1);
     // Test that favorite gets sent to settings and to correct position
@@ -176,31 +178,37 @@ describe('FavoriteHeart', () => {
   });
 
   test('should render favorited', async () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
-        <FavoriteHeart id="123" />
+        <FavoriteHeart id="123" name="Test App" />
       </Favorites>
     );
 
-    expect(container.querySelector('#av-favorite-heart-123')).toBeDefined();
+    const heart = container.querySelector('#av-favorite-heart-123');
 
-    await waitFor(() => getByText('This item is favorited.'));
+    expect(heart).toBeDefined();
+
+    expect(heart).toHaveAttribute('aria-label', 'Favorite Test App');
+
+    await waitFor(() => expect(heart).toBeChecked());
   });
 
   test('should render not favorited', async () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="1234" />
       </Favorites>
     );
 
-    expect(container.querySelector('#av-favorite-heart-1234')).toBeDefined();
+    const heart = container.querySelector('#av-favorite-heart-1234');
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    expect(heart).toBeDefined();
+
+    await waitFor(() => expect(heart).not.toBeChecked());
   });
 
   test('should update when avMessage changed event triggers from elsewhere', async () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="123" />
       </Favorites>
@@ -210,7 +218,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
 
     avMessages.DOMAIN = 'http://localhost';
 
@@ -219,11 +227,11 @@ describe('FavoriteHeart', () => {
       message: { favorites: [] },
     });
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
   });
 
   test('should update when avMessage updated event triggers from elsewhere', async () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="123" />
       </Favorites>
@@ -233,7 +241,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
 
     avMessages.DOMAIN = 'http://localhost';
 
@@ -242,7 +250,7 @@ describe('FavoriteHeart', () => {
       message: { favorites: [] },
     });
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
   });
 
   test('should delete favorite and send post message with updated favorites', async () => {
@@ -259,7 +267,7 @@ describe('FavoriteHeart', () => {
       })
     );
 
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="123" />
       </Favorites>
@@ -269,12 +277,12 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
 
     // Simulate user unfavoriting item
     fireEvent.click(heart);
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     expect(avMessages.send).toHaveBeenCalledTimes(1);
     expect(avMessages.send.mock.calls[0][0].event).toBe('av:favorites:update');
@@ -299,7 +307,7 @@ describe('FavoriteHeart', () => {
       })
     );
 
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="123" />
       </Favorites>
@@ -309,12 +317,12 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is favorited.'));
+    await waitFor(() => expect(heart).toBeChecked());
 
     // Simulate user unfavoriting item
     fireEvent.keyPress(heart, { key: 'Enter', code: 13, charCode: 13 });
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     expect(avMessages.send).toHaveBeenCalledTimes(1);
     expect(avMessages.send.mock.calls[0][0].event).toBe('av:favorites:update');
@@ -326,7 +334,7 @@ describe('FavoriteHeart', () => {
 
   test('should call onChange once toggled', async () => {
     const onChange = jest.fn(() => {});
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart onChange={onChange} id="1234" />
       </Favorites>
@@ -336,7 +344,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     fireEvent.click(heart);
 
@@ -345,7 +353,7 @@ describe('FavoriteHeart', () => {
   test('should prevent default focus event', async () => {
     const onChange = jest.fn(() => {});
     const onMouseDown = jest.fn();
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart
           onChange={onChange}
@@ -359,7 +367,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     const event = new MouseEvent('mouseDown');
 
@@ -371,7 +379,7 @@ describe('FavoriteHeart', () => {
   });
 
   test('should show tooltip', async () => {
-    const { container, getByText, getByTestId } = render(
+    const { container, getByTestId } = render(
       <Favorites>
         <FavoriteHeart id="1234" />
       </Favorites>
@@ -381,7 +389,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     await fireEvent.mouseOver(heart);
 
@@ -408,7 +416,7 @@ describe('FavoriteHeart', () => {
       })
     );
 
-    const { container, getByText } = render(
+    const { container } = render(
       <Favorites>
         <FavoriteHeart id="123" />
       </Favorites>
@@ -418,7 +426,7 @@ describe('FavoriteHeart', () => {
 
     expect(heart).toBeDefined();
 
-    await waitFor(() => getByText('This item is not favorited.'));
+    await waitFor(() => expect(heart).not.toBeChecked());
 
     fireEvent.click(heart);
 

--- a/packages/favorites/style.scss
+++ b/packages/favorites/style.scss
@@ -56,7 +56,7 @@ $av-heart-val-borderSize: $av-heart-val-iconSize + 2;
       content: $av-heart-val-emptyHeart;
     }
   }
-  &:hover {
+  &:hover, &:focus {
     .default-filled {
       height: $av-heart-val-borderSize;
       width: $av-heart-val-borderSize;
@@ -90,7 +90,7 @@ $av-heart-val-borderSize: $av-heart-val-iconSize + 2;
     .outline {
       display: none;
     }
-    &:hover {
+    &:hover, &:focus {
       .selected-filled {
         color: $av-heart-val-selected-color-hover;
       }

--- a/packages/favorites/types/FavoriteHeart.d.ts
+++ b/packages/favorites/types/FavoriteHeart.d.ts
@@ -1,6 +1,7 @@
 interface FavoriteHeartProps {
   [key: string]: any;
   id: string;
+  name: string;
   onChange?: (isFavorited: boolean, event: React.MouseEvent<any>) => void;
 }
 declare const FavoriteHeart: React.FunctionComponent<FavoriteHeartProps>;

--- a/storybook/stories/favorites.stories.js
+++ b/storybook/stories/favorites.stories.js
@@ -21,7 +21,7 @@ storiesOf('Icons|Favorite', module)
   .add('default', () => (
     <Favorites>
       <Card tag={CardBody} className="d-flex flex-row">
-        <FavoriteHeart id="1234" />
+        <FavoriteHeart id="1234" name="Hello World" />
         <CardTitle className="ml-2">Hello World</CardTitle>
       </Card>
     </Favorites>


### PR DESCRIPTION
[issue]
Favorite heart custom control does not provide a unique textual name in context.

[Recommendation]
- Use role=checkbox to communicate type of control
- Use aria-label with descriptive text to communicate name of control
- Use aria-checked with true/false value to communicate state of control
- Use tabindex=0 to allow focus within the page sequence
