### PR TITLE
Fix/authorize loop

### DIFF
--- a/docusaurus/docs/components/authorize.mdx
+++ b/docusaurus/docs/components/authorize.mdx
@@ -11,14 +11,22 @@ Check user permissions to see if the current user is authorized to see your cont
 npm
 
 ```bash
-npm install @availity/authorize @availity/api-axios axios --save
+npm install @availity/authorize @availity/api-axios axios react-query --save
 ```
 
 Yarn
 
 ```bash
-yarn add @availity/authorize @availity/api-axios axios
+yarn add @availity/authorize @availity/api-axios axios react-query
 ```
+
+## Usage
+
+This package exports both a component `Authorize`, and hook `useAuthorize`. The component is used to wrap sections of your app where you want to restrict access. The hook can be used in situations where more control is required.
+
+:::important
+As of version 2, this package uses [react-query](https://react-query.tanstack.com/). This means you will need to add a `QueryClientProvider` to your application if you do not already have one [setup](https://react-query.tanstack.com/quick-start). The only default option set is `enabled` which checks to see if the `permissions` prop/arg exists. This can be overridden. We recommend you configure `staleTime` and `refetchOnWindowFocus` as these settings can greatly impact the user experience.
+:::
 
 ### Example
 
@@ -33,7 +41,7 @@ const Example = () => (
 );
 ```
 
-#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-authorize--default"> Storybook</a>
+#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-authorize--default">Storybook</a>
 
 ### Props
 
@@ -73,17 +81,21 @@ The content that renders when the user _does_ have the permissions required.
 
 Negate the authorization. If the user _does_ have the permissions specified, they are considered "unauthorized" (shown the `unauthorized` prop content). If the user _does not_ have the permissions specified, they are considered "authorized" (shown the `children` prop content)
 
+#### `queryOptions?: object`
+
+`react-query` [options](https://github.com/tannerlinsley/react-query/blob/master/src/core/types.ts#L47) object that will be passed to the `useAuthorize` hook.
+
+`enabled` is set to check if `permissions` exist. This can be overridden.
+
 ### useAuthorize
 
 Hook which validates the user's permissions.
 
-Returns `[authorized, loading, currentRegion]`
+Returns `{ authorized, isLoading }`
 
-- `authorized` : Whether the user is authorized to see the content.
+- `authorized`: Whether the user is authorized to see the content.
 
-- `loading` : Whether the component is loading/checking permissions.
-
-- `currentRegion` : The current region of the user. Useful for avoiding extra API calls if code downstream depends on current region.
+- `isLoading`: Whether the component is checking the permissions.
 
 #### Arguments
 
@@ -97,6 +109,7 @@ Returns `[authorized, loading, currentRegion]`
   - **`resources`**: String,Number,Array<`String`,`Number`,Array<`String`,`Number`>>. Optional.
     - **string/number**: The resource ID, eg: `'12345'` or `12345`
     - **array**: The array can contain resource ID strings/numbers as well as other arrays which contain resource ID strings/numbers, eg: `['12345', '23456', ['34567', '45678'], ['56789', '67890']]`. The items in a nested array indicate resource IDs that must _all_ be granted to the user to be considered authorized - they act as "AND". The items in the top of the array act as "OR" - if _any_ are granted to the user, the user is considered authorized. The example `['12345', '23456', ['34567', '45678'], ['56789', '67890']]` is similar to `'12345' || '23456' || ('34567' && '45678') || ('56789' && '67890')`.
+- **`queryOptions`** Object. Optional. `react-query` [options](https://github.com/tannerlinsley/react-query/blob/master/src/core/types.ts#L47) object that will be passed to the `useQuery` hook. `enabled` is set to check if `permissions` exist. This can be overridden.
 
 #### Usage
 
@@ -104,13 +117,15 @@ Returns `[authorized, loading, currentRegion]`
 import React from 'react';
 import { useAuthorize } from '@availity/authorize';
 
-const Component () => {
-  const [authorized, loading] = useAuthorized(['1234', '5678'], {
+const Component = () => {
+  const { authorized, isLoading } = useAuthorized(['1234', '5678'], {
     region: 'FL',
   });
+
+  if (isLoading) return <p>Loading...</p>;
 
   return authorized && <SomeAuthorizedComponent />;
 };
 ```
 
-#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-authorize--useAuthorize"> Storybook</a>
+#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-authorize--useAuthorize">Storybook</a>

--- a/packages/authorize/index.d.ts
+++ b/packages/authorize/index.d.ts
@@ -1,3 +1,4 @@
 export { default } from './types/Authorize';
+export { default as useAuthorize } from './types/useAuthorize';
 export * from './types/Authorize';
 export * from './types/useAuthorize';

--- a/packages/authorize/package.json
+++ b/packages/authorize/package.json
@@ -28,11 +28,13 @@
     "@availity/api-axios": "^6.0.0",
     "axios": "^0.21.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-query": "^3.0.0"
   },
   "peerDependencies": {
     "@availity/api-axios": "^6.0.0",
     "axios": "^0.21.1",
-    "react": ">=16.3.0"
+    "react": ">=16.8.0",
+    "react-query": "^3.0.0"
   }
 }

--- a/packages/authorize/src/Authorize.js
+++ b/packages/authorize/src/Authorize.js
@@ -14,20 +14,26 @@ const Authorize = ({
   negate,
   children,
   unauthorized,
+  queryOptions,
 }) => {
-  const [authorized, loading] = useAuthorize(permissions, {
-    customerId,
-    organizationId,
-    region,
-    resources,
-  });
+  const { authorized, isLoading } = useAuthorize(
+    permissions,
+    {
+      customerId,
+      organizationId,
+      region,
+      resources,
+    },
+    queryOptions
+  );
 
-  if (loading) {
+  if (isLoading) {
     if (loader) return loader === true ? <BlockUi blocking /> : loader;
     return null;
   }
-  const showChildren = authorized ^ negate; // eslint-disable-line no-bitwise
-  if (showChildren) {
+
+  // show children when authorized or negate is exclusively true
+  if ((authorized || negate) && !(authorized && negate)) {
     return children;
   }
 
@@ -57,13 +63,14 @@ Authorize.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
-  region: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  loader: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
-  organizationId: PropTypes.string,
-  customerId: PropTypes.string,
-  unauthorized: PropTypes.node,
   children: PropTypes.node,
+  customerId: PropTypes.string,
+  loader: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   negate: PropTypes.bool,
+  organizationId: PropTypes.string,
+  queryOptions: PropTypes.object,
+  region: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  unauthorized: PropTypes.node,
 };
 
 Authorize.defaultProps = {

--- a/packages/authorize/src/useAuthorize.js
+++ b/packages/authorize/src/useAuthorize.js
@@ -1,102 +1,14 @@
-import { useState, useEffect } from 'react';
-import { avUserPermissionsApi, avRegionsApi } from '@availity/api-axios';
+import { useQuery } from 'react-query';
+import { checkPermissions } from './util';
 
-const useAuthorize = (permissions, { organizationId, customerId, region = true, resources } = {}) => {
-  const [authorized, setAuthorized] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [currentRegion, setCurrentRegion] = useState('');
+const useAuthorize = (permissions, { organizationId, customerId, region = true, resources } = {}, options) => {
+  const { data: authorized = false, isLoading } = useQuery(
+    ['authorized', permissions, region, resources, organizationId, customerId],
+    () => checkPermissions(permissions, region, resources, organizationId, customerId),
+    { enabled: !!permissions, ...options }
+  );
 
-  const getRegion = async () => {
-    if (region === true) {
-      const resp = await avRegionsApi.getCurrentRegion();
-      const currentRegion = (resp && resp.data && resp.data.regions && resp.data.regions[0]) || undefined;
-
-      setCurrentRegion(currentRegion);
-
-      return (currentRegion && currentRegion.id) || undefined;
-    }
-    if (region) {
-      return region;
-    }
-    // eslint-disable-next-line unicorn/no-useless-undefined
-    return undefined;
-  };
-
-  const checkPermission = (permission) => {
-    if (!permission) return false;
-    let isAuthorizedForCustomerId = true;
-    let isAuthorizedForOrganizationId = true;
-    let isAuthorizedForResources = true;
-
-    if (organizationId) {
-      isAuthorizedForOrganizationId =
-        permission.organizations.filter(({ id: orgId }) => orgId === organizationId).length > 0;
-    }
-
-    if (customerId) {
-      isAuthorizedForCustomerId =
-        permission.organizations.filter(({ customerId: orgCustomerId }) => orgCustomerId === customerId).length > 0;
-    }
-
-    if (resources !== undefined) {
-      const resourceSets = Array.isArray(resources) ? resources : [resources];
-      isAuthorizedForResources =
-        resourceSets.length === 0 ||
-        resourceSets.some((resourceSet) => {
-          if (Array.isArray(resourceSet)) {
-            return resourceSet.every((resource) =>
-              permission.organizations.some(({ resources: orgResources = [] }) =>
-                orgResources.some(({ id }) => `${id}` === `${resource}`)
-              )
-            );
-          }
-          return permission.organizations.some(({ resources: orgResources = [] }) =>
-            orgResources.some(({ id }) => `${id}` === `${resourceSet}`)
-          );
-        });
-    }
-
-    return isAuthorizedForCustomerId && isAuthorizedForOrganizationId && isAuthorizedForResources;
-  };
-
-  // TODO: Move most of this logic to avUserPermissionsApi or something more common.
-  const checkPermissions = async () => {
-    const permissionsSets = Array.isArray(permissions) ? permissions : [permissions];
-    const permissionsList = [].concat(...permissionsSets);
-    const newPermissions = (await avUserPermissionsApi.getPermissions(permissionsList, await getRegion())).reduce(
-      (prev, cur) => {
-        prev[cur.id] = cur;
-        return prev;
-      },
-      {}
-    );
-
-    const authorized = permissionsSets.some((permissionSet) => {
-      if (Array.isArray(permissionSet)) {
-        return permissionSet.every((permission) => checkPermission(newPermissions[permission]));
-      }
-      return checkPermission(newPermissions[permissionSet]);
-    });
-    if (permissionsList.join() === [].concat(...(Array.isArray(permissions) ? permissions : [permissions])).join()) {
-      setLoading(false);
-      setAuthorized(authorized);
-    }
-  };
-
-  useEffect(() => {
-    if (!loading) setLoading(true);
-
-    if (permissions) {
-      checkPermissions();
-    } else {
-      setLoading(false);
-    }
-    // todo - optimize this so we only have a permissions effect for fetching
-    // and the others are just filters
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [organizationId, region, customerId, permissions]);
-
-  return [authorized, loading, currentRegion];
+  return { authorized, isLoading };
 };
 
 export default useAuthorize;

--- a/packages/authorize/src/util.js
+++ b/packages/authorize/src/util.js
@@ -1,0 +1,85 @@
+import { avUserPermissionsApi, avRegionsApi } from '@availity/api-axios';
+
+export const getRegion = async (region) => {
+  if (region === true) {
+    const resp = await avRegionsApi.getCurrentRegion();
+
+    return resp?.data?.regions?.[0]?.id;
+  }
+
+  return region;
+};
+
+export const getPermissions = async (permissions, region) => {
+  if (!permissions) return {};
+
+  const response = await avUserPermissionsApi.getPermissions(permissions, await getRegion(region));
+
+  return response.reduce((prev, cur) => {
+    prev[cur.id] = cur;
+    return prev;
+  }, {});
+};
+
+export const checkPermission = (permission, resources, organizationId, customerId) => {
+  if (!permission) return false;
+
+  let isAuthorizedForCustomerId = true;
+  let isAuthorizedForOrganizationId = true;
+  let isAuthorizedForResources = true;
+
+  // Check if user has org in list based on organizationId
+  if (organizationId) {
+    isAuthorizedForOrganizationId =
+      permission.organizations.filter(({ id: orgId }) => orgId === organizationId).length > 0;
+  }
+
+  // Check if user has org in list based on customerId
+  if (customerId) {
+    isAuthorizedForCustomerId =
+      permission.organizations.filter(({ customerId: orgCustomerId }) => orgCustomerId === customerId).length > 0;
+  }
+
+  // Check if resources are in response
+  if (resources !== undefined) {
+    const resourceSets = Array.isArray(resources) ? resources : [resources];
+
+    isAuthorizedForResources =
+      resourceSets.length === 0 ||
+      resourceSets.some((resourceSet) => {
+        if (Array.isArray(resourceSet)) {
+          return resourceSet.every((resource) =>
+            permission.organizations.some(({ resources: orgResources = [] }) =>
+              orgResources.some(({ id }) => `${id}` === `${resource}`)
+            )
+          );
+        }
+
+        return permission.organizations.some(({ resources: orgResources = [] }) =>
+          orgResources.some(({ id }) => `${id}` === `${resourceSet}`)
+        );
+      });
+  }
+
+  return isAuthorizedForCustomerId && isAuthorizedForOrganizationId && isAuthorizedForResources;
+};
+
+export const checkPermissions = async (permissions, region, resources, organizationId, customerId) => {
+  if (!permissions) return false;
+
+  permissions = Array.isArray(permissions) ? permissions : [permissions];
+
+  const response = await getPermissions(permissions, region);
+
+  const authorized = permissions.some((permissionSet) => {
+    if (Array.isArray(permissionSet)) {
+      return permissionSet.every((permission) =>
+        checkPermission(response[permission], resources, organizationId, customerId)
+      );
+    }
+
+    return checkPermission(response[permissionSet], resources, organizationId, customerId);
+  });
+
+  return authorized;
+};

--- a/packages/authorize/tests/Authorize.test.js
+++ b/packages/authorize/tests/Authorize.test.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render, cleanup, waitFor } from '@testing-library/react';
 import { avUserPermissionsApi } from '@availity/api-axios';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import Authorize from '..';
 
 jest.mock('@availity/api-axios');
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
+  queryClient.clear();
 });
 
 beforeEach(() => {
@@ -38,9 +42,11 @@ beforeEach(() => {
 describe('Authorize', () => {
   test('should render authorized content', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" loader>
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" loader>
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -52,7 +58,9 @@ describe('Authorize', () => {
 
   test('should render unauthorized content', async () => {
     const { getByText } = render(
-      <Authorize permissions="12345" unauthorized="You do not have permission to see this" />
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="12345" unauthorized="You do not have permission to see this" />
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -64,9 +72,11 @@ describe('Authorize', () => {
 
   test('should render authorized with array of permissions', async () => {
     const { getByText } = render(
-      <Authorize permissions={['1234', 2345, [3456, '4567']]} unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions={['1234', 2345, [3456, '4567']]} unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -78,9 +88,11 @@ describe('Authorize', () => {
 
   test('should render negate permissions', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" negate unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" negate unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -90,11 +102,29 @@ describe('Authorize', () => {
     });
   });
 
+  test('should negate and show authorized when unauthorized', async () => {
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="12345" negate unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      const el = getByText('You have permission to see this');
+      expect(el).toBeDefined();
+      return el;
+    });
+  });
+
   test('should render authorized with correct organizationId', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" organizationId="1111" unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" organizationId="1111" unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -106,9 +136,11 @@ describe('Authorize', () => {
 
   test('should render unauthorized with incorrect organizationId', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" organizationId="1112" unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" organizationId="1112" unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -120,9 +152,11 @@ describe('Authorize', () => {
 
   test('should render authorized with correct customerId', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" customerId="1194" unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" customerId="1194" unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -134,9 +168,11 @@ describe('Authorize', () => {
 
   test('should render unauthorized with incorrect customerId', async () => {
     const { getByText } = render(
-      <Authorize permissions="1234" customerId="1193" unauthorized="You do not have permission to see this">
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize permissions="1234" customerId="1193" unauthorized="You do not have permission to see this">
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -148,14 +184,16 @@ describe('Authorize', () => {
 
   test('should render authorized with correct resources', async () => {
     const { getByText } = render(
-      <Authorize
-        permissions="1234"
-        customerId="1194"
-        unauthorized="You do not have permission to see this"
-        resources="2"
-      >
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize
+          permissions="1234"
+          customerId="1194"
+          unauthorized="You do not have permission to see this"
+          resources="2"
+        >
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -167,14 +205,16 @@ describe('Authorize', () => {
 
   test('should render unauthorized with incorrect resources', async () => {
     const { getByText } = render(
-      <Authorize
-        permissions="1234"
-        customerId="1194"
-        unauthorized="You do not have permission to see this"
-        resources="5"
-      >
-        You have permission to see this
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize
+          permissions="1234"
+          customerId="1194"
+          unauthorized="You do not have permission to see this"
+          resources="5"
+        >
+          You have permission to see this
+        </Authorize>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {

--- a/packages/authorize/tests/useAuthorize.test.js
+++ b/packages/authorize/tests/useAuthorize.test.js
@@ -1,39 +1,28 @@
 import React from 'react';
 import { render, cleanup, waitFor } from '@testing-library/react';
 import { avUserPermissionsApi, avRegionsApi } from '@availity/api-axios';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { useAuthorize } from '..';
 
 jest.mock('@availity/api-axios');
 
+const queryClient = new QueryClient();
+
 afterEach(() => {
   jest.clearAllMocks();
   cleanup();
+  queryClient.clear();
 });
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ permissions, children, ...options }) => {
-  const [authorized, loading] = useAuthorize(permissions, options);
+  const { authorized, isLoading } = useAuthorize(permissions, options);
 
-  if (loading) {
+  if (isLoading) {
     return <span data-testid="component-loading">Loading</span>;
   }
 
   return authorized ? children : <span data-testid="component-content">You do not have permission to see this</span>;
-};
-
-// eslint-disable-next-line react/prop-types
-const RegionComponent = ({ permissions, ...options }) => {
-  const [authorized, loading, currentRegion] = useAuthorize(permissions, options);
-
-  if (loading) {
-    return <span data-testid="component-loading">Loading</span>;
-  }
-
-  return authorized ? (
-    <span data-testid="component-region">{currentRegion.value}</span>
-  ) : (
-    <span data-testid="component-content">You do not have permission to see this</span>
-  );
 };
 
 beforeEach(() => {
@@ -75,7 +64,11 @@ beforeEach(() => {
 
 describe('useAuthorize', () => {
   test('should render authorized content', async () => {
-    const { getByText } = render(<Component permissions="1234">You have permission to see this</Component>);
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234">You have permission to see this</Component>
+      </QueryClientProvider>
+    );
 
     await waitFor(() => {
       const el = getByText('You have permission to see this');
@@ -85,7 +78,11 @@ describe('useAuthorize', () => {
   });
 
   test('should render unauthorized content', async () => {
-    const { getByText } = render(<Component permissions="12345" />);
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="12345" />
+      </QueryClientProvider>
+    );
 
     await waitFor(() => {
       const el = getByText('You do not have permission to see this');
@@ -96,7 +93,9 @@ describe('useAuthorize', () => {
 
   test('should render authorized with array of permissions', async () => {
     const { getByText } = render(
-      <Component permissions={['1234', 2345, [3456, '4567']]}>You have permission to see this</Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions={['1234', 2345, [3456, '4567']]}>You have permission to see this</Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -108,9 +107,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct organizationId', async () => {
     const { getByText } = render(
-      <Component permissions="1234" organizationId="1111">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" organizationId="1111">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -143,9 +144,11 @@ describe('useAuthorize', () => {
     ]);
 
     const { getByText } = render(
-      <Component permissions={['1234', ['5678', '9012']]} region="FL" organizationId="1111">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions={['1234', ['5678', '9012']]} region="FL" organizationId="1111">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -157,9 +160,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with region', async () => {
     const { getByText } = render(
-      <Component permissions="1234" region="FL" organizationId="1111">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" region="FL" organizationId="1111">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -171,9 +176,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with no region', async () => {
     const { getByText } = render(
-      <Component permissions="1234" region={false} organizationId="1111">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" region={false} organizationId="1111">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -186,9 +193,11 @@ describe('useAuthorize', () => {
   test('should render unauthorized with region', async () => {
     avUserPermissionsApi.getPermissions.mockResolvedValue([]);
     const { getByText } = render(
-      <Component permissions="1234" region="GA" organizationId="1111">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" region="GA" organizationId="1111">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -200,9 +209,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect organizationId', async () => {
     const { getByText } = render(
-      <Component permissions="1234" organizationId="1112">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" organizationId="1112">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -214,9 +225,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct customerId', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -228,9 +241,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect customerId', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1193">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1193">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -242,9 +257,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct resources as string', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources="1">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources="1">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -256,9 +273,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct resources as number', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={2}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={2}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -270,9 +289,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct resources as array', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={['1']}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={['1']}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -284,9 +305,11 @@ describe('useAuthorize', () => {
 
   test('should render authorized with correct resources as nested array', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={[['1', '2']]}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={[['1', '2']]}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -298,9 +321,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect resources as string', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources="5">
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources="5">
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -312,9 +337,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect resources as number', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={6}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={6}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -326,9 +353,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect resources as array', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={['5']}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={['5']}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -340,9 +369,11 @@ describe('useAuthorize', () => {
 
   test('should render unauthorized with incorrect resources as nested array', async () => {
     const { getByText } = render(
-      <Component permissions="1234" customerId="1194" resources={[['1', '5']]}>
-        You have permission to see this
-      </Component>
+      <QueryClientProvider client={queryClient}>
+        <Component permissions="1234" customerId="1194" resources={[['1', '5']]}>
+          You have permission to see this
+        </Component>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {
@@ -352,20 +383,12 @@ describe('useAuthorize', () => {
     });
   });
 
-  test('should get current region back from useAuthorize hook', async () => {
-    const { getByText } = await render(
-      <RegionComponent permissions="1234">You have permission to see this</RegionComponent>
-    );
-
-    await waitFor(() => {
-      expect(avUserPermissionsApi.getPermissions).toHaveBeenCalled();
-      expect(avRegionsApi.getCurrentRegion).toHaveBeenCalled();
-      expect(getByText('Washington')).toBeDefined();
-    });
-  });
-
   test('should not call permissions api if no permissions are passed', async () => {
-    const { getByText } = await render(<RegionComponent>You have permission to see this</RegionComponent>);
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <Component>You have permission to see this</Component>
+      </QueryClientProvider>
+    );
 
     await waitFor(() => {
       expect(avUserPermissionsApi.getPermissions).not.toHaveBeenCalled();

--- a/packages/authorize/tests/util.test.js
+++ b/packages/authorize/tests/util.test.js
@@ -1,0 +1,87 @@
+import { avUserPermissionsApi, avRegionsApi } from '@availity/api-axios';
+import { checkPermission, checkPermissions, getPermissions, getRegion } from '../src/util';
+
+jest.mock('@availity/api-axios');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+beforeEach(() => {
+  avUserPermissionsApi.getPermissions.mockResolvedValue([
+    {
+      id: '1234',
+      organizations: [
+        {
+          id: '1111',
+          customerId: '1194',
+          resources: [
+            {
+              id: '1',
+            },
+            {
+              id: '2',
+            },
+            {
+              id: '3',
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+
+  avRegionsApi.getCurrentRegion.mockResolvedValue({
+    data: {
+      regions: [
+        {
+          id: 'WA',
+          value: 'Washington',
+          currentlySelected: true,
+        },
+      ],
+    },
+  });
+});
+
+describe('useAuthorize', () => {
+  test('should fetch region', async () => {
+    const region = await getRegion(true);
+
+    expect(region).toEqual('WA');
+    expect(avRegionsApi.getCurrentRegion).toHaveBeenCalled();
+  });
+
+  test('should not fetch region', async () => {
+    const region = await getRegion('FL');
+
+    expect(region).toEqual('FL');
+    expect(avRegionsApi.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('should check permission', () => {
+    // Fail if no permisison passed
+    expect(checkPermission()).toBeFalsy();
+
+    // Pass if only permission passed
+    expect(checkPermission('123')).toBeTruthy();
+
+    // Pass when orgId or customerId matches
+    expect(checkPermission({ organizations: [{ id: '111' }] }, undefined, '111')).toBeTruthy();
+    expect(checkPermission({ organizations: [{ customerId: '111' }] }, undefined, '', '111')).toBeTruthy();
+  });
+
+  test('should fetch permissions', async () => {
+    const permissions = await getPermissions('1234');
+
+    expect(permissions['1234'].id).toEqual('1234');
+  });
+
+  test('should check permissions', async () => {
+    // Fail because org doesn't match
+    expect(await checkPermissions('1234', true, undefined, '999', '1194')).toBeFalsy();
+
+    // Pass when no constraints
+    expect(await checkPermissions('1234')).toBeTruthy();
+  });
+});

--- a/packages/authorize/types/Authorize.d.ts
+++ b/packages/authorize/types/Authorize.d.ts
@@ -1,3 +1,5 @@
+import { QueryOptions } from 'react-query';
+
 export type NumberOrString = string | number;
 export type Permission = string | number | NumberOrString[];
 export type Resource = string | number | NumberOrString[];
@@ -11,6 +13,7 @@ export interface AuthorizeProps {
   customerId?: string;
   unauthorized?: React.ReactNode;
   negate?: boolean;
+  queryOptions?: QueryOptions<boolean>;
 }
 
 declare const Authorize: React.FC<AuthorizeProps>;

--- a/packages/authorize/types/useAuthorize.d.ts
+++ b/packages/authorize/types/useAuthorize.d.ts
@@ -1,3 +1,4 @@
+import { QueryOptions } from 'react-query';
 import { Permission, Resource } from './Authorize';
 
 export interface AuthorizeOpts {
@@ -9,7 +10,8 @@ export interface AuthorizeOpts {
 
 declare function useAuthorize(
   permissions: string | number | Permission[],
-  options?: AuthorizeOpts
-): [boolean, boolean, string];
+  options?: AuthorizeOpts,
+  queryOptions?: QueryOptions<boolean>
+): { authorized: boolean; isLoading: boolean };
 
 export default useAuthorize;

--- a/storybook/stories/components/authorize.stories.js
+++ b/storybook/stories/components/authorize.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean, object } from '@storybook/addon-knobs';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Alert } from 'reactstrap';
 
 import { useAuthorize } from '@availity/authorize';
 import README from '@availity/authorize/README.md';
@@ -10,14 +12,20 @@ import { Preview } from '../util';
 
 const Authorize = React.lazy(() => import('@availity/authorize'));
 
+const queryClient = new QueryClient();
+
 const Component = () => {
-  const [authorized] = useAuthorize(text('Permissions', '1234') || object('Permissions Array', []), {
-    organizationId: text('OrganizationId', '1111'),
+  const { authorized, isLoading } = useAuthorize(text('Permissions', '1234') || object('Permissions Array', []), {
+    organizationId: text('Organization ID', '1111'),
+    customerId: text('Customer ID', ''),
   });
 
-  return authorized
-    ? text('Authorized Content', 'You are authorized to see this content.')
-    : text('UnAuthorized Content', 'You are not authorized to see this content.');
+  if (isLoading) return <p className="text-center">Loading...</p>;
+
+  const auth = text('Authorized Content', 'You are authorized to see this content.');
+  const unAuth = text('Unauthorized Content', 'You are not authorized to see this content.');
+
+  return <Alert color={authorized ? 'success' : 'danger'}>{authorized ? auth : unAuth}</Alert>;
 };
 
 storiesOf('Components/Authorize', module)
@@ -32,28 +40,35 @@ storiesOf('Components/Authorize', module)
   .add('default', () => (
     <div>
       <p>
-        For this demo, the following permissions are granted: 1234, 2345, 3456, 4567, 5678, 6789. You can use the knobs
+        For this demo, the following permissions are returned: 1234, 2345, 3456, 4567, 5678, 6789. You can use the knobs
         to see what the component will do when you set the required permissions to various things.
       </p>
       <hr />
-      <Authorize
-        permissions={text('Permissions', '1234') || object('Permissions Array', [])}
-        organizationId={text('OrganizationId', '1111')}
-        negate={boolean('Negate', false)}
-        loader={boolean('Loader', true)}
-        unauthorized={text('Unauthorized Content', 'You are not authorized to see this content.')}
-      >
-        {text('Authorized Content', 'You are authorized to see this content.')}
-      </Authorize>
+      <QueryClientProvider client={queryClient}>
+        <Authorize
+          permissions={text('Permissions', '1234') || object('Permissions Array', [])}
+          organizationId={text('Organization ID', '1111')}
+          customerId={text('Customer ID', '')}
+          negate={boolean('Negate', false)}
+          loader={boolean('Loader', true)}
+          unauthorized={
+            <Alert color="danger">{text('Unauthorized Content', 'You are not authorized to see this content.')}</Alert>
+          }
+        >
+          <Alert color="success">{text('Authorized Content', 'You are authorized to see this content.')}</Alert>
+        </Authorize>
+      </QueryClientProvider>
     </div>
   ))
   .add('useAuthorize', () => (
     <div>
       <p>
-        For this demo, the following permissions are granted: 1234, 2345, 3456, 4567, 5678, 6789. You can use the knobs
+        For this demo, the following permissions are returned: 1234, 2345, 3456, 4567, 5678, 6789. You can use the knobs
         to see what the component will do when you set the required permissions to various things.
       </p>
       <hr />
-      <Component />
+      <QueryClientProvider client={queryClient}>
+        <Component />
+      </QueryClientProvider>
     </div>
   ));


### PR DESCRIPTION
I've added `react-query` to the `useAuthorize` hook. `react-query` will replace the logic that was previously using `useEffect`. The `useAuthorize` hook had functions defined inside of it previously. I moved these to `utils.js` file and added tests. 

In the future I would like to break up how the permissions are fetched so this hook can leverage the `react-query` cache to grab already fetched permissions or so the app can use the permissions this hook has fetched. 

I updated the docs and storybook to account for `react-query`.

Breaking change as `react-query` is now required and I changed the value returned to an object from an array

Closes #630.
