### PR TITLE
fix(feedback): fixed focus issue for feedback in dropdowns

### DIFF
--- a/packages/feedback/src/Feedback.js
+++ b/packages/feedback/src/Feedback.js
@@ -46,6 +46,7 @@ const Feedback = ({
           showSupport={showSupport}
           supportZIndex={supportZIndex}
           feedbackToggle={feedbackToggle}
+          autoFocusFeedbackButton={false}
           {...formProps}
         />
       ) : (
@@ -60,6 +61,7 @@ const Feedback = ({
           supportZIndex={supportZIndex}
           modal={modal}
           {...formProps}
+          autoFocusFeedbackButton
         />
       )}
     </Dropdown>

--- a/packages/feedback/src/FeedbackDropdown.js
+++ b/packages/feedback/src/FeedbackDropdown.js
@@ -16,6 +16,7 @@ const FeedbackDropdown = ({
   supportZIndex,
   modal,
   feedbackToggle,
+  autoFocusFeedbackButton,
   ...formProps
 }) => {
   const [supportIsActive, setSupportIsActive] = React.useState(false);
@@ -46,6 +47,7 @@ const FeedbackDropdown = ({
       onClose={toggle}
       showSupport={showSupport}
       setSupportIsActive={setSupportIsActive}
+      autoFocusFeedbackButton={autoFocusFeedbackButton}
       {...formProps}
     />
   );
@@ -72,6 +74,7 @@ FeedbackDropdown.propTypes = {
   supportZIndex: PropTypes.string,
   modal: PropTypes.bool,
   feedbackToggle: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 export default FeedbackDropdown;

--- a/packages/feedback/src/FeedbackForm.js
+++ b/packages/feedback/src/FeedbackForm.js
@@ -44,6 +44,7 @@ const FeedbackForm = ({
   modalHeaderProps,
   showSupport,
   setSupportIsActive,
+  autoFocusFeedbackButton,
   ...formProps
 }) => {
   const [active, setActive] = useState(null);
@@ -160,6 +161,7 @@ const FeedbackForm = ({
               options={faceOptions}
               name="smileField"
               onChange={(option) => setActive(option)}
+              autoFocusFeedbackButton={autoFocusFeedbackButton}
             />
           </FormGroup>
           {active ? (
@@ -261,6 +263,7 @@ FeedbackForm.propTypes = {
   }),
   showSupport: PropTypes.bool,
   setSupportIsActive: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 FeedbackForm.defaultProps = {

--- a/packages/feedback/src/FeedbackModal.js
+++ b/packages/feedback/src/FeedbackModal.js
@@ -11,6 +11,7 @@ const FeedbackModal = ({
   showSupport,
   supportZIndex,
   feedbackToggle,
+  autoFocusFeedbackButton,
   ...formOptions
 }) => {
   const [supportIsActive, setSupportIsActive] = React.useState(false);
@@ -38,6 +39,7 @@ const FeedbackModal = ({
         onClose={toggle}
         showSupport={showSupport}
         setSupportIsActive={setSupportIsActive}
+        autoFocusFeedbackButton={autoFocusFeedbackButton}
         {...formOptions}
       />
     </Modal>
@@ -51,6 +53,7 @@ FeedbackModal.propTypes = {
   zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   supportZIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   feedbackToggle: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 export default FeedbackModal;

--- a/packages/feedback/src/SmileField.js
+++ b/packages/feedback/src/SmileField.js
@@ -5,16 +5,17 @@ import FeedbackButton from './FeedbackButton';
 
 const btnStyles = { flex: 1, margin: '0 2% 0 2%' };
 
-const SmileField = ({ name, options, onChange }) => {
+const SmileField = ({ name, options, onChange, autoFocusFeedbackButton }) => {
   const [{ value }] = useField(name);
   const { setFieldValue } = useFormikContext();
 
   return options.map((option, i) => (
     <FeedbackButton
-      autoFocus={i === 0}
+      autoFocus={i === 0 && autoFocusFeedbackButton}
       style={btnStyles}
       key={option.icon}
       icon={option.icon}
+      id={`feedbackButton${i}`}
       iconSize="2x"
       value={option}
       active={value && value.icon}
@@ -40,6 +41,7 @@ SmileField.propTypes = {
     })
   ),
   onChange: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 SmileField.defaultProps = {

--- a/packages/feedback/tests/Feedback.test.js
+++ b/packages/feedback/tests/Feedback.test.js
@@ -104,4 +104,28 @@ describe('Feedback', () => {
 
     expect(giveFeedbackButton).toHaveAttribute('aria-expanded', 'false');
   });
+
+  test('should focus first SmileField button if modal', async () => {
+    const { getByText } = render(
+      <Feedback showSupport={false} outline={false} modal={false} />
+    );
+
+    fireEvent.click(getByText('Give Feedback'));
+    const firstFeedbackButton = getByText('Smiley face').closest('button');
+    await waitFor(() => {
+      expect(firstFeedbackButton).toHaveFocus();
+    });
+  });
+
+  test('should not focus first SmileField button if not modal', async () => {
+    const { getByText } = render(
+      <Feedback showSupport={false} outline={false} modal />
+    );
+
+    fireEvent.click(getByText('Give Feedback'));
+    const firstFeedbackButton = getByText('Smiley face').closest('button');
+    await waitFor(() => {
+      expect(firstFeedbackButton).not.toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
Issue Reported by @chrishavekost 

I noticed an issue within the feedback package. For some use cases that render a feedback form inside a dropdown (like at the end of a list of search results) the autoFocus prop on FeedbackButton ends up automatically closing the dropdown, leaving users unable to see or select anything.

Proposed Solution:
I think autoFocus should be made into a boolean prop, FeedbackDropdown can set this value as true and others just rendering the form could set it false?