### PR TITLE
fix(feedback): fixed focus issue for feedback in dropdowns

### DIFF
--- a/docusaurus/docs/components/feedback/form.md
+++ b/docusaurus/docs/components/feedback/form.md
@@ -57,6 +57,10 @@ If `true`, shows an optional comments field below.
 
 Static (non-user-entered) key/value pairs to be sent in feedback submission.
 
+#### `autoFocusFeedbackButton?: bool`
+
+Default: ```true```. When set to false, the first feedback button is not focused. This is to avoid issues with focus causing other elements to close (e.g. dropdowns)
+
 #### `modalHeaderProps?: ModalHeaderProps`
 
 Props to be spread onto the `<ModalHeader />` rendered inside of the `<FeedbackForm />`. See [ModalHeader](https://github.com/reactstrap/reactstrap/blob/master/src/ModalHeader.js)

--- a/packages/feedback/src/FeedbackForm.js
+++ b/packages/feedback/src/FeedbackForm.js
@@ -44,6 +44,7 @@ const FeedbackForm = ({
   modalHeaderProps,
   showSupport,
   setSupportIsActive,
+  autoFocusFeedbackButton,
   ...formProps
 }) => {
   const [active, setActive] = useState(null);
@@ -160,6 +161,7 @@ const FeedbackForm = ({
               options={faceOptions}
               name="smileField"
               onChange={(option) => setActive(option)}
+              autoFocusFeedbackButton={autoFocusFeedbackButton}
             />
           </FormGroup>
           {active ? (
@@ -261,6 +263,7 @@ FeedbackForm.propTypes = {
   }),
   showSupport: PropTypes.bool,
   setSupportIsActive: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 FeedbackForm.defaultProps = {

--- a/packages/feedback/src/SmileField.js
+++ b/packages/feedback/src/SmileField.js
@@ -5,13 +5,13 @@ import FeedbackButton from './FeedbackButton';
 
 const btnStyles = { flex: 1, margin: '0 2% 0 2%' };
 
-const SmileField = ({ name, options, onChange }) => {
+const SmileField = ({ name, options, onChange, autoFocusFeedbackButton }) => {
   const [{ value }] = useField(name);
   const { setFieldValue } = useFormikContext();
 
   return options.map((option, i) => (
     <FeedbackButton
-      autoFocus={i === 0}
+      autoFocus={i === 0 && autoFocusFeedbackButton}
       style={btnStyles}
       key={option.icon}
       icon={option.icon}
@@ -40,6 +40,7 @@ SmileField.propTypes = {
     })
   ),
   onChange: PropTypes.func,
+  autoFocusFeedbackButton: PropTypes.bool,
 };
 
 SmileField.defaultProps = {
@@ -60,6 +61,7 @@ SmileField.defaultProps = {
       label: "What don't you like?",
     },
   ],
+  autoFocusFeedbackButton: true,
 };
 
 export default SmileField;

--- a/packages/feedback/tests/FeedbackForm.test.js
+++ b/packages/feedback/tests/FeedbackForm.test.js
@@ -247,4 +247,24 @@ describe('FeedbackForm', () => {
       'feedback-form-header'
     );
   });
+
+  test('should focus first SmileField button by default', async () => {
+    const { getByText } = render(<FeedbackForm name="Payer Space" />);
+
+    const firstFeedbackButton = getByText('Smiley face').closest('button');
+    await waitFor(() => {
+      expect(firstFeedbackButton).toHaveFocus();
+    });
+  });
+
+  test('should not focus first SmileField button if autofocus is set to false', async () => {
+    const { getByText } = render(
+      <FeedbackForm name="Payer Space" autoFocusFeedbackButton={false} />
+    );
+
+    const firstFeedbackButton = getByText('Smiley face').closest('button');
+    await waitFor(() => {
+      expect(firstFeedbackButton).not.toHaveFocus();
+    });
+  });
 });


### PR DESCRIPTION
Issue Reported by @chrishavekost

I noticed an issue within the feedback package. For some use cases that render a feedback form inside a dropdown (like at the end of a list of search results) the autoFocus prop on FeedbackButton ends up automatically closing the dropdown, leaving users unable to see or select anything.

Proposed Solution:
FeedbackForm needs to accept and pass that prop down to SmileField. SmileField can default the prop to true, and anyone using FeedbackForm can provide false for the value
