### PR TITLE
feat(form)!: run formatter with new settings

### DIFF
--- a/packages/form/MIGRATION.md
+++ b/packages/form/MIGRATION.md
@@ -119,10 +119,7 @@ const Example = () => (
       zipCode: yup
         .string()
         .isRequired(true, 'This Field is Required.')
-        .matches(
-          /^\d{5}(?:-\d{4})?$/,
-          'Valid Zip Code Formats: 12345 or 12345-6789'
-        ),
+        .matches(/^\d{5}(?:-\d{4})?$/, 'Valid Zip Code Formats: 12345 or 12345-6789'),
     })}
   >
     <Field name="memberId" type="text" label="Member ID" />

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -4,18 +4,19 @@ import { FieldHelpIcon } from '@availity/help';
 import { Label, Input } from 'reactstrap';
 import { v4 as uuid } from 'uuid';
 import classNames from 'classnames';
+
 import { useCheckboxGroup } from './CheckboxGroup';
 import FormGroup from './FormGroup';
 
 const Checkbox = ({
-  label,
-  value: checkValue,
-  groupClassName,
   className,
-  id,
-  inline,
+  groupClassName,
   groupName,
   helpId,
+  id,
+  inline,
+  label,
+  value: checkValue,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -30,21 +31,12 @@ const Checkbox = ({
 
   // should only reference feedback id when feedback is in the DOM
   const errorIndicated = !!metadata.touched && !!metadata.error;
-  const groupFeedbackId =
-    errorIndicated && groupName ? `${groupName}-feedback`.toLowerCase() : '';
+  const groupFeedbackId = errorIndicated && groupName ? `${groupName}-feedback`.toLowerCase() : '';
   const labelId = `${inputId}-label`.toLowerCase();
-  const helpIcon = helpId ? (
-    <FieldHelpIcon id={helpId} labelId={labelId} />
-  ) : null;
+  const helpIcon = helpId ? <FieldHelpIcon id={helpId} labelId={labelId} /> : null;
 
   return (
-    <FormGroup
-      for={inputId}
-      className={groupClassName}
-      check
-      inline={inline}
-      disabled={attributes.disabled}
-    >
+    <FormGroup for={inputId} className={groupClassName} check inline={inline} disabled={attributes.disabled}>
       <Input
         id={inputId}
         name={inputId}
@@ -66,19 +58,15 @@ const Checkbox = ({
 };
 
 Checkbox.propTypes = {
-  id: PropTypes.string,
-  label: PropTypes.string,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.object,
-  ]),
-  inline: PropTypes.bool,
-  disabled: PropTypes.bool,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   groupClassName: PropTypes.string,
   groupName: PropTypes.string,
   helpId: PropTypes.string,
+  id: PropTypes.string,
+  inline: PropTypes.bool,
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
 };
 
 Checkbox.defaultProps = {

--- a/packages/form/src/CheckboxGroup.js
+++ b/packages/form/src/CheckboxGroup.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FieldHelpIcon } from '@availity/help';
 import { useField, useFormikContext } from 'formik';
+
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
 
@@ -10,12 +11,7 @@ export const CheckboxGroupContext = createContext();
 
 export const useCheckboxGroup = (name) => {
   const { setFieldValue } = useFormikContext();
-  const {
-    name: groupName,
-    groupOnChange,
-    value = [],
-    ...rest
-  } = useContext(CheckboxGroupContext);
+  const { name: groupName, groupOnChange, value = [], ...rest } = useContext(CheckboxGroupContext);
 
   const toggle = () => {
     const valueArray = [...value];
@@ -38,15 +34,7 @@ export const useCheckboxGroup = (name) => {
   return { toggle, value: value.indexOf(name) > -1, ...rest };
 };
 
-const CheckboxGroup = ({
-  name,
-  children,
-  onChange: groupOnChange,
-  groupClassName,
-  label,
-  helpId,
-  ...rest
-}) => {
+const CheckboxGroup = ({ name, children, onChange: groupOnChange, groupClassName, label, helpId, ...rest }) => {
   const [field, metadata] = useField(name);
 
   const classes = classNames(
@@ -81,9 +69,7 @@ const CheckboxGroup = ({
   }
 
   return (
-    <CheckboxGroupContext.Provider
-      value={{ ...field, groupOnChange, metadata }}
-    >
+    <CheckboxGroupContext.Provider value={{ ...field, groupOnChange, metadata }}>
       <FormGroup tag={tag} for={name} {...rest}>
         {legend}
         <div className={classes} data-testid={`check-items-${name}`}>
@@ -96,12 +82,12 @@ const CheckboxGroup = ({
 };
 
 CheckboxGroup.propTypes = {
-  name: PropTypes.string,
   children: PropTypes.node,
-  label: PropTypes.node,
-  onChange: PropTypes.func,
   groupClassName: PropTypes.string,
   helpId: PropTypes.string,
+  label: PropTypes.node,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
 };
 
 export default CheckboxGroup;

--- a/packages/form/src/Feedback.js
+++ b/packages/form/src/Feedback.js
@@ -5,14 +5,7 @@ import { ErrorMessage } from 'formik';
 
 const Feedback = ({ name, ...rest }) => {
   const feedbackId = `${name}-feedback`.toLowerCase();
-  return (
-    <ErrorMessage
-      id={feedbackId}
-      component={FormFeedback}
-      name={name}
-      {...rest}
-    />
-  );
+  return <ErrorMessage id={feedbackId} component={FormFeedback} name={name} {...rest} />;
 };
 
 Feedback.propTypes = {

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -1,16 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FieldHelpIcon } from '@availity/help';
-import {
-  Input as RsInput,
-  Label,
-  FormText,
-  Col,
-  InputGroup,
-  InputGroupText,
-  InputGroupAddon,
-} from 'reactstrap';
+import { Input as RsInput, Label, FormText, Col, InputGroup, InputGroupText, InputGroupAddon } from 'reactstrap';
 import { v4 as uuid } from 'uuid';
+
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
 import Input from './Input';
@@ -71,21 +64,13 @@ const Field = ({
       <InputGroup>
         {prepend && (
           <InputGroupAddon addonType="prepend">
-            {typeof prepend === 'string' ? (
-              <InputGroupText>{prepend}</InputGroupText>
-            ) : (
-              prepend
-            )}
+            {typeof prepend === 'string' ? <InputGroupText>{prepend}</InputGroupText> : prepend}
           </InputGroupAddon>
         )}
         {input}
         {append && (
           <InputGroupAddon addonType="append">
-            {typeof append === 'string' ? (
-              <InputGroupText>{append}</InputGroupText>
-            ) : (
-              append
-            )}
+            {typeof append === 'string' ? <InputGroupText>{append}</InputGroupText> : append}
           </InputGroupAddon>
         )}
         <Feedback name={id} />
@@ -93,9 +78,7 @@ const Field = ({
     );
   }
 
-  const help = helpMessage ? (
-    <FormText id={`${id}-helpmessage`.toLowerCase()}>{helpMessage}</FormText>
-  ) : null;
+  const help = helpMessage ? <FormText id={`${id}-helpmessage`.toLowerCase()}>{helpMessage}</FormText> : null;
   const feedback = <Feedback name={id} />;
   let inputRow = row ? (
     <Col {...col}>
@@ -112,18 +95,10 @@ const Field = ({
   }
 
   const check = attributes.type === 'checkbox';
-  const helpIcon = helpId ? (
-    <FieldHelpIcon labelId={`${inputId}-label`} id={helpId} />
-  ) : null;
+  const helpIcon = helpId ? <FieldHelpIcon labelId={`${inputId}-label`} id={helpId} /> : null;
 
   return (
-    <FormGroup
-      for={id}
-      check={check}
-      disabled={disabled}
-      row={row}
-      {...groupAttrs}
-    >
+    <FormGroup for={id} check={check} disabled={disabled} row={row} {...groupAttrs}>
       {check && inputRow}
       {label && (
         <>
@@ -149,23 +124,23 @@ const Field = ({
 };
 
 Field.propTypes = {
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  label: PropTypes.node,
-  labelHidden: PropTypes.bool,
-  disabled: PropTypes.bool,
-  readOnly: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-  size: PropTypes.string,
-  inputClass: PropTypes.string,
-  labelClass: PropTypes.string,
-  helpMessage: PropTypes.node,
-  labelAttrs: PropTypes.object,
-  groupAttrs: PropTypes.object,
-  grid: PropTypes.object,
-  children: PropTypes.func,
   append: PropTypes.node,
-  prepend: PropTypes.node,
+  children: PropTypes.func,
+  disabled: PropTypes.bool,
+  grid: PropTypes.object,
+  groupAttrs: PropTypes.object,
   helpId: PropTypes.string,
+  helpMessage: PropTypes.node,
+  inputClass: PropTypes.string,
+  label: PropTypes.node,
+  labelAttrs: PropTypes.object,
+  labelClass: PropTypes.string,
+  labelHidden: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  prepend: PropTypes.node,
+  readOnly: PropTypes.bool,
+  size: PropTypes.string,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 };
 
 Field.defaultProps = {

--- a/packages/form/src/Form.js
+++ b/packages/form/src/Form.js
@@ -37,20 +37,19 @@ const Form = ({
   </Formik>
 );
 
+/* eslint-disable react/forbid-prop-types */
 Form.propTypes = {
-  initialValues: PropTypes.object.isRequired,
-  enableReinitialize: PropTypes.bool,
-  onSubmit: PropTypes.func,
-  onReset: PropTypes.func,
-  // eslint-disable-next-line react/forbid-prop-types
-  initialStatus: PropTypes.any,
-  initialErrors: PropTypes.object,
-  initialTouched: PropTypes.object,
-  validationSchema: PropTypes.object,
-  validate: PropTypes.func,
-  // eslint-disable-next-line react/forbid-prop-types
-  innerRef: PropTypes.any,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  enableReinitialize: PropTypes.bool,
+  initialErrors: PropTypes.object,
+  initialStatus: PropTypes.any,
+  initialTouched: PropTypes.object,
+  initialValues: PropTypes.object.isRequired,
+  innerRef: PropTypes.any,
+  onReset: PropTypes.func,
+  onSubmit: PropTypes.func,
+  validate: PropTypes.func,
+  validationSchema: PropTypes.object,
 };
 
 Form.defaultProps = {

--- a/packages/form/src/FormGroup.js
+++ b/packages/form/src/FormGroup.js
@@ -7,10 +7,7 @@ import { useField } from 'formik';
 const FormGroup = ({ className, for: For, ...props }) => {
   const [, metadata] = useField(For);
 
-  const classname = classNames(
-    className,
-    metadata.touched && metadata.error && `text-danger`
-  );
+  const classname = classNames(className, metadata.touched && metadata.error && `text-danger`);
 
   return <RsFormGroup className={classname} {...props} />;
 };

--- a/packages/form/src/Input.js
+++ b/packages/form/src/Input.js
@@ -4,16 +4,7 @@ import classNames from 'classnames';
 import { Input as RsInput } from 'reactstrap';
 import { useField } from 'formik';
 
-const Input = ({
-  tag: Tag,
-  className,
-  onChange: propsOnChange,
-  validate,
-  name,
-  feedback,
-  help,
-  ...rest
-}) => {
+const Input = ({ tag: Tag, className, onChange: propsOnChange, validate, name, feedback, help, ...rest }) => {
   const [{ onChange, ...field }, metadata] = useField({
     name,
     validate,
@@ -24,10 +15,7 @@ const Input = ({
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.error ? 'av-invalid' : 'av-valid',
     metadata.touched && metadata.error && 'is-invalid',
-    rest.type === 'checkbox' &&
-      metadata.touched &&
-      metadata.error &&
-      'was-validated'
+    rest.type === 'checkbox' && metadata.touched && metadata.error && 'was-validated'
   );
 
   const error = !!metadata.touched && !!metadata.error;
@@ -60,13 +48,13 @@ const Input = ({
 };
 
 Input.propTypes = {
-  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   className: PropTypes.string,
-  validate: PropTypes.func,
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
   feedback: PropTypes.bool,
   help: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  validate: PropTypes.func,
 };
 
 Input.defaultProps = {

--- a/packages/form/src/Radio.js
+++ b/packages/form/src/Radio.js
@@ -4,20 +4,11 @@ import { FieldHelpIcon } from '@availity/help';
 import { Label, Input } from 'reactstrap';
 import { v4 as uuid } from 'uuid';
 import classNames from 'classnames';
+
 import { useRadioGroup } from './RadioGroup';
 import FormGroup from './FormGroup';
 
-const Radio = ({
-  label,
-  id,
-  name,
-  value: checkValue,
-  className,
-  groupClassName,
-  children,
-  helpId,
-  ...attributes
-}) => {
+const Radio = ({ label, id, name, value: checkValue, className, groupClassName, children, helpId, ...attributes }) => {
   const { value, setValue, metadata, inline } = useRadioGroup(checkValue);
 
   const [inputId] = useState(id || uuid());
@@ -29,21 +20,12 @@ const Radio = ({
   );
 
   const errorIndicated = !!metadata.touched && !!metadata.error;
-  const feedbackId =
-    errorIndicated && name ? `${name}-feedback`.toLowerCase() : '';
+  const feedbackId = errorIndicated && name ? `${name}-feedback`.toLowerCase() : '';
   const labelId = `${inputId}-label`.toLowerCase();
-  const helpIcon = helpId ? (
-    <FieldHelpIcon id={helpId} labelId={labelId} />
-  ) : null;
+  const helpIcon = helpId ? <FieldHelpIcon id={helpId} labelId={labelId} /> : null;
 
   return (
-    <FormGroup
-      for={inputId}
-      check
-      className={groupClassName}
-      inline={inline}
-      disabled={attributes.disabled}
-    >
+    <FormGroup for={inputId} check className={groupClassName} inline={inline} disabled={attributes.disabled}>
       <Input
         id={inputId}
         name={name || inputId}
@@ -65,19 +47,15 @@ const Radio = ({
 };
 
 Radio.propTypes = {
-  id: PropTypes.string,
-  name: PropTypes.string,
-  label: PropTypes.node,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.bool,
-    PropTypes.object,
-  ]),
-  disabled: PropTypes.bool,
-  className: PropTypes.string,
-  groupClassName: PropTypes.string,
   children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helpId: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.node,
+  name: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
 };
 
 export default Radio;

--- a/packages/form/src/RadioGroup.js
+++ b/packages/form/src/RadioGroup.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FieldHelpIcon } from '@availity/help';
 import { useField, useFormikContext } from 'formik';
+
 import Feedback from './Feedback';
 import FormGroup from './FormGroup';
 
@@ -10,12 +11,7 @@ export const RadioGroupContext = createContext();
 
 export const useRadioGroup = (radioValue) => {
   const { setFieldValue } = useFormikContext();
-  const {
-    name: groupName,
-    value = '',
-    groupOnChange,
-    ...rest
-  } = useContext(RadioGroupContext);
+  const { name: groupName, value = '', groupOnChange, ...rest } = useContext(RadioGroupContext);
 
   const setValue = () => {
     setFieldValue(groupName, radioValue);
@@ -71,9 +67,7 @@ const RadioGroup = ({
   }
 
   return (
-    <RadioGroupContext.Provider
-      value={{ ...field, groupOnChange, metadata, inline }}
-    >
+    <RadioGroupContext.Provider value={{ ...field, groupOnChange, metadata, inline }}>
       <FormGroup tag={tag} for={name} {...rest}>
         {legend}
         <div className={classes} data-testid={`radio-items-${name}`}>
@@ -86,13 +80,13 @@ const RadioGroup = ({
 };
 
 RadioGroup.propTypes = {
-  name: PropTypes.string,
   children: PropTypes.node,
-  label: PropTypes.node,
-  onChange: PropTypes.func,
-  inline: PropTypes.bool,
   groupClassName: PropTypes.string,
   helpId: PropTypes.string,
+  inline: PropTypes.bool,
+  label: PropTypes.node,
+  name: PropTypes.string,
+  onChange: PropTypes.func,
 };
 
 export default RadioGroup;

--- a/packages/form/tests/Checkbox.test.js
+++ b/packages/form/tests/Checkbox.test.js
@@ -50,7 +50,7 @@ describe('Checkbox', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const checkbox = getByTestId('hello-check');
@@ -73,12 +73,7 @@ describe('Checkbox', () => {
         onSubmit={() => {}}
       >
         <CheckboxGroup name="hello" label="Checkbox Group">
-          <Checkbox
-            groupName="hello"
-            label="Check One"
-            value="uno"
-            data-testid="hello-check"
-          />
+          <Checkbox groupName="hello" label="Check One" value="uno" data-testid="hello-check" />
         </CheckboxGroup>
         <Button type="submit">Submit</Button>
       </Form>
@@ -89,15 +84,12 @@ describe('Checkbox', () => {
     expect(checkbox).toHaveAttribute('aria-invalid', 'false');
     expect(checkbox).toHaveAttribute('aria-describedby', '');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(checkbox).toHaveAttribute('aria-invalid', 'true');
       expect(checkbox).toHaveAttribute('aria-describedby', 'hello-feedback');
-      expect(getByText('This field is required')).toHaveAttribute(
-        'id',
-        'hello-feedback'
-      );
+      expect(getByText('This field is required')).toHaveAttribute('id', 'hello-feedback');
     });
   });
 
@@ -119,7 +111,7 @@ describe('Checkbox', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const checkbox = getByTestId('hello-check');

--- a/packages/form/tests/CheckboxGroup.test.js
+++ b/packages/form/tests/CheckboxGroup.test.js
@@ -19,11 +19,7 @@ describe('CheckboxGroup', () => {
           hello: yup.array().required('At least one checkbox is required'),
         })}
       >
-        <CheckboxGroup
-          name="hello"
-          label="Checkbox Group"
-          groupClassName="some-group"
-        >
+        <CheckboxGroup name="hello" label="Checkbox Group" groupClassName="some-group">
           <Checkbox label="Chcek One" value="uno" />
         </CheckboxGroup>
         <Button type="submit">Submit</Button>
@@ -56,7 +52,7 @@ describe('CheckboxGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const checkboxGroup = getByTestId('check-items-hello');
@@ -74,11 +70,7 @@ describe('CheckboxGroup', () => {
         }}
         onSubmit={() => {}}
       >
-        <CheckboxGroup
-          name="hello"
-          label="Checkbox Group"
-          helpId="helloHelpTopic"
-        >
+        <CheckboxGroup name="hello" label="Checkbox Group" helpId="helloHelpTopic">
           <Checkbox label="Check One" value="uno" />
         </CheckboxGroup>
         <Button type="submit">Submit</Button>
@@ -110,10 +102,10 @@ describe('CheckboxGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Check One'));
-    await fireEvent.click(getByText('Check Two'));
+    fireEvent.click(getByText('Check One'));
+    fireEvent.click(getByText('Check Two'));
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -146,10 +138,10 @@ describe('CheckboxGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Check One'));
-    await fireEvent.click(getByText('Check Two'));
+    fireEvent.click(getByText('Check One'));
+    fireEvent.click(getByText('Check Two'));
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -181,7 +173,7 @@ describe('CheckboxGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Check One'));
+    fireEvent.click(getByText('Check One'));
 
     await waitFor(() => {
       expect(onChange.mock.calls[0][0][0]).toBe('uno');

--- a/packages/form/tests/Feedback.test.js
+++ b/packages/form/tests/Feedback.test.js
@@ -24,7 +24,7 @@ describe('Feedback', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const feedback = getByTestId('hello-feedback');

--- a/packages/form/tests/Field.test.js
+++ b/packages/form/tests/Field.test.js
@@ -57,12 +57,7 @@ describe('Field', () => {
         }}
         onSubmit={() => {}}
       >
-        <Field
-          name="hello"
-          label="Hello Label"
-          data-testid="hello-input"
-          helpId="hellohelptopic"
-        />
+        <Field name="hello" label="Hello Label" data-testid="hello-input" helpId="hellohelptopic" />
       </Form>
     );
 
@@ -84,10 +79,7 @@ describe('Field', () => {
     const el = getByText('help text');
     expect(el).toBeDefined();
     expect(el).toHaveAttribute('id', 'hello-helpmessage');
-    expect(getByTestId('hello-input')).toHaveAttribute(
-      'aria-describedby',
-      ' hello-helpmessage'
-    );
+    expect(getByTestId('hello-input')).toHaveAttribute('aria-describedby', ' hello-helpmessage');
   });
 
   test('renders with initial value', () => {
@@ -116,7 +108,7 @@ describe('Field', () => {
       </Form>
     );
 
-    await fireEvent.change(getByDisplayValue('John'), {
+    fireEvent.change(getByDisplayValue('John'), {
       target: {
         name: 'name',
         value: '',
@@ -159,12 +151,8 @@ describe('Field', () => {
       </Form>
     );
 
-    expect(container.querySelector('input').getAttribute('id')).toEqual(
-      inputId
-    );
-    expect(container.querySelector('label').getAttribute('for')).toEqual(
-      inputId
-    );
+    expect(container.querySelector('input').getAttribute('id')).toEqual(inputId);
+    expect(container.querySelector('label').getAttribute('for')).toEqual(inputId);
   });
 
   test('should generate uuid even when label is not added', () => {
@@ -196,7 +184,7 @@ describe('Field', () => {
     expect(input).toHaveAttribute('aria-describedby', ' name-helpmessage');
     expect(input).toHaveAttribute('aria-invalid', 'false');
 
-    await fireEvent.change(getByDisplayValue('John'), {
+    fireEvent.change(getByDisplayValue('John'), {
       target: {
         name: 'name',
         value: '',
@@ -211,10 +199,7 @@ describe('Field', () => {
       expect(feedback).toHaveAttribute('id', 'name-feedback');
       expect(help).toHaveAttribute('id', 'name-helpmessage');
       expect(input).toHaveAttribute('aria-invalid', 'true');
-      expect(input).toHaveAttribute(
-        'aria-describedby',
-        'name-feedback name-helpmessage'
-      );
+      expect(input).toHaveAttribute('aria-describedby', 'name-feedback name-helpmessage');
     });
   });
 });

--- a/packages/form/tests/Form.test.js
+++ b/packages/form/tests/Form.test.js
@@ -8,9 +8,7 @@ afterEach(cleanup);
 
 describe('Form', () => {
   test('renders', () => {
-    const { getByTestId } = render(
-      <Form initialValues={{}} onSubmit={() => {}} />
-    );
+    const { getByTestId } = render(<Form initialValues={{}} onSubmit={() => {}} />);
 
     const el = getByTestId('form-container');
     expect(el).toBeDefined();
@@ -38,7 +36,7 @@ describe('Form', () => {
 
     getByTestId('form-container');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(

--- a/packages/form/tests/FormGroup.test.js
+++ b/packages/form/tests/FormGroup.test.js
@@ -25,7 +25,7 @@ describe('FormGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const formGroup = getByTestId('hello-group');

--- a/packages/form/tests/Input.test.js
+++ b/packages/form/tests/Input.test.js
@@ -40,7 +40,7 @@ describe('Input', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const input = getByTestId('hello-input');
@@ -65,9 +65,9 @@ describe('Input', () => {
       </Form>
     );
 
-    await fireEvent.focus(getByTestId('hello-input'));
+    fireEvent.focus(getByTestId('hello-input'));
 
-    await fireEvent.blur(getByTestId('hello-input'));
+    fireEvent.blur(getByTestId('hello-input'));
 
     await waitFor(() => {
       const input = getByTestId('hello-input');
@@ -92,9 +92,9 @@ describe('Input', () => {
       </Form>
     );
 
-    await fireEvent.focus(getByTestId('hello-input'));
+    fireEvent.focus(getByTestId('hello-input'));
 
-    await fireEvent.blur(getByTestId('hello-input'));
+    fireEvent.blur(getByTestId('hello-input'));
 
     await waitFor(() => {
       const input = getByTestId('hello-input');
@@ -145,7 +145,7 @@ describe('Input', () => {
     expect(input).toHaveAttribute('aria-invalid', 'false');
     expect(input).toHaveAttribute('aria-describedby', '');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(input).toHaveAttribute('aria-invalid', 'true');

--- a/packages/form/tests/Radio.test.js
+++ b/packages/form/tests/Radio.test.js
@@ -22,11 +22,7 @@ describe('Radio', () => {
       >
         <RadioGroup name="greeting" label="Radio Group">
           <Radio label="Hello" value="hello" data-testid="greeting-radio-1" />
-          <Radio
-            label="Goodbye"
-            value="goodbye"
-            data-testid="greeting-radio-2"
-          />
+          <Radio label="Goodbye" value="goodbye" data-testid="greeting-radio-2" />
         </RadioGroup>
         <Button type="submit">Submit</Button>
       </Form>
@@ -61,11 +57,7 @@ describe('Radio', () => {
       >
         <RadioGroup name="greeting" label="Radio Group">
           <Radio label="Hello" value="hello" data-testid="greeting-radio-1" />
-          <Radio
-            label="Goodbye"
-            value="goodbye"
-            data-testid="greeting-radio-2"
-          />
+          <Radio label="Goodbye" value="goodbye" data-testid="greeting-radio-2" />
         </RadioGroup>
         <Button type="submit">Submit</Button>
       </Form>
@@ -106,7 +98,7 @@ describe('Radio', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const radio = getByTestId('hello-radio');
@@ -143,12 +135,7 @@ describe('Radio', () => {
         onSubmit={() => {}}
       >
         <RadioGroup name="hello" label="Radio Group">
-          <Radio
-            name="hello"
-            label="Radio One"
-            value="uno"
-            helpId="radioOneHelpTopic"
-          />
+          <Radio name="hello" label="Radio One" value="uno" helpId="radioOneHelpTopic" />
         </RadioGroup>
       </Form>
     );
@@ -192,12 +179,7 @@ describe('Radio', () => {
         onSubmit={() => {}}
       >
         <RadioGroup name="hello" label="Radio Group">
-          <Radio
-            name="hello"
-            label="Radio One"
-            value="uno"
-            data-testid="hello-radio"
-          />
+          <Radio name="hello" label="Radio One" value="uno" data-testid="hello-radio" />
         </RadioGroup>
         <Button type="submit">Submit</Button>
       </Form>
@@ -207,15 +189,12 @@ describe('Radio', () => {
     expect(radio).toHaveAttribute('aria-invalid', 'false');
     expect(radio).toHaveAttribute('aria-describedby', '');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(radio).toHaveAttribute('aria-invalid', 'true');
       expect(radio).toHaveAttribute('aria-describedby', 'hello-feedback');
-      expect(getByText('This field is required')).toHaveAttribute(
-        'id',
-        'hello-feedback'
-      );
+      expect(getByText('This field is required')).toHaveAttribute('id', 'hello-feedback');
     });
   });
 });

--- a/packages/form/tests/RadioGroup.test.js
+++ b/packages/form/tests/RadioGroup.test.js
@@ -18,11 +18,7 @@ describe('RadioGroup', () => {
           hello: yup.string().required('This field is required'),
         })}
       >
-        <RadioGroup
-          name="hello"
-          label="Radio Group"
-          groupClassName="some-group"
-        >
+        <RadioGroup name="hello" label="Radio Group" groupClassName="some-group">
           <Radio label="Radio One" value="uno" />
         </RadioGroup>
         <Button type="submit">Submit</Button>
@@ -53,7 +49,7 @@ describe('RadioGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const radioGroup = getByTestId('radio-items-hello');
@@ -85,9 +81,9 @@ describe('RadioGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Radio One'));
+    fireEvent.click(getByText('Radio One'));
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -120,7 +116,7 @@ describe('RadioGroup', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Radio One'));
+    fireEvent.click(getByText('Radio One'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith('uno');

--- a/packages/form/types/FormGroup.d.ts
+++ b/packages/form/types/FormGroup.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 
 export interface FormGroupProps extends React.HTMLAttributes<HTMLFormElement> {


### PR DESCRIPTION
BREAKING CHANGE: promote to v1

These changes are for promoting `@availty/form` to v1. I ran the formatter on each file, alphabetized the `prop-types` with an extension, and removed an `await` that was not needed in tests.

There should be no breaking changes. The commit message is for updating the version
