### PR TITLE
Pagination accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ reports/
 /**/dist
 /**/lib
 /**/node_modules
+/**/storybook-docs

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -40,3 +40,8 @@ When `true` an ellipse is displayed when there are more pages outside of the pag
 #### `ariaLabel?: string`
 
 If used, it will override the default ariaLabel prop. **Default:** `pagination`
+
+#### `listClassName?: string`
+
+Add bootstrap styles to list element.
+

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -36,3 +36,7 @@ The number of pages to display on the ends when there are pages outside of the p
 #### `breakLabel?: boolean`
 
 When `true` an ellipse is displayed when there are more pages outside of the page range.
+
+#### `ariaLabel?: string`
+
+If used, it will override the default ariaLabel prop. **Default:** `pagination`

--- a/packages/pagination/src/PaginationContent.js
+++ b/packages/pagination/src/PaginationContent.js
@@ -104,6 +104,7 @@ const PaginationContent = ({
         <Button
           data-testid="sr-only-pagination-load-more-btn"
           className="sr-only"
+          aria-label="Load More"
           onClick={() => {
             setDoFocusRefOnPageChange(true);
             setPage(currentPage + 1);

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -108,7 +108,7 @@ const PaginationControls = ({
   };
 
   return pageCount > 1 || !autoHide ? (
-    <Pagination data-testid="pagination-controls-con" aria-label={ariaLabel} {...rest}>
+    <Pagination data-testid="pagination-controls-con" {...rest}>
       {directionLinks ? (
         <PaginationItem
           disabled={currentPage === 1}

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -15,7 +15,6 @@ const PaginationControls = ({
   marginPages,
   breakLabel,
   ariaLabel,
-  listClassName,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -15,6 +15,7 @@ const PaginationControls = ({
   marginPages,
   breakLabel,
   ariaLabel,
+  listClassName,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -58,7 +59,7 @@ const PaginationControls = ({
       <PaginationLink
         onClick={() => handleBreakClick(index)}
         type="button"
-        aria-label={currentPage < index ? 'Jump forwards to page ' + getForwardJump() : 'Jump backwards to page ' + getBackwardJump()}
+        aria-label={currentPage < index ? `Jump forwards to page ${getForwardJump()}` : `Jump backwards to page ${getBackwardJump()}`}
         >
         &hellip;
       </PaginationLink>
@@ -161,7 +162,8 @@ PaginationControls.propTypes = {
   pageRange: PropTypes.number,
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
-  ariaLabel: PropTypes.string
+  ariaLabel: PropTypes.string,
+  listClassName: PropTypes.string,
 };
 
 PaginationControls.defaultProps = {
@@ -172,4 +174,5 @@ PaginationControls.defaultProps = {
   breakLabel: true,
   ariaLabel: 'pagination'
 };
+
 export default PaginationControls;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -30,7 +30,7 @@ const PaginationControls = ({
         style={{ zIndex: 'auto' }}
         onClick={() => setPage(pageNumber)}
         type="button"
-        aria-label={`Page ${pageNumber}`}
+        aria-label={`Go to page ${pageNumber}`}
         aria-current={currentPage === pageNumber}
       >
         {pageNumber}
@@ -58,8 +58,8 @@ const PaginationControls = ({
       <PaginationLink
         onClick={() => handleBreakClick(index)}
         type="button"
-        aria-label="ellipsis"
-      >
+        aria-label={currentPage < index ? 'Jump forwards to page ' + getForwardJump() : 'Jump backwards to page ' + getBackwardJump()}
+        >
         &hellip;
       </PaginationLink>
     </PaginationItem>

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -14,6 +14,7 @@ const PaginationControls = ({
   pageRange,
   marginPages,
   breakLabel,
+  ariaLabel,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -22,14 +23,15 @@ const PaginationControls = ({
     <PaginationItem
       key={pageNumber}
       active={currentPage === pageNumber}
-      aria-label={`Page ${pageNumber}`}
-      aria-current={currentPage === pageNumber}
       data-testid={`control-page-${pageNumber}`}
     >
       <PaginationLink
+
         style={{ zIndex: 'auto' }}
         onClick={() => setPage(pageNumber)}
         type="button"
+        aria-label={`Page ${pageNumber}`}
+        aria-current={currentPage === pageNumber}
       >
         {pageNumber}
       </PaginationLink>
@@ -53,7 +55,11 @@ const PaginationControls = ({
 
   const createBreak = (index) => (
     <PaginationItem key={index} data-testid={`control-page-${index}`}>
-      <PaginationLink onClick={() => handleBreakClick(index)} type="button">
+      <PaginationLink
+        onClick={() => handleBreakClick(index)}
+        type="button"
+        aria-label="ellipsis"
+      >
         &hellip;
       </PaginationLink>
     </PaginationItem>
@@ -102,7 +108,7 @@ const PaginationControls = ({
   };
 
   return pageCount > 1 || !autoHide ? (
-    <Pagination data-testid="pagination-controls-con" {...rest}>
+    <Pagination data-testid="pagination-controls-con" aria-label={ariaLabel} {...rest}>
       {directionLinks ? (
         <PaginationItem
           disabled={currentPage === 1}
@@ -113,6 +119,7 @@ const PaginationControls = ({
               currentPage === 1 ? null : setPage(currentPage - 1)
             }
             type="button"
+            aria-disabled={currentPage === 1}
             previous
           >
             {leftCaret} Prev
@@ -133,6 +140,7 @@ const PaginationControls = ({
               currentPage === pageCount ? null : setPage(currentPage + 1)
             }
             type="button"
+            aria-disabled={currentPage === pageCount}
             next
           >
             Next {rightCaret}
@@ -153,6 +161,7 @@ PaginationControls.propTypes = {
   pageRange: PropTypes.number,
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
+  ariaLabel: PropTypes.string
 };
 
 PaginationControls.defaultProps = {
@@ -161,5 +170,6 @@ PaginationControls.defaultProps = {
   pageRange: 5,
   marginPages: 2,
   breakLabel: true,
+  ariaLabel: 'pagination'
 };
 export default PaginationControls;

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -139,7 +139,7 @@ describe('Pagination Controls', () => {
       const page1 = getByTestId('control-page-1');
       expect(page1).toBeDefined();
       const page1Button = page1.querySelector('button');
-      expect(page1Button).toHaveAttribute('aria-label', 'Page 1');
+      expect(page1Button).toHaveAttribute('aria-label', 'Go to page 1');
     });
   });
 

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -120,4 +120,79 @@ describe('Pagination Controls', () => {
       expect(next.firstChild.textContent).toContain('Next ›');
     });
   });
+
+  test('should have aria-label with page number on page link buttons', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const page1 = getByTestId('control-page-1');
+      expect(page1).toBeDefined();
+      var page1Button = page1.querySelector('button');
+      expect(page1Button).toHaveAttribute('aria-label', 'Page 1');
+    });
+  });
+
+  test('should have aria-label on the Prev and Next buttons', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks aria-label='toppagination'/>
+      </Pagination>
+    );
+    await waitFor(() => {
+      const previous = getByTestId('pagination-control-previous');
+      expect(previous).toBeDefined();
+      var previousButton = previous.querySelector('button');
+
+      
+      const next = getByTestId('pagination-control-next');
+      expect(next).toBeDefined();
+      var nextButton = next.querySelector('button');
+
+      expect(previousButton).toHaveAttribute('aria-label', 'Previous');
+      expect(nextButton).toHaveAttribute('aria-label', 'Next');
+    });
+  });
+
+  test('should have a customizable pagination aria-label', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks aria-label='pagination below results'/>
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageList = getByTestId('pagination-controls-con');
+      const paginationNav = pageList.parentElement;
+      expect(paginationNav).toBeDefined();
+
+      expect(paginationNav).toHaveAttribute('aria-label', 'pagination below results');
+    });
+  });
+
 });

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -138,7 +138,7 @@ describe('Pagination Controls', () => {
     await waitFor(() => {
       const page1 = getByTestId('control-page-1');
       expect(page1).toBeDefined();
-      var page1Button = page1.querySelector('button');
+      const page1Button = page1.querySelector('button');
       expect(page1Button).toHaveAttribute('aria-label', 'Page 1');
     });
   });
@@ -160,12 +160,12 @@ describe('Pagination Controls', () => {
     await waitFor(() => {
       const previous = getByTestId('pagination-control-previous');
       expect(previous).toBeDefined();
-      var previousButton = previous.querySelector('button');
+      const previousButton = previous.querySelector('button');
 
       
       const next = getByTestId('pagination-control-next');
       expect(next).toBeDefined();
-      var nextButton = next.querySelector('button');
+      const nextButton = next.querySelector('button');
 
       expect(previousButton).toHaveAttribute('aria-label', 'Previous');
       expect(nextButton).toHaveAttribute('aria-label', 'Next');

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -154,7 +154,12 @@ describe('Pagination Controls', () => {
 
     const { getByTestId } = render(
       <Pagination items={items} itemsPerPage={1}>
-        <PaginationControls pageRange={5} marginPages={1} directionLinks aria-label='toppagination'/>
+        <PaginationControls
+          pageRange={5}
+          marginPages={1}
+          directionLinks
+          aria-label="toppagination"
+        />
       </Pagination>
     );
     await waitFor(() => {
@@ -162,7 +167,6 @@ describe('Pagination Controls', () => {
       expect(previous).toBeDefined();
       const previousButton = previous.querySelector('button');
 
-      
       const next = getByTestId('pagination-control-next');
       expect(next).toBeDefined();
       const nextButton = next.querySelector('button');
@@ -183,7 +187,12 @@ describe('Pagination Controls', () => {
 
     const { getByTestId } = render(
       <Pagination items={items} itemsPerPage={1}>
-        <PaginationControls pageRange={5} marginPages={1} directionLinks aria-label='pagination below results'/>
+        <PaginationControls
+          pageRange={5}
+          marginPages={1}
+          directionLinks
+          aria-label="pagination below results"
+        />
       </Pagination>
     );
     await waitFor(() => {
@@ -191,8 +200,51 @@ describe('Pagination Controls', () => {
       const paginationNav = pageList.parentElement;
       expect(paginationNav).toBeDefined();
 
-      expect(paginationNav).toHaveAttribute('aria-label', 'pagination below results');
+      expect(paginationNav).toHaveAttribute(
+        'aria-label',
+        'pagination below results'
+      );
     });
   });
 
+  test('should have a page break ellipsis to jump forward', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '6', key: 6 },
+      { value: '7', key: 7 },
+      { value: '8', key: 8 },
+      { value: '9', key: 9 },
+      { value: '10', key: 10 },
+      { value: '11', key: 11 },
+      { value: '12', key: 12 },
+      { value: '13', key: 13 },
+      { value: '14', key: 14 },
+      { value: '15', key: 15 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls
+          pageRange={5}
+          marginPages={2}
+          breakLabel
+          directionLinks
+          aria-label="pagination below results"
+        />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageBreakEllipsisItem = getByTestId('control-page-7');
+      const pageBreakEllipsisLink = pageBreakEllipsisItem.firstChild;
+      expect(pageBreakEllipsisLink).toBeDefined();
+
+      expect(pageBreakEllipsisLink).toHaveAttribute(
+        'aria-label',
+        'Jump forwards to page 6'
+      );
+    });
+  });
 });

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -103,6 +103,9 @@ storiesOf('Components|Pagination', module)
       <PaginationControls
         directionLinks={boolean('Direction Links', true)}
         autoHide={boolean('Auto Hide', true)}
+        listClassName={
+          boolean('Unstyled', false) ? 'pagination-unstyled' : ''
+        }
       />
     </Pagination>
   ))
@@ -130,6 +133,9 @@ storiesOf('Components|Pagination', module)
               breakLabel={boolean('Break Label', true)}
               marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
               directionLinks={boolean('Direction Links', true)}
+              listClassName={
+                boolean('Unstyled', false) ? 'pagination-unstyled' : ''
+              }
             />
           )}
         </div>

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -88,6 +88,7 @@ storiesOf('Components|Pagination', module)
               marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
               directionLinks={boolean('Direction Links', true)}
               autoHide={boolean('Auto Hide Controls', true)}
+              ariaLabel="pagination below results"
             />
           )}
         </div>

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -89,6 +89,9 @@ storiesOf('Components|Pagination', module)
               directionLinks={boolean('Direction Links', true)}
               autoHide={boolean('Auto Hide Controls', true)}
               ariaLabel="pagination below results"
+              listClassName={
+                boolean('Unstyled', false) ? 'pagination-unstyled' : ''
+              }
             />
           )}
         </div>


### PR DESCRIPTION
- Move aria-label and aria-current attributes from the LI to the BUTTON elements to ensure name and state are announced.
- Allow for user to pass in custom aria label for pagination. e.g. `aria-label="pagination above results"`, `aria-label="pagination below results"`. This allows us to differentiate between components if there is more than 1 pagination component on the page.
