### PR TITLE
fix(select): fixed the contrast issues with the select options backgr…

### DIFF
--- a/packages/pagination/src/__test__/PaginationContent.test.js
+++ b/packages/pagination/src/__test__/PaginationContent.test.js
@@ -133,9 +133,11 @@ describe('Pagination Content', () => {
     expect(getByTestId('pagination-table')).toBeDefined();
     expect(getByTestId('pagination-table-header')).toBeDefined();
 
-    loadPage().items.forEach((item) => {
-      expect(getByTestId(`item-tr-${item.value}`)).toBeDefined();
-      expect(getByTestId(`item-td-${item.value}`)).toBeDefined();
+    await waitFor(() => {
+      loadPage().items.forEach((item) => {
+        expect(getByTestId(`item-tr-${item.value}`)).toBeDefined();
+        expect(getByTestId(`item-td-${item.value}`)).toBeDefined();
+      });
     });
   });
 });

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -335,7 +335,10 @@ const Select = ({
             ...provided,
             borderRadius: '.25em',
             backgroundColor: showError ? '#fbcbc8' : 'white',
-            borderColor: showError ? '#931b1d' : 'hsl(0,0%,80%)',
+            borderColor: showError ? '#931b1d' : '#555555',
+            ':hover': {
+              borderColor: showError ? '#931b1d' : 'rgb(50 98 175)',
+            },
             zIndex: state.focused && '3',
           };
         },
@@ -361,9 +364,17 @@ const Select = ({
         },
         option: (provided) => ({
           ...provided,
-          color: '#000',
         }),
       }}
+      theme={theme => ({
+        ...theme,
+        borderRadius: 0,
+        colors: {
+          ...theme.colors,
+          primary25: '#85a8dc',
+          primary: 'rgb(50 98 175)',
+        },
+      })}
       {...attributes}
       value={getViewValue()}
     />


### PR DESCRIPTION
…ound and text color

Issues being fixed:
1. The following active interface control(s) do not meet the required contrast ratio of 3:1:
All combobox inputs on focus (e.g. "Select a Provider")
All combobox flyout list items on focus
Form input borders (text, comboboxes, listboxes) using light gray on white background
