### PR TITLE
refactor(date): add option to reformat date input in daterange

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -67,7 +67,7 @@ const AvDate = ({
   const onInputChange = (value) => {
     const date = moment(
       value,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
+      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
       true
     );
     const isoFormatted = date.format(isoDateFormat);
@@ -116,7 +116,7 @@ const AvDate = ({
   const getDateValue = () => {
     const date = moment(
       field.value,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
+      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
       true
     );
     if (date.isValid()) return date;

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -82,12 +82,26 @@ const DateRange = ({
   const endValue = value.endDate || '';
 
   const startValueMoment = useMemo(
-    () => moment(startValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD']),
+    () =>
+      moment(startValue, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+        'M/D/YYYY',
+      ]),
     [startValue, format]
   );
 
   const endValueMoment = useMemo(
-    () => moment(endValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD']),
+    () =>
+      moment(endValue, [
+        isoDateFormat,
+        format,
+        'MMDDYYYY',
+        'YYYYMMDD',
+        'M/D/YYYY',
+      ]),
     [endValue, format]
   );
 
@@ -114,7 +128,7 @@ const DateRange = ({
     const isStart = focusedInput === 'startDate';
     const date = moment(
       val,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
+      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
       true
     );
 
@@ -192,7 +206,7 @@ const DateRange = ({
   const getDateValue = (val) => {
     const date = moment(
       val,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD'],
+      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
       true
     );
     if (date.isValid()) return date;

--- a/packages/date/tests/Date.test.js
+++ b/packages/date/tests/Date.test.js
@@ -115,6 +115,41 @@ describe('Date', () => {
     });
   });
 
+  test('works with text input in M/D/YYYY format', async () => {
+    const onSubmit = jest.fn();
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleDate: '',
+        }}
+        onSubmit={onSubmit}
+      >
+        <FormikDate name="singleDate" data-testid="single-select" />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const input = container.querySelector('.DateInput_input');
+
+    fireEvent.change(input, {
+      target: {
+        value: '1/4/1997',
+      },
+    });
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          singleDate: '1997-01-04',
+        }),
+        expect.anything()
+      );
+    });
+  });
+
   test('works with date picker', async () => {
     const onSubmit = jest.fn();
 

--- a/packages/date/tests/DateRange.test.js
+++ b/packages/date/tests/DateRange.test.js
@@ -191,6 +191,56 @@ describe('DateRange', () => {
     });
   });
 
+  test('works with text input in M/D/YYYY format', async () => {
+    const onSubmit = jest.fn();
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          dateRange: undefined,
+        }}
+        onSubmit={onSubmit}
+      >
+        <DateRange id="dateRange" name="dateRange" />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    // Simulate user entering start date
+    const start = container.querySelector('#dateRange-start');
+
+    fireEvent.focus(start);
+
+    fireEvent.change(start, {
+      target: {
+        value: '1/4/1997',
+      },
+    });
+
+    // Simulate user entering end date
+    const end = container.querySelector('#dateRange-end');
+
+    fireEvent.change(end, {
+      target: {
+        value: '1/5/1997',
+      },
+    });
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dateRange: {
+            startDate: '1997-01-04',
+            endDate: '1997-01-05',
+          },
+        }),
+        expect.anything()
+      );
+    });
+  });
+
   test('works with date picker', async () => {
     const onSubmit = jest.fn();
 


### PR DESCRIPTION
- User entered M/D/YYYY now reformats successfully (ex. 3/3/2020 -> 03/03/2020)
- Previously if M/D/YYYY was entered, it was not accepted as a valid date