### PR TITLE
feat(link): adding underline for all links 508 compliance

### DIFF
--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -62,6 +62,7 @@ const AvLink = ({
     <Tag
       href={url}
       target={target}
+      style={{ textDecoration: 'underline' }}
       onClick={(event) => onClick && onClick(event, url)}
       data-testid="av-link-tag"
       rel={setRel(url, target, absolute)}

--- a/packages/link/Link.js
+++ b/packages/link/Link.js
@@ -45,6 +45,8 @@ const setRel = (url, target, absolute) => {
   return undefined;
 };
 
+const linkStyles = { textDecoration: 'underline' };
+
 const AvLink = ({
   tag: Tag,
   href,
@@ -62,7 +64,7 @@ const AvLink = ({
     <Tag
       href={url}
       target={target}
-      style={{ textDecoration: 'underline' }}
+      style={linkStyles}
       onClick={(event) => onClick && onClick(event, url)}
       data-testid="av-link-tag"
       rel={setRel(url, target, absolute)}

--- a/packages/training-link/TrainingLink.js
+++ b/packages/training-link/TrainingLink.js
@@ -5,10 +5,12 @@ const shouldProbablyBeInUIKit = {
   paddingTop: '12px',
 };
 
+const linkStyles = { textDecoration: 'underline' };
+
 const TrainingLink = ({ name, link }) => (
   <span style={shouldProbablyBeInUIKit} className="ml-auto">
     Need Help?{' '}
-    <a href={link} target="_blank" rel="noopener noreferrer">
+    <a href={link} style={linkStyles} target="_blank" rel="noopener noreferrer">
       Watch a demo
     </a>{' '}
     for {name}

--- a/packages/training-link/tests/__snapshots__/TrainingLink.test.js.snap
+++ b/packages/training-link/tests/__snapshots__/TrainingLink.test.js.snap
@@ -11,6 +11,7 @@ exports[`TrainingLink should not render with link and name 1`] = `
     <a
       href="http://catvidoes.com"
       rel="noopener noreferrer"
+      style="text-decoration: underline;"
       target="_blank"
     >
       Watch a demo


### PR DESCRIPTION
"Ensure color is not the sole means of communicating information
Blue link elements use color as the only visual means to convey they are links that can be interacted with.
Provide an underline text decoration in the link's default state, with an underline on focus and hover."
