### PR TITLE
chore: bump dependency version of @availity/form

### DIFF
--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -30,7 +30,7 @@
     "react-dates": "^21.8.0"
   },
   "devDependencies": {
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "@availity/yup": "^3.0.11",
     "formik": "^2.2.8",
     "react": "^17.0.2",
@@ -39,7 +39,7 @@
     "yup": "^0.30.0"
   },
   "peerDependencies": {
-    "@availity/form": "^0.1.0 || ^0.2.0 || ^0.3.0 || ^0.4.0  || ^0.5.0 || ^0.6.0 || ^0.7.0",
+    "@availity/form": "^1.0.1",
     "@availity/yup": "^3.0.2",
     "formik": "^2.0.1",
     "react": ">=16.3.0",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "@availity/hooks": "^3.0.4",
     "@availity/icon": "^0.9.0",
     "@availity/native-form": "^3.0.0",

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@availity/api-axios": "^6.0.0",
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "@availity/upload-core": "^4.1.1",
     "formik": "^2.2.8",
     "nock": "^13.0.4",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@availity/api-axios": "^6.0.0",
-    "@availity/form": "^0.4.9 || ^0.5.0",
+    "@availity/form": "^1.0.1",
     "@availity/upload-core": "^4.1.1",
     "formik": "^2.0.1",
     "react": ">=16.8.0",

--- a/packages/phone/package.json
+++ b/packages/phone/package.json
@@ -15,7 +15,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "formik": "^2.2.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -23,7 +23,7 @@
     "yup": "^0.30.0"
   },
   "peerDependencies": {
-    "@availity/form": "^0.7.0",
+    "@availity/form": "^1.0.1",
     "formik": "^2.0.1",
     "react": ">=16.8.3",
     "reactstrap": "^8.4.1",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@availity/api-axios": "^6.0.0",
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "axios": "^0.21.1",
     "formik": "^2.2.8",
     "react": "^17.0.2",
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@availity/api-axios": "^6.0.0",
-    "@availity/form": "^0.2.0 || ^0.3.0 || ^0.4.0  || ^0.5.0 || ^0.6.0 || ^0.7.0",
+    "@availity/form": "^1.0.1",
     "axios": "^0.21.1",
     "formik": "^2.0.1",
     "react": ">=16.8.3",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -37,7 +37,7 @@
     "@availity/favorites": "^2.2.2",
     "@availity/feature": "^1.2.26",
     "@availity/feedback": "^6.0.15",
-    "@availity/form": "^0.9.0",
+    "@availity/form": "^1.0.1",
     "@availity/help": "^1.4.5",
     "@availity/hooks": "^3.0.4",
     "@availity/icon": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,16 +153,6 @@
   dependencies:
     core-js "^3.12.1"
 
-"@availity/form@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@availity/form/-/form-0.9.0.tgz#d664ba315b666fa3822b0cbf5a3cd9cc4088cf25"
-  integrity sha512-GUKFO1rG/86kE1/+/LpOeJ+aKtZfhKphcJNsk+9RtGPet2Wp4/5HcChueXjHhalyZnphD4VU/g+9jpkFEL/lTQ==
-  dependencies:
-    "@availity/help" "^1.4.5"
-    classnames "^2.3.1"
-    prop-types "^15.7.2"
-    uuid "^8.3.2"
-
 "@availity/icon@^0.8.0":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@availity/icon/-/icon-0.8.2.tgz#757f6f9ad6eeee11c4801f56072d3d0f1321dc26"


### PR DESCRIPTION
This PR brings in the major version bump for `@availity/form`
