### PR TITLE
update workflow steps, add default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 *       @chrishavekost @jordan-a-young @nylon22
 
-/packages/upload
+/packages/upload/
 *       @bjnewman

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these users will be requested for
+# review when someone opens a pull request.
+*       @chrishavekost @jordan-a-young @nylon22

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# these users will be requested for
-# review when someone opens a pull request.
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence,
+# these users will be requested for review when someone opens a pull request.
+# Order is important; the last matching pattern takes the most precedence.
+
 *       @chrishavekost @jordan-a-young @nylon22
+
+/packages/upload
+*       @bjnewman

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,19 +18,20 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           fetch-depth: 0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - run: yarn check:packages
       - run: yarn install
       - run: yarn lint
       - run: yarn test:ci
@@ -49,7 +50,6 @@ jobs:
           target_branch: gh-pages
           build_dir: docusaurus/build
           commit_message: deployed docs [skip ci]
-          committer_name: ${{ secrets.GH_USER }}
-          committer_email: ${{ secrets.GH_EMAIL }}
+          committer: ${{ secrets.GH_USER }} ${{ secrets.GH_EMAIL }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,20 +33,23 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - run: yarn check:packages
       - run: yarn install
       - run: yarn lint
       - run: yarn test:ci
         # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
         # Workflow runs triggered by Dependabot PRs run as if they are from a forked repository, using a read-only GITHUB_TOKEN.
         # These workflow runs cannot access any secrets.
-        if: github.actor != 'dependabot[bot]'
       - uses: codecov/codecov-action@v1.0.6 # FIXME: no CI provider detected
+        if: github.actor != 'dependabot[bot]' # TODO: separate workflow for dependabot
         with:
           file: ./coverage/coverage-final.json
           token: ${{ secrets.CODECOV_TOKEN }}
       - run: yarn build:docs
+        if: github.actor != 'dependabot[bot]'
       - name: Deploy draft to Netlify
         uses: South-Paw/action-netlify-deploy@v1.0.4
+        if: github.actor != 'dependabot[bot]'
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           netlify-auth-token: ${{ secrets.NETLIFY_DEPLOY_KEY }}

--- a/scripts/artifactory-check.sh
+++ b/scripts/artifactory-check.sh
@@ -7,6 +7,7 @@
 #
 #   - Run:
 #       npm run check:packages
+#       yarn check:packages
 #
 
 # error out if something fails
@@ -24,8 +25,8 @@ then
   printf " (.-./\`-'\.-.)(.-./\`-\`\.-.)(.-./\`-\`\.-.)(.-./\`-'\.-.)(.-./\`-\`\.-.)\n"
   printf "  \`-'     \`-'  \`-'     \`-'  \`-'     \`-'  \`-'     \`-'  \`-'     \`-' \n"
   printf "\n\n"
-  printf "\nOne of your packages contains a dependency from registry: artifactory.availity.com.\n"
-  printf "Please correct this by running 'yarn nuke' and then 'yarn'.\n\n"
+  printf "\nOne of your packages contains a dependency from a private Availity registry.\n"
+  printf "Please correct this by running 'yarn nuke' and then 'yarn' off of the Availity proxy.\n\n"
   exit 1
 else
   echo "Artifactory Check Passed"


### PR DESCRIPTION
You can see from my commit dates that I meant to push this out a month ago..

This PR updates the versions we use for some GH actions, adds `yarn:check-packages` as part of the build step so that artifactory urls cannot be pushed out accidentally, and it disables some steps for GH Dependabot until we get a separate workflow set up for it.