### PR TITLE
Fix/date types

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -49,10 +49,7 @@ const AvDate = ({
     datepicker && 'av-calendar-show'
   );
 
-  const pickerId = `${(attributes.id || name).replace(
-    /[^\da-z]/gi,
-    ''
-  )}-picker`;
+  const pickerId = `${(attributes.id || name).replace(/[^\da-z]/gi, '')}-picker`;
 
   // Should only run validation once per real change to component, instead of each time setFieldValue/Touched is called.
   // By batching multiple calls for validation we can avoid multiple moment comparisons of the same values
@@ -65,11 +62,7 @@ const AvDate = ({
 
   // For updating when we delete the current input
   const onInputChange = (value) => {
-    const date = moment(
-      value,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
-      true
-    );
+    const date = moment(value, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'], true);
     const isoFormatted = date.format(isoDateFormat);
     setFieldValue(name, date.isValid() ? isoFormatted : date, false);
     setFieldTouched(name, true, false);
@@ -114,11 +107,7 @@ const AvDate = ({
   };
 
   const getDateValue = () => {
-    const date = moment(
-      field.value,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
-      true
-    );
+    const date = moment(field.value, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'], true);
     if (date.isValid()) return date;
 
     return null;
@@ -177,9 +166,7 @@ const AvDate = ({
       <InputGroup
         disabled={attributes.disabled}
         className={classes}
-        onChange={({ target }) =>
-          target.id === pickerId && onInputChange(target.value)
-        }
+        onChange={({ target }) => target.id === pickerId && onInputChange(target.value)}
         data-testid={`date-input-group-${name}`}
       >
         <SingleDatePicker

--- a/packages/date/src/DateField.js
+++ b/packages/date/src/DateField.js
@@ -4,23 +4,10 @@ import { Label } from 'reactstrap';
 import { FormGroup, Feedback } from '@availity/form';
 import Date from './Date';
 
-const DateField = ({
-  name,
-  label,
-  labelClass,
-  labelHidden,
-  labelAttrs,
-  id = name,
-  ...props
-}) => (
+const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name, ...props }) => (
   <FormGroup for={name}>
     {label && (
-      <Label
-        for={`${id}-picker`}
-        className={labelClass}
-        hidden={labelHidden}
-        {...labelAttrs}
-      >
+      <Label for={`${id}-picker`} className={labelClass} hidden={labelHidden} {...labelAttrs}>
         {label}
       </Label>
     )}
@@ -31,7 +18,7 @@ const DateField = ({
 
 DateField.propTypes = {
   id: PropTypes.string,
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   label: PropTypes.node,
   labelClass: PropTypes.string,
   labelHidden: PropTypes.bool,

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -82,26 +82,12 @@ const DateRange = ({
   const endValue = value.endDate || '';
 
   const startValueMoment = useMemo(
-    () =>
-      moment(startValue, [
-        isoDateFormat,
-        format,
-        'MMDDYYYY',
-        'YYYYMMDD',
-        'M/D/YYYY',
-      ]),
+    () => moment(startValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY']),
     [startValue, format]
   );
 
   const endValueMoment = useMemo(
-    () =>
-      moment(endValue, [
-        isoDateFormat,
-        format,
-        'MMDDYYYY',
-        'YYYYMMDD',
-        'M/D/YYYY',
-      ]),
+    () => moment(endValue, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY']),
     [endValue, format]
   );
 
@@ -126,11 +112,7 @@ const DateRange = ({
   // For updating when we delete the current input
   const onInputChange = (val) => {
     const isStart = focusedInput === 'startDate';
-    const date = moment(
-      val,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
-      true
-    );
+    const date = moment(val, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'], true);
 
     const valueToSet = date.isValid() ? date.format(format) : null;
 
@@ -204,11 +186,7 @@ const DateRange = ({
   };
 
   const getDateValue = (val) => {
-    const date = moment(
-      val,
-      [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'],
-      true
-    );
+    const date = moment(val, [isoDateFormat, format, 'MMDDYYYY', 'YYYYMMDD', 'M/D/YYYY'], true);
     if (date.isValid()) return date;
 
     return null;
@@ -219,9 +197,7 @@ const DateRange = ({
     if (typeof propsRanges === 'boolean' && propsRanges) {
       ranges = relativeRanges;
     } else if (propsRanges) {
-      ranges = Array.isArray(propsRanges)
-        ? pick(relativeRanges, propsRanges)
-        : propsRanges;
+      ranges = Array.isArray(propsRanges) ? pick(relativeRanges, propsRanges) : propsRanges;
     }
 
     return ranges ? (
@@ -231,8 +207,7 @@ const DateRange = ({
 
           // Comparing moments with unit as 'millisecond' avoids moment cloning
           const isSelected =
-            startDate.isSame(startValueMoment, 'millisecond') &&
-            endDate.isSame(endValueMoment, 'millisecond');
+            startDate.isSame(startValueMoment, 'millisecond') && endDate.isSame(endValueMoment, 'millisecond');
 
           return (
             <Button
@@ -378,11 +353,7 @@ DateRange.propTypes = {
   datepickerProps: PropTypes.object,
   'data-testid': PropTypes.string,
   autoSync: PropTypes.bool,
-  ranges: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.array,
-    PropTypes.object,
-  ]),
+  ranges: PropTypes.oneOfType([PropTypes.bool, PropTypes.array, PropTypes.object]),
   customArrowIcon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   openDirection: PropTypes.string,
 };

--- a/packages/date/src/DateRangeField.js
+++ b/packages/date/src/DateRangeField.js
@@ -4,23 +4,10 @@ import { Label } from 'reactstrap';
 import { FormGroup, Feedback } from '@availity/form';
 import DateRange from './DateRange';
 
-const DateRangeField = ({
-  name,
-  label,
-  labelClass,
-  labelHidden,
-  labelAttrs,
-  id = name,
-  ...props
-}) => (
+const DateRangeField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name, ...props }) => (
   <FormGroup for={name}>
     {label && (
-      <Label
-        for={`${id.replace(/[^\da-z]/gi, '')}-start`}
-        className={labelClass}
-        hidden={labelHidden}
-        {...labelAttrs}
-      >
+      <Label for={`${id.replace(/[^\da-z]/gi, '')}-start`} className={labelClass} hidden={labelHidden} {...labelAttrs}>
         {label}
       </Label>
     )}

--- a/packages/date/types/Date.d.ts
+++ b/packages/date/types/Date.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SingleDatePickerShape } from 'react-dates';
+import { FieldValidator } from 'formik';
 
 export type limitType = {
   value?: number;
@@ -11,23 +12,24 @@ export type limitTypeAlt = {
   _isValid?: Function;
 };
 
-export interface DateBaseProps {
-  id: string;
+export type DateProps = {
+  id?: string;
   name: string;
-  disabled?: boolean | false;
+  disabled?: boolean;
   className?: string;
   min?: string | limitType | limitTypeAlt;
   max?: string | limitType | limitTypeAlt;
   calendarIcon?: React.ReactNode;
-  onChange?: Function;
-  onPickerFocusChange?: Function;
+  onChange?: (date: string) => void;
+  onPickerFocusChange?: (arg: { focused: boolean }) => void;
   innerRef?: Function | string;
-  datePickerProps?: object;
   format?: string;
-}
+  datepicker?: boolean;
+  datePickerProps?: SingleDatePickerShape;
+  validate?: FieldValidator;
+  openDirection?: 'down' | 'up';
+};
 
-export type DateProps = SingleDatePickerShape & DateBaseProps;
-
-declare class Date extends React.Component<DateProps> {}
+declare const Date: (props: DateProps) => JSX.Element;
 
 export default Date;

--- a/packages/date/types/DateField.d.ts
+++ b/packages/date/types/DateField.d.ts
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { DateProps } from './Date';
 
 export type DateFieldProps = {
-  id: string;
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;
   labelAttrs?: React.HTMLAttributes<HTMLLabelElement>;
 } & DateProps;
 
-declare class DateField extends React.Component<DateFieldProps> {}
+declare const DateField: (props: DateFieldProps) => JSX.Element;
 
 export default DateField;

--- a/packages/date/types/DateRange.d.ts
+++ b/packages/date/types/DateRange.d.ts
@@ -1,18 +1,22 @@
 import * as React from 'react';
-import { DateRangePicker } from 'react-dates';
+import { DateRangePickerShape } from 'react-dates';
 import { Moment } from 'moment';
-import { DateBaseProps } from './Date';
+import { DateProps } from './Date';
 
 interface MomentDateRange {
   startDate: Moment;
   endDate: Moment;
 }
 
-export interface DateRangeProps extends DateRangePicker, DateBaseProps {
+export type DateRangeProps = {
+  datepickerProps?: DateRangePickerShape;
   ranges?: boolean | string[] | { [key: string]: MomentDateRange };
   autoSync?: boolean;
-}
+  onChange?: (dates: { startDate: string; endDate: string }) => void;
+  onPickerFocusChange?: (arg: { focusedInput: 'startDate' | 'endDate' | null }) => void;
+  customArrowIcon?: React.ReactNode;
+} & Omit<DateProps, 'datePickerProps'>;
 
-declare class DateRange extends React.Component<DateRangeProps> {}
+declare const DateRange: (props: DateRangeProps) => JSX.Element;
 
 export default DateRange;

--- a/packages/date/types/DateRangeField.d.ts
+++ b/packages/date/types/DateRangeField.d.ts
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { DateRangeProps } from './DateRange';
 
-export interface DateRangeFieldProps extends DateRangeProps {
-  id: string;
+export type DateRangeFieldProps = {
   label?: React.ReactNode;
   labelClass?: string;
   labelHidden?: boolean;
   labelAttrs?: React.HTMLAttributes<HTMLLabelElement>;
-}
+} & DateRangeProps;
 
-declare class DateRangeField extends React.Component<DateRangeFieldProps> {}
+declare const DateRangeField: (props: DateRangeFieldProps) => JSX.Element;
 
 export default DateRangeField;

--- a/storybook/stories/form-components/date.stories.js
+++ b/storybook/stories/form-components/date.stories.js
@@ -1,20 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import {
-  withKnobs,
-  boolean,
-  text,
-  select,
-  number,
-} from '@storybook/addon-knobs';
+import { withKnobs, boolean, text, select, number } from '@storybook/addon-knobs';
 import { Button } from 'reactstrap';
 import { avDate, dateRange } from '@availity/yup';
 import { object } from 'yup';
-import FormikDate, {
-  DateField,
-  DateRange,
-  DateRangeField,
-} from '@availity/date';
+import FormikDate, { DateField, DateRange, DateRangeField } from '@availity/date';
 import '@availity/date/styles.scss';
 import README from '@availity/date/README.md';
 import moment from 'moment';


### PR DESCRIPTION
Closes #822 

The exported types for this package were not accurate. They were improperly extending types from `react-dates` which were not used. Some types were also ambiguous like `onChange` so I updated these to be more descriptive. I also ran prettier on files in this package
