### PR TITLE
fix(date): added css for onFocus datepickerInput for Accessibility

### DIFF
--- a/packages/date/styles.scss
+++ b/packages/date/styles.scss
@@ -78,6 +78,10 @@
   ); /* Do not remove this. Used to match Date Input heights to Reactstrap Input heights */
 }
 
+.DateInput_input__focused {
+  outline: 3px solid #2261b5;
+}
+
 .av-calendar-show .SingleDatePicker input.DateInput_input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;


### PR DESCRIPTION
Issue
There is no visual indication of keyboard focus when using TAB or SHIFT+TAB to navigate through "Services Dates" front and to date inputs only provide cursor

Applied css provided from UX team for input