### PR TITLE
Pagination: adding custom aria-label and listClassName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ reports/
 /**/dist
 /**/lib
 /**/node_modules
+/**/storybook-docs

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -36,3 +36,12 @@ The number of pages to display on the ends when there are pages outside of the p
 #### `breakLabel?: boolean`
 
 When `true` an ellipse is displayed when there are more pages outside of the page range.
+
+#### `ariaLabel?: string`
+
+If used, it will override the default ariaLabel prop. **Default:** `pagination`
+
+#### `listClassName?: string`
+
+Add bootstrap styles to list element.
+

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -41,3 +41,7 @@ When `true` an ellipse is displayed when there are more pages outside of the pag
 
 Add bootstrap styles to list element.
 
+#### `aria-label?: string`
+
+Allows for custom aria-label.
+

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -37,10 +37,6 @@ The number of pages to display on the ends when there are pages outside of the p
 
 When `true` an ellipse is displayed when there are more pages outside of the page range.
 
-#### `ariaLabel?: string`
-
-If used, it will override the default ariaLabel prop. **Default:** `pagination`
-
 #### `listClassName?: string`
 
 Add bootstrap styles to list element.

--- a/packages/pagination/src/PaginationContent.js
+++ b/packages/pagination/src/PaginationContent.js
@@ -104,6 +104,7 @@ const PaginationContent = ({
         <Button
           data-testid="sr-only-pagination-load-more-btn"
           className="sr-only"
+          aria-label="Load More"
           onClick={() => {
             setDoFocusRefOnPageChange(true);
             setPage(currentPage + 1);

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -14,7 +14,6 @@ const PaginationControls = ({
   pageRange,
   marginPages,
   breakLabel,
-  ariaLabel,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -164,7 +163,6 @@ PaginationControls.propTypes = {
   pageRange: PropTypes.number,
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
-  ariaLabel: PropTypes.string,
   listClassName: PropTypes.string,
 };
 
@@ -174,7 +172,6 @@ PaginationControls.defaultProps = {
   pageRange: 5,
   marginPages: 2,
   breakLabel: true,
-  ariaLabel: 'pagination',
 };
 
 export default PaginationControls;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -15,7 +15,6 @@ const PaginationControls = ({
   marginPages,
   breakLabel,
   ariaLabel,
-  listClassName,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -14,6 +14,7 @@ const PaginationControls = ({
   pageRange,
   marginPages,
   breakLabel,
+  ariaLabel,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -22,14 +23,14 @@ const PaginationControls = ({
     <PaginationItem
       key={pageNumber}
       active={currentPage === pageNumber}
-      aria-label={`Page ${pageNumber}`}
-      aria-current={currentPage === pageNumber}
       data-testid={`control-page-${pageNumber}`}
     >
       <PaginationLink
         style={{ zIndex: 'auto' }}
         onClick={() => setPage(pageNumber)}
         type="button"
+        aria-label={`Go to page ${pageNumber}`}
+        aria-current={currentPage === pageNumber}
       >
         {pageNumber}
       </PaginationLink>
@@ -53,7 +54,15 @@ const PaginationControls = ({
 
   const createBreak = (index) => (
     <PaginationItem key={index} data-testid={`control-page-${index}`}>
-      <PaginationLink onClick={() => handleBreakClick(index)} type="button">
+      <PaginationLink
+        onClick={() => handleBreakClick(index)}
+        type="button"
+        aria-label={
+          currentPage < index
+            ? `Jump forwards to page ${getForwardJump()}`
+            : `Jump backwards to page ${getBackwardJump()}`
+        }
+      >
         &hellip;
       </PaginationLink>
     </PaginationItem>
@@ -113,6 +122,7 @@ const PaginationControls = ({
               currentPage === 1 ? null : setPage(currentPage - 1)
             }
             type="button"
+            aria-disabled={currentPage === 1}
             previous
           >
             {leftCaret} Prev
@@ -133,6 +143,7 @@ const PaginationControls = ({
               currentPage === pageCount ? null : setPage(currentPage + 1)
             }
             type="button"
+            aria-disabled={currentPage === pageCount}
             next
           >
             Next {rightCaret}
@@ -153,6 +164,7 @@ PaginationControls.propTypes = {
   pageRange: PropTypes.number,
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
+  ariaLabel: PropTypes.string,
 };
 
 PaginationControls.defaultProps = {
@@ -161,5 +173,6 @@ PaginationControls.defaultProps = {
   pageRange: 5,
   marginPages: 2,
   breakLabel: true,
+  ariaLabel: 'pagination',
 };
 export default PaginationControls;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -164,6 +164,7 @@ PaginationControls.propTypes = {
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
   listClassName: PropTypes.string,
+  'aria-label': PropTypes.string,
 };
 
 PaginationControls.defaultProps = {

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -15,6 +15,7 @@ const PaginationControls = ({
   marginPages,
   breakLabel,
   ariaLabel,
+  listClassName,
   ...rest
 }) => {
   const { pageCount, currentPage, setPage } = usePagination();
@@ -165,6 +166,7 @@ PaginationControls.propTypes = {
   marginPages: PropTypes.number,
   breakLabel: PropTypes.bool,
   ariaLabel: PropTypes.string,
+  listClassName: PropTypes.string,
 };
 
 PaginationControls.defaultProps = {
@@ -175,4 +177,5 @@ PaginationControls.defaultProps = {
   breakLabel: true,
   ariaLabel: 'pagination',
 };
+
 export default PaginationControls;

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -207,6 +207,29 @@ describe('Pagination Controls', () => {
     });
   });
 
+  test('should have a default pagination aria-label', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageList = getByTestId('pagination-controls-con');
+      const paginationNav = pageList.parentElement;
+      expect(paginationNav).toBeDefined();
+
+      expect(paginationNav).toHaveAttribute('aria-label', 'pagination');
+    });
+  });
+
   test('should have a page break ellipsis to jump forward', async () => {
     const items = [
       { value: '1', key: 1 },

--- a/packages/pagination/src/__test__/PaginationControls.test.js
+++ b/packages/pagination/src/__test__/PaginationControls.test.js
@@ -120,4 +120,131 @@ describe('Pagination Controls', () => {
       expect(next.firstChild.textContent).toContain('Next ›');
     });
   });
+
+  test('should have aria-label with page number on page link buttons', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const page1 = getByTestId('control-page-1');
+      expect(page1).toBeDefined();
+      const page1Button = page1.querySelector('button');
+      expect(page1Button).toHaveAttribute('aria-label', 'Go to page 1');
+    });
+  });
+
+  test('should have aria-label on the Prev and Next buttons', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls
+          pageRange={5}
+          marginPages={1}
+          directionLinks
+          aria-label="toppagination"
+        />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const previous = getByTestId('pagination-control-previous');
+      expect(previous).toBeDefined();
+      const previousButton = previous.querySelector('button');
+
+      const next = getByTestId('pagination-control-next');
+      expect(next).toBeDefined();
+      const nextButton = next.querySelector('button');
+
+      expect(previousButton).toHaveAttribute('aria-label', 'Previous');
+      expect(nextButton).toHaveAttribute('aria-label', 'Next');
+    });
+  });
+
+  test('should have a customizable pagination aria-label', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls
+          pageRange={5}
+          marginPages={1}
+          directionLinks
+          aria-label="pagination below results"
+        />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageList = getByTestId('pagination-controls-con');
+      const paginationNav = pageList.parentElement;
+      expect(paginationNav).toBeDefined();
+
+      expect(paginationNav).toHaveAttribute(
+        'aria-label',
+        'pagination below results'
+      );
+    });
+  });
+
+  test('should have a page break ellipsis to jump forward', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '6', key: 6 },
+      { value: '7', key: 7 },
+      { value: '8', key: 8 },
+      { value: '9', key: 9 },
+      { value: '10', key: 10 },
+      { value: '11', key: 11 },
+      { value: '12', key: 12 },
+      { value: '13', key: 13 },
+      { value: '14', key: 14 },
+      { value: '15', key: 15 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls
+          pageRange={5}
+          marginPages={2}
+          breakLabel
+          directionLinks
+          aria-label="pagination below results"
+        />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageBreakEllipsisItem = getByTestId('control-page-7');
+      const pageBreakEllipsisLink = pageBreakEllipsisItem.firstChild;
+      expect(pageBreakEllipsisLink).toBeDefined();
+
+      expect(pageBreakEllipsisLink).toHaveAttribute(
+        'aria-label',
+        'Jump forwards to page 6'
+      );
+    });
+  });
 });

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -88,6 +88,7 @@ storiesOf('Components|Pagination', module)
               marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
               directionLinks={boolean('Direction Links', true)}
               autoHide={boolean('Auto Hide Controls', true)}
+              ariaLabel="pagination below results"
             />
           )}
         </div>

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -88,7 +88,7 @@ storiesOf('Components|Pagination', module)
               marginPages={number('Margin Pages', 2, { min: 1 }) || 1}
               directionLinks={boolean('Direction Links', true)}
               autoHide={boolean('Auto Hide Controls', true)}
-              ariaLabel="pagination below results"
+              aria-label="custom pagination label"
               listClassName={
                 boolean('Unstyled', false) ? 'pagination-unstyled' : ''
               }

--- a/storybook/stories/pagination.stories.js
+++ b/storybook/stories/pagination.stories.js
@@ -89,6 +89,9 @@ storiesOf('Components|Pagination', module)
               directionLinks={boolean('Direction Links', true)}
               autoHide={boolean('Auto Hide Controls', true)}
               ariaLabel="pagination below results"
+              listClassName={
+                boolean('Unstyled', false) ? 'pagination-unstyled' : ''
+              }
             />
           )}
         </div>


### PR DESCRIPTION
- Move aria-label and aria-current attributes from the LI to the BUTTON elements to ensure name and state are announced.

- Allow for user to pass in custom aria label for pagination. e.g. aria-label="pagination above results", aria-label="pagination below results". This allows us to differentiate between components if there is more than 1 pagination component on the page.

- add custom listClassName prop to allow users to toggle between styled unstyled pagination components.