### PR TITLE
Types and other general refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ https://availity.github.io/availity-react/storybook
 
 https://availity.github.io/availity-react
 
-## [Contributing](./.github/CONTRIBUTING.md)
+## Contributing
+
+[Contributing Guide](./.github/CONTRIBUTING.md)
 
 ## Additional Notes
 

--- a/packages/app-icon/package.json
+++ b/packages/app-icon/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "classnames": "^2.3.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/app-icon/src/AppIcon.js
+++ b/packages/app-icon/src/AppIcon.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 function AppIcon({ tag: Tag, color, size, src: image, alt, branded, className, children, ...props }) {
-  const classname = [
-    className,
-    'app-icon',
-    branded ? `app-icon-branded-${color}` : `app-icon-${color}`,
-    size && `app-icon-${size}`,
-    image && 'border-0',
-  ]
-    .filter((a) => a)
-    .join(' ');
+  const classes = classNames(className, 'app-icon', {
+    [`app-icon-${color}`]: color && !branded,
+    [`app-icon-branded-${color}`]: color && branded,
+    [`app-icon-${size}`]: size,
+    'border-0': image,
+  });
 
   return (
-    <Tag {...props} className={classname}>
+    <Tag {...props} className={classes}>
       {image ? <img className="w-100 h-100 align-baseline" src={image} alt={alt} /> : children}
       {branded && <span className="caret" />}
     </Tag>

--- a/packages/help/index.d.ts
+++ b/packages/help/index.d.ts
@@ -1,2 +1,2 @@
-export { default } from './types/Help';
+export { default, Help, useHelp, constants, triggerFieldHelp, FieldHelpIcon } from './types/Help';
 export * from './types/Help';

--- a/packages/help/types/Help.d.ts
+++ b/packages/help/types/Help.d.ts
@@ -6,6 +6,7 @@ export interface HelpObj {
 export type TopNavConstants = {
   SET_HELP: 'nav:help:set';
   RESET_HELP: 'nav:help:reset';
+  OPEN_FIELD_HELP: 'nav:help:field';
 };
 
 export interface HelpContext {

--- a/packages/link/types/Link.d.ts
+++ b/packages/link/types/Link.d.ts
@@ -1,8 +1,10 @@
-import * as React from 'react';
-
 export interface AvLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  target?: string;
   tag?: React.ReactType | string;
+  onClick?: (event: React.SyntheticEvent<HTMLAnchorElement>, url: string) => void;
+  href: string;
   loadApp?: boolean;
+  rel?: string;
 }
 
 declare const AvLink: React.FC<AvLinkProps>;

--- a/packages/list-group-item/types/ListGroupItem.d.ts
+++ b/packages/list-group-item/types/ListGroupItem.d.ts
@@ -2,8 +2,9 @@ import { ListGroupItemProps as RsListGroupItemProps } from 'reactstrap';
 
 export interface ListGroupItemProps extends RsListGroupItemProps {
   borderColor?: string;
+  className?: string;
 }
 
-declare const ListGroupItem: React.FC<ListGroupItemProps>;
+declare const ListGroupItem: (props: ListGroupItemProps) => JSX.Element;
 
 export default ListGroupItem;

--- a/packages/list-group-item/types/ListGroupItemStatus.d.ts
+++ b/packages/list-group-item/types/ListGroupItemStatus.d.ts
@@ -1,14 +1,17 @@
-import { ListGroupItemProps } from './ListGroupItem';
+import { ListGroupItemProps as RsListGroupItemProps } from 'reactstrap';
 
 type BadgeType = {
   color?: string;
   text?: string;
 };
-export interface ListGroupItemStatusProps extends ListGroupItemProps {
-  titleContent?: React.ReactType;
+
+export interface ListGroupItemStatusProps extends RsListGroupItemProps {
+  titleContent?: React.ReactNode;
+  children: React.ReactNode;
+  color?: string;
   badge?: boolean | string | BadgeType;
 }
 
-declare const ListGroupItemStatus: React.StatelessComponent<ListGroupItemStatusProps>;
+declare const ListGroupItemStatus: (props: ListGroupItemStatusProps) => JSX.Element;
 
 export default ListGroupItemStatus;

--- a/packages/list-group/package.json
+++ b/packages/list-group/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "dependencies": {
+    "classnames": "^2.3.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/list-group/src/ListGroup.js
+++ b/packages/list-group/src/ListGroup.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ListGroup as RsListGroup } from 'reactstrap';
+import classNames from 'classnames';
 
 const ListGroup = React.forwardRef(({ cards, selectable, className, ...props }, ref) => {
-  const classname = [className, cards && 'list-group-cards', selectable && 'list-group-selectable']
-    .filter((a) => a)
-    .join(' ');
+  const classes = classNames(className, { 'list-group-cards': cards, 'list-group-selectable': selectable });
 
-  return <RsListGroup ref={ref} {...props} className={classname} />;
+  return <RsListGroup ref={ref} {...props} className={classes} />;
 });
 
 ListGroup.propTypes = {

--- a/packages/list-group/types/ListGroup.d.ts
+++ b/packages/list-group/types/ListGroup.d.ts
@@ -6,6 +6,6 @@ export interface ListGroupProps extends RsListGroupProps {
   className?: string;
 }
 
-declare const ListGroup: React.StatelessComponent<ListGroupProps>;
+declare const ListGroup: (props: ListGroupProps) => JSX.Element;
 
 export default ListGroup;

--- a/packages/payer-logo/index.d.ts
+++ b/packages/payer-logo/index.d.ts
@@ -1,2 +1,2 @@
-export { default } from './types/PayerLogo';
+export { default, getLogo } from './types/PayerLogo';
 export * from './types/PayerLogo';

--- a/packages/payer-logo/types/PayerLogo.d.ts
+++ b/packages/payer-logo/types/PayerLogo.d.ts
@@ -4,9 +4,9 @@ export interface PayerLogoProps {
   clientId: string;
 }
 
-declare function getLogo(spaceId?: string, payerId?: string, clientId?: string): string;
+declare function getLogo(spaceId?: string, payerId?: string, clientId?: string): Promise<string>;
 
-declare const PayerLogo: React.FC<PayerLogoProps>;
+declare const PayerLogo: (props: PayerLogoProps) => JSX.Element | null;
 
 export default PayerLogo;
 

--- a/packages/phone/types/Phone.d.ts
+++ b/packages/phone/types/Phone.d.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FieldProps } from '@availity/form/types/Field';
 
 interface ExtensionProps extends FieldProps {
@@ -10,11 +9,12 @@ interface ExtensionProps extends FieldProps {
 export interface PhoneProps extends FieldProps {
   name: string;
   id?: string;
-  showExtension?: boolean | false;
+  country?: string;
+  showExtension?: boolean;
   phoneColProps?: object;
   extProps?: ExtensionProps;
 }
 
-declare const Phone: React.FC<PhoneProps>;
+declare const Phone: (props: PhoneProps) => JSX.Element;
 
 export default Phone;

--- a/packages/progress/types/Progress.d.ts
+++ b/packages/progress/types/Progress.d.ts
@@ -9,6 +9,6 @@ export interface ProgressProps {
   color?: string;
 }
 
-declare const Progress: React.FC<ProgressProps>;
+declare const Progress: (props: ProgressProps) => JSX.Element;
 
 export default Progress;

--- a/packages/training-link/types/TrainingLink.d.ts
+++ b/packages/training-link/types/TrainingLink.d.ts
@@ -3,6 +3,6 @@ export interface TrainingLinkProps {
   name: string;
 }
 
-declare const TrainingLink: React.FC<TrainingLinkProps>;
+declare const TrainingLink: (props: TrainingLinkProps) => JSX.Element;
 
 export default TrainingLink;

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -44,7 +44,6 @@
     "@availity/link": "^2.3.2",
     "@availity/list-group": "^1.2.24",
     "@availity/list-group-item": "^1.2.23",
-    "@availity/localstorage-core": "^3.0.0",
     "@availity/mock": "^2.1.0",
     "@availity/page-header": "^11.0.15",
     "@availity/pagination": "^2.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,11 +161,6 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@availity/localstorage-core@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@availity/localstorage-core/-/localstorage-core-3.0.0.tgz#3c8f7fbb84338562d117569b59a4cec415d8aa1f"
-  integrity sha512-3N0fHI7DuHksvnhdtvZcnnFpKYY4BmCcL1nc3jb9U9sPEIhw/9q4203yhd9MEsYcICLbpA6I03p7/vbo048ayA==
-
 "@availity/message-core@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@availity/message-core/-/message-core-5.0.0.tgz#c0c429cb3a128453f79e204b4f3c43e2feade392"
@@ -7197,8 +7192,8 @@ class-utils@^0.3.5:
 
 classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+  resolved "https://packages.availity.com:443/artifactory/api/npm/availity-npm-all/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha1-38+jiR4wbsHa0QXQ6I9EF7hTXo4=
 
 clean-css@4.2.x, clean-css@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
This pull request has 2 types of changes. 

1) I updated types of some packages. This includes adding omitted types and using `JSX.Element` instead of `React.FC` so `children` will not be accepted
2) For `app-icon` and `list-group` I added the `classnames` package. I opted to use it here because it is small, and I believe aids the readability of the code.
