### PR TITLE
Feat/accessible form groups and input labels

### DIFF
--- a/docusaurus/docs/components/help.mdx
+++ b/docusaurus/docs/components/help.mdx
@@ -53,7 +53,8 @@ import { FieldHelpIcon } from '@availity/help';
 
 const Example = () => (
   <div>
-    Select A Provider <FieldHelpIcon id="1234-5678-910" />
+    <Label id="provider-label">Select A Provider </Label>
+    <FieldHelpIcon id="1234-5678-910" labelId="provider-label" />
   </div>
 );
 ```
@@ -71,3 +72,7 @@ The bootstrap 3 color of the icon. **Default:**`primary`
 #### `size?: string`
 
 The size of the help icon. **Default:** `1x`
+
+### `labelId?: string`
+
+The id of the associated label for `aria-describedby`, needed for accessibility.

--- a/docusaurus/docs/form/components/checkbox-group.md
+++ b/docusaurus/docs/form/components/checkbox-group.md
@@ -15,3 +15,7 @@ Label for the group or checkboxes.
 #### `groupClassName?: string`
 
 Class name to apply to the form control.
+
+#### `helpId?: string`
+
+Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).

--- a/docusaurus/docs/form/components/checkbox.md
+++ b/docusaurus/docs/form/components/checkbox.md
@@ -23,9 +23,9 @@ const Example = () => (
     })}
   >
     <CheckboxGroup name="hello" label="Checkbox Group">
-      <Checkbox groupName="checkboxGroup" label="Check One" value="uno" />
-      <Checkbox groupName="checkboxGroup" label="Check Two" value="dos" />
-      <Checkbox groupName="checkboxGroup" label="Check Three" value="tres" />
+      <Checkbox groupName="hello" label="Check One" value="uno" />
+      <Checkbox groupName="hello" label="Check Two" value="dos" />
+      <Checkbox groupName="hello" label="Check Three" value="tres" />
     </CheckboxGroup>
     <Button type="submit" color="primary">
       Submit
@@ -40,7 +40,7 @@ const Example = () => (
 
 #### `id?: string`
 
-Id and name for the checkbox. **default:** generated uuid
+Id and name for the checkbox.
 
 #### `groupName?: string`
 
@@ -49,6 +49,10 @@ Should match `<CheckboxGroup />` name to accessibly link input to form feedback.
 #### `label?: ReactNode`
 
 Label for the checkbox.
+
+#### `helpId?: string`
+
+Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).
 
 #### `value?: string`
 

--- a/docusaurus/docs/form/components/field.md
+++ b/docusaurus/docs/form/components/field.md
@@ -70,6 +70,10 @@ Class names passed to the input tag.
 
 Class names passed to the label tag.
 
+#### `helpId?: string`
+
+Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).
+
 #### `helpMessage?: React.ReactNode`
 
 Display info text below the field

--- a/docusaurus/docs/form/components/input.md
+++ b/docusaurus/docs/form/components/input.md
@@ -47,7 +47,7 @@ The Node or tag to substitute as the input field. Default is reactstrap `Input` 
 
 Will add default feedback id to `aria-describedby`.
 
-#### `helpMessage?: boolean`
+#### `help?: boolean`
 
 Will add default help message id to `aria-describedby`. Used by `<Field />`.
 

--- a/docusaurus/docs/form/components/radio-group.md
+++ b/docusaurus/docs/form/components/radio-group.md
@@ -19,3 +19,7 @@ Class name to apply to the form control.
 #### `inline?: boolean`
 
 Will render the checkbox inline with other checkboxes.
+
+#### `helpId?: string`
+
+Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).

--- a/docusaurus/docs/form/components/radio.md
+++ b/docusaurus/docs/form/components/radio.md
@@ -38,7 +38,7 @@ const Example = () => (
 
 #### `id?: string`
 
-Id for the radio button. **default:** generated uuid
+Id for the radio button.
 
 #### `name?: string`
 
@@ -47,6 +47,10 @@ Should match `<RadioGroup />` name for validation and accessibly linking button 
 #### `label?: ReactNode`
 
 Label for the radio button.
+
+#### `helpId?: string`
+
+Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).
 
 #### `value?: string`
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@availity/help": "^1.4.0",
     "classnames": "^2.3.1",
     "prop-types": "^15.7.2",
     "uuid": "^8.3.2"

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -35,9 +35,7 @@ const Checkbox = ({
   const labelId = `${inputId}-label`.toLowerCase();
   const helpIcon = helpId ? (
     <FieldHelpIcon id={helpId} labelId={labelId} />
-  ) : (
-    false
-  );
+  ) : null;
 
   return (
     <FormGroup

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { FieldHelpIcon } from '@availity/help';
 import { Label, Input } from 'reactstrap';
 import { v4 as uuid } from 'uuid';
 import classNames from 'classnames';
@@ -14,6 +15,7 @@ const Checkbox = ({
   id,
   inline,
   groupName,
+  helpId,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -30,6 +32,12 @@ const Checkbox = ({
   const errorIndicated = !!metadata.touched && !!metadata.error;
   const groupFeedbackId =
     errorIndicated && groupName ? `${groupName}-feedback`.toLowerCase() : '';
+  const labelId = `${inputId}-label`.toLowerCase();
+  const helpIcon = helpId ? (
+    <FieldHelpIcon id={helpId} labelId={labelId} />
+  ) : (
+    false
+  );
 
   return (
     <FormGroup
@@ -51,9 +59,10 @@ const Checkbox = ({
         checked={value}
         onChange={toggle}
       />
-      <Label check for={inputId}>
+      <Label check id={labelId} for={inputId}>
         {label}
       </Label>
+      {helpIcon}
     </FormGroup>
   );
 };
@@ -71,6 +80,7 @@ Checkbox.propTypes = {
   className: PropTypes.string,
   groupClassName: PropTypes.string,
   groupName: PropTypes.string,
+  helpId: PropTypes.string,
 };
 
 Checkbox.defaultProps = {

--- a/packages/form/src/CheckboxGroup.js
+++ b/packages/form/src/CheckboxGroup.js
@@ -57,7 +57,7 @@ const CheckboxGroup = ({
   );
 
   let tag = 'div';
-  let legend = false;
+  let legend = null;
 
   if (label) {
     tag = 'fieldset';

--- a/packages/form/src/CheckboxGroup.js
+++ b/packages/form/src/CheckboxGroup.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { FieldHelpIcon } from '@availity/help';
 import { useField, useFormikContext } from 'formik';
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
@@ -9,9 +10,12 @@ export const CheckboxGroupContext = createContext();
 
 export const useCheckboxGroup = (name) => {
   const { setFieldValue } = useFormikContext();
-  const { name: groupName, groupOnChange, value = [], ...rest } = useContext(
-    CheckboxGroupContext
-  );
+  const {
+    name: groupName,
+    groupOnChange,
+    value = [],
+    ...rest
+  } = useContext(CheckboxGroupContext);
 
   const toggle = () => {
     const valueArray = [...value];
@@ -40,6 +44,7 @@ const CheckboxGroup = ({
   onChange: groupOnChange,
   groupClassName,
   label,
+  helpId,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
@@ -51,13 +56,35 @@ const CheckboxGroup = ({
     metadata.touched && metadata.error && 'is-invalid'
   );
 
-  const legend = label ? <legend>{label}</legend> : '';
+  let tag = 'div';
+  let legend = false;
+
+  if (label) {
+    tag = 'fieldset';
+    legend = <legend>{label}</legend>;
+
+    if (helpId) {
+      const legendId = `${name}-legend`.toLowerCase();
+      const legendStyle = { fontSize: '1.5rem', marginBottom: '.5rem' };
+      legend = (
+        <>
+          <legend id={legendId} className="sr-only">
+            {label}
+          </legend>
+          <div className="form-inline" style={legendStyle}>
+            <div aria-hidden="true">{label}</div>
+            <FieldHelpIcon id={helpId} labelId={legendId} />
+          </div>
+        </>
+      );
+    }
+  }
 
   return (
     <CheckboxGroupContext.Provider
       value={{ ...field, groupOnChange, metadata }}
     >
-      <FormGroup tag="fieldset" for={name} {...rest}>
+      <FormGroup tag={tag} for={name} {...rest}>
         {legend}
         <div className={classes} data-testid={`check-items-${name}`}>
           {children}
@@ -74,6 +101,7 @@ CheckboxGroup.propTypes = {
   label: PropTypes.node,
   onChange: PropTypes.func,
   groupClassName: PropTypes.string,
+  helpId: PropTypes.string,
 };
 
 export default CheckboxGroup;

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -61,7 +61,7 @@ const Field = ({
       disabled={disabled}
       readOnly={readOnly}
       feedback
-      helpMessage={!!helpMessage}
+      help={!!helpMessage}
       {...attributes}
     />
   );

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FieldHelpIcon } from '@availity/help';
 import {
   Input as RsInput,
   Label,
@@ -18,6 +19,7 @@ const colSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 const Field = ({
   helpMessage,
+  helpId,
   label,
   labelHidden,
   inputClass,
@@ -110,6 +112,11 @@ const Field = ({
   }
 
   const check = attributes.type === 'checkbox';
+  const helpIcon = helpId ? (
+    <FieldHelpIcon labelId={`${inputId}-label`} id={helpId} />
+  ) : (
+    false
+  );
 
   return (
     <FormGroup
@@ -121,16 +128,20 @@ const Field = ({
     >
       {check && inputRow}
       {label && (
-        <Label
-          for={inputId}
-          className={labelClass}
-          hidden={labelHidden}
-          size={size}
-          {...labelCol}
-          {...labelAttrs}
-        >
-          {label}
-        </Label>
+        <>
+          <Label
+            id={`${inputId}-label`}
+            for={inputId}
+            className={labelClass}
+            hidden={labelHidden}
+            size={size}
+            {...labelCol}
+            {...labelAttrs}
+          >
+            {label}
+          </Label>
+          {helpIcon}
+        </>
       )}
       {!check && inputRow}
       {!row && !prepend && !append && feedback}
@@ -156,6 +167,7 @@ Field.propTypes = {
   children: PropTypes.func,
   append: PropTypes.node,
   prepend: PropTypes.node,
+  helpId: PropTypes.string,
 };
 
 Field.defaultProps = {

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -114,9 +114,7 @@ const Field = ({
   const check = attributes.type === 'checkbox';
   const helpIcon = helpId ? (
     <FieldHelpIcon labelId={`${inputId}-label`} id={helpId} />
-  ) : (
-    false
-  );
+  ) : null;
 
   return (
     <FormGroup

--- a/packages/form/src/Input.js
+++ b/packages/form/src/Input.js
@@ -11,7 +11,7 @@ const Input = ({
   validate,
   name,
   feedback,
-  helpMessage,
+  help,
   ...rest
 }) => {
   const [{ onChange, ...field }, metadata] = useField({
@@ -32,7 +32,7 @@ const Input = ({
 
   const error = !!metadata.touched && !!metadata.error;
   const feedbackId = error && feedback ? `${name}-feedback`.toLowerCase() : '';
-  const helpMessageId = helpMessage ? ` ${name}-helpmessage`.toLowerCase() : '';
+  const helpMessageId = help ? ` ${name}-helpmessage`.toLowerCase() : '';
 
   const extraProps = {};
 
@@ -66,7 +66,7 @@ Input.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   feedback: PropTypes.bool,
-  helpMessage: PropTypes.bool,
+  help: PropTypes.bool,
 };
 
 Input.defaultProps = {

--- a/packages/form/src/Radio.js
+++ b/packages/form/src/Radio.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { FieldHelpIcon } from '@availity/help';
 import { Label, Input } from 'reactstrap';
 import { v4 as uuid } from 'uuid';
 import classNames from 'classnames';
@@ -14,6 +15,7 @@ const Radio = ({
   className,
   groupClassName,
   children,
+  helpId,
   ...attributes
 }) => {
   const { value, setValue, metadata, inline } = useRadioGroup(checkValue);
@@ -29,6 +31,12 @@ const Radio = ({
   const errorIndicated = !!metadata.touched && !!metadata.error;
   const feedbackId =
     errorIndicated && name ? `${name}-feedback`.toLowerCase() : '';
+  const labelId = `${inputId}-label`.toLowerCase();
+  const helpIcon = helpId ? (
+    <FieldHelpIcon id={helpId} labelId={labelId} />
+  ) : (
+    false
+  );
 
   return (
     <FormGroup
@@ -50,9 +58,10 @@ const Radio = ({
         checked={value}
         onChange={setValue}
       />
-      <Label check for={inputId}>
+      <Label check id={labelId} for={inputId}>
         {label || children}
       </Label>
+      {helpIcon}
     </FormGroup>
   );
 };
@@ -70,6 +79,7 @@ Radio.propTypes = {
   className: PropTypes.string,
   groupClassName: PropTypes.string,
   children: PropTypes.node,
+  helpId: PropTypes.string,
 };
 
 export default Radio;

--- a/packages/form/src/Radio.js
+++ b/packages/form/src/Radio.js
@@ -34,9 +34,7 @@ const Radio = ({
   const labelId = `${inputId}-label`.toLowerCase();
   const helpIcon = helpId ? (
     <FieldHelpIcon id={helpId} labelId={labelId} />
-  ) : (
-    false
-  );
+  ) : null;
 
   return (
     <FormGroup

--- a/packages/form/src/RadioGroup.js
+++ b/packages/form/src/RadioGroup.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { FieldHelpIcon } from '@availity/help';
 import { useField, useFormikContext } from 'formik';
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
@@ -9,9 +10,12 @@ export const RadioGroupContext = createContext();
 
 export const useRadioGroup = (radioValue) => {
   const { setFieldValue } = useFormikContext();
-  const { name: groupName, value = '', groupOnChange, ...rest } = useContext(
-    RadioGroupContext
-  );
+  const {
+    name: groupName,
+    value = '',
+    groupOnChange,
+    ...rest
+  } = useContext(RadioGroupContext);
 
   const setValue = () => {
     setFieldValue(groupName, radioValue);
@@ -30,6 +34,7 @@ const RadioGroup = ({
   onChange: groupOnChange,
   groupClassName,
   inline = false,
+  helpId,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
@@ -41,13 +46,35 @@ const RadioGroup = ({
     metadata.touched && metadata.error && 'is-invalid'
   );
 
-  const legend = label ? <legend>{label}</legend> : '';
+  let tag = 'div';
+  let legend = false;
+
+  if (label) {
+    tag = 'fieldset';
+    legend = <legend>{label}</legend>;
+
+    if (helpId) {
+      const legendId = `${name}-legend`.toLowerCase();
+      const legendStyle = { fontSize: '1.5rem', marginBottom: '.5rem' };
+      legend = (
+        <>
+          <legend id={legendId} className="sr-only">
+            {label}
+          </legend>
+          <div className="form-inline" style={legendStyle}>
+            <div aria-hidden="true">{label}</div>
+            <FieldHelpIcon id={helpId} labelId={legendId} />
+          </div>
+        </>
+      );
+    }
+  }
 
   return (
     <RadioGroupContext.Provider
       value={{ ...field, groupOnChange, metadata, inline }}
     >
-      <FormGroup tag="fieldset" for={name} {...rest}>
+      <FormGroup tag={tag} for={name} {...rest}>
         {legend}
         <div className={classes} data-testid={`radio-items-${name}`}>
           {children}
@@ -65,6 +92,7 @@ RadioGroup.propTypes = {
   onChange: PropTypes.func,
   inline: PropTypes.bool,
   groupClassName: PropTypes.string,
+  helpId: PropTypes.string,
 };
 
 export default RadioGroup;

--- a/packages/form/src/RadioGroup.js
+++ b/packages/form/src/RadioGroup.js
@@ -47,7 +47,7 @@ const RadioGroup = ({
   );
 
   let tag = 'div';
-  let legend = false;
+  let legend = null;
 
   if (label) {
     tag = 'fieldset';

--- a/packages/form/tests/Checkbox.test.js
+++ b/packages/form/tests/Checkbox.test.js
@@ -147,6 +147,24 @@ describe('Checkbox', () => {
     expect(el).toBeDefined();
   });
 
+  test('renders with field help icon', () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+      >
+        <CheckboxGroup name="hello" label="Checkbox Group">
+          <Checkbox label="Check One" value="uno" helpId="UnoHelpTopic" />
+        </CheckboxGroup>
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    expect(getByTestId('field-help-icon')).toBeDefined();
+  });
+
   test('renders without inline applied', async () => {
     const { getByText } = render(
       <Form

--- a/packages/form/tests/CheckboxGroup.test.js
+++ b/packages/form/tests/CheckboxGroup.test.js
@@ -66,6 +66,28 @@ describe('CheckboxGroup', () => {
     });
   });
 
+  test('renders with field help icon', () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+      >
+        <CheckboxGroup
+          name="hello"
+          label="Checkbox Group"
+          helpId="helloHelpTopic"
+        >
+          <Checkbox label="Check One" value="uno" />
+        </CheckboxGroup>
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    expect(getByTestId('field-help-icon')).toBeDefined();
+  });
+
   test('submits with proper radio values', async () => {
     const onSubmit = jest.fn();
     const { getByText } = render(

--- a/packages/form/tests/Field.test.js
+++ b/packages/form/tests/Field.test.js
@@ -49,6 +49,26 @@ describe('Field', () => {
     expect(label.className).toContain('col-md-6');
   });
 
+  test('renders with field help icon', () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: 'hello',
+        }}
+        onSubmit={() => {}}
+      >
+        <Field
+          name="hello"
+          label="Hello Label"
+          data-testid="hello-input"
+          helpId="hellohelptopic"
+        />
+      </Form>
+    );
+
+    expect(getByTestId('field-help-icon')).toBeDefined();
+  });
+
   test('should render help message', () => {
     const { getByText, getByTestId } = render(
       <Form

--- a/packages/form/tests/Radio.test.js
+++ b/packages/form/tests/Radio.test.js
@@ -134,6 +134,28 @@ describe('Radio', () => {
     expect(el).toBeDefined();
   });
 
+  test('renders with field help icon', async () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+      >
+        <RadioGroup name="hello" label="Radio Group">
+          <Radio
+            name="hello"
+            label="Radio One"
+            value="uno"
+            helpId="radioOneHelpTopic"
+          />
+        </RadioGroup>
+      </Form>
+    );
+
+    expect(getByTestId('field-help-icon')).toBeDefined();
+  });
+
   test('should generate uuid even when id is not added', () => {
     const { container } = render(
       <Form initialValues={{ name: 'John' }} onSubmit={() => {}}>

--- a/packages/form/tests/RadioGroup.test.js
+++ b/packages/form/tests/RadioGroup.test.js
@@ -147,4 +147,25 @@ describe('RadioGroup', () => {
     const formGroup = radioGroup.children[0];
     expect(formGroup.className).toContain('form-check-inline');
   });
+
+  test('renders field help icon', async () => {
+    const { getByTestId } = render(
+      <Form
+        initialValues={{
+          hello: '',
+        }}
+        onSubmit={() => {}}
+        validationSchema={yup.object().shape({
+          hello: yup.string().required('This field is required'),
+        })}
+      >
+        <RadioGroup name="hello" label="Radio Group" helpId="helloHelpTopic">
+          <Radio label="Radio One" value="uno" />
+        </RadioGroup>
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    expect(getByTestId('field-help-icon')).toBeDefined();
+  });
 });

--- a/packages/form/typings/Checkbox.d.ts
+++ b/packages/form/typings/Checkbox.d.ts
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { InputProps } from './Input';
 
-interface CheckboxProps extends InputProps {
+interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
   label?: React.ReactNode;
   value?: string | boolean | object;
   inline?: boolean;
+  disabled?: boolean;
   id?: string;
   groupClassName?: string;
+  groupName?: string;
+  helpId?: string;
 }
 
 declare class Checkbox extends React.Component<CheckboxProps> {}

--- a/packages/form/typings/CheckboxGroup.d.ts
+++ b/packages/form/typings/CheckboxGroup.d.ts
@@ -6,6 +6,7 @@ interface CheckboxGroupProps extends FormGroupProps {
   label?: React.ReactNode;
   groupClassName?: string;
   onChange?: (value: any) => void;
+  helpId?: string;
 }
 
 declare class CheckboxGroup extends React.Component<CheckboxGroupProps> {}

--- a/packages/form/typings/Field.d.ts
+++ b/packages/form/typings/Field.d.ts
@@ -22,6 +22,7 @@ export interface FieldProps extends InputProps {
   children?: (props: FieldChildProps) => React.ReactNode;
   append?: string | React.ReactNode;
   prepend?: string | React.ReactNode;
+  helpId?: string;
 }
 
 declare class Field extends React.Component<FieldProps> {}

--- a/packages/form/typings/Input.d.ts
+++ b/packages/form/typings/Input.d.ts
@@ -34,6 +34,8 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   name: string;
   validate?: FieldValidator; 
   tag?: Node | string;
+  feedback?: boolean;
+  help?: boolean;
 }
 
 declare class Input extends React.Component<InputProps> {}

--- a/packages/form/typings/Radio.d.ts
+++ b/packages/form/typings/Radio.d.ts
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { InputProps } from './Input';
 
 interface RadioProps extends React.HTMLAttributes<HTMLInputElement> {
   label?: React.ReactNode;
+  name?: string;
   id?: string;
   groupClassName?: string;
   value?: string | boolean | object;
+  disabled?: boolean;
+  helpId?: string;
 }
 
 declare class Radio extends React.Component<RadioProps> {}

--- a/packages/form/typings/RadioGroup.d.ts
+++ b/packages/form/typings/RadioGroup.d.ts
@@ -6,6 +6,7 @@ interface RadioGroupProps extends React.HTMLAttributes<HTMLFormElement> {
   groupClassName?: string;
   onChange?: (value: any) => void;
   inline?: boolean | false;
+  helpId: string;
 }
 
 declare class RadioGroup extends React.Component<RadioGroupProps> {}

--- a/packages/help/Help.js
+++ b/packages/help/Help.js
@@ -148,6 +148,7 @@ FieldHelpIcon.defaultProps = {
 Help.propTypes = {
   type: PropTypes.string,
   id: PropTypes.string.isRequired,
+  children: PropTypes.node,
 };
 
 Help.defaultProps = {

--- a/packages/help/Help.js
+++ b/packages/help/Help.js
@@ -127,6 +127,7 @@ export const FieldHelpIcon = ({ color, size, id, labelId }) => (
     onClick={() => triggerFieldHelp(id)}
     tabIndex={0}
     onKeyPress={(e) => handleKeyPress(e, id)}
+    aria-hidden="false"
     aria-label="help"
     aria-describedby={labelId || ''}
   />

--- a/packages/help/index.d.ts
+++ b/packages/help/index.d.ts
@@ -18,9 +18,10 @@ declare const constants: TopNavConstants;
 
 declare const HelpProvider: React.FC;
 
-declare const Help: React.StatelessComponent<HelpObj>;
+declare const Help: React.FunctionComponent<HelpObj>;
 
 declare const FieldHelpIcon: (props: {
+  labelId?: string;
   color?: string;
   size?: string;
   id: string;

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@availity/message-core": "^5.0.0",
+    "@availity/icon": "^0.8.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/storybook/stories/form-components/form.stories.js
+++ b/storybook/stories/form-components/form.stories.js
@@ -102,6 +102,7 @@ storiesOf('Form Components/Form', module)
           type="text"
           label="Hello"
           helpMessage={text('Help message', '')}
+          helpId={text('Help topic id', '')}
         />
         <Button className="ml-1" color="primary" type="submit">
           Submit
@@ -124,7 +125,11 @@ storiesOf('Form Components/Form', module)
         }}
         validationSchema={schema}
       >
-        <CheckboxGroup name="checkboxGroup" label="Checkbox Group">
+        <CheckboxGroup
+          name="checkboxGroup"
+          helpId={text('Checkbox Group help topic id', '')}
+          label="Checkbox Group"
+        >
           <Checkbox groupName="checkboxGroup" label="Check One" value="uno" />
           <Checkbox groupName="checkboxGroup" label="Check Two" value="dos" />
           <Checkbox
@@ -153,7 +158,11 @@ storiesOf('Form Components/Form', module)
         }}
         validationSchema={schema}
       >
-        <RadioGroup name="hello" label="Radio Group">
+        <RadioGroup
+          name="hello"
+          label="Radio Group"
+          helpId={text('Radio Group help topic id', '')}
+        >
           <Radio name="hello" label="Radio One" value="uno" />
           <Radio name="hello" label="Radio Two" value="dos" />
           <Radio name="hello" label="Radio Three" value="tres" />


### PR DESCRIPTION
- Option to add FieldHelpIcon outside of label/legend for all input types with a label/legend. (needed for accessibility)
- fix FieldHelpIcon to not be aria-hidden
- addressed a few existing errors with typing