### PR TITLE
fix: add timezone to jest global setup

### DIFF
--- a/global-setup.js
+++ b/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,4 +22,5 @@ module.exports = {
   globals: {
     jsdom: true,
   },
+  globalSetup: './global-setup.js',
 };


### PR DESCRIPTION
`new Date()` and `moment()` were creating dates in different timezones in some of the date/time utility tests, causing them to fail when run in the evening. In my case, my timezone has a four hour offset from UTC, so if I ran tests within the last four hours before midnight, they would fail. Other times of day they would pass.

This PR sets the timezone for jest to UTC. Now the tests should be passing any time of day.
