### PR TITLE
build: updates gh-pages to v2, fixes commit warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn check:packages
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --prefer-offline
       - run: yarn lint
       - run: yarn test:ci
       - uses: codecov/codecov-action@v1.0.6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - run: yarn release:ci
       - name: Deploy docs
         run: yarn build:deploy
-      - uses: crazy-max/ghaction-github-pages@v1
+      - uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages
           build_dir: docusaurus/build

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,7 +34,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn check:packages
-      - run: yarn install
+      - run: yarn install --frozen-lockfile --prefer-offline
       - run: yarn lint
       - run: yarn test:ci
         # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -2,7 +2,7 @@
   "name": "@availity/feedback",
   "version": "5.8.0",
   "author": "Evan Sharp <evan.sharp@availity.com>",
-  "description": "Availity feedback with simley faces react component.",
+  "description": "Availity feedback with smiley faces react component.",
   "main": "index.js",
   "keywords": [
     "react",


### PR DESCRIPTION
PR #794 used `BREAKING CHANGE` on a `.md` file, so it was ignored during the release. This commit should fix that.