### PR TITLE
Fix/select refs

### DIFF
--- a/packages/reactstrap-validation-select/src/AvResourceSelect.js
+++ b/packages/reactstrap-validation-select/src/AvResourceSelect.js
@@ -199,7 +199,7 @@ class AvResourceSelect extends Component {
         customerId: this.props.customerId,
         ...this.props.parameters,
       };
-      _cacheUniq = watchParams.map((watchParam) => params[watchParam]).join(',');
+      _cacheUniq = watchParams.map((watchParam) => params[watchParam]);
     }
 
     return (

--- a/packages/reactstrap-validation-select/src/AvSelect.js
+++ b/packages/reactstrap-validation-select/src/AvSelect.js
@@ -253,7 +253,8 @@ class AvSelect extends AvBaseInput {
 
     return (
       <Tag
-        ref={selectRef}
+        ref={attributes.loadOptions ? undefined : selectRef}
+        selectRef={attributes.loadOptions ? selectRef : undefined}
         classNamePrefix="av"
         role="listbox"
         className={classes}

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -249,7 +249,8 @@ const Select = ({
     <Tag
       {...field}
       onChange={onChangeHandler}
-      ref={selectRef}
+      ref={attributes.loadOptions ? undefined : selectRef}
+      selectRef={attributes.loadOptions ? selectRef : undefined}
       name={name}
       classNamePrefix="av"
       role="listbox"

--- a/storybook/stories/components/phone.stories.tsx
+++ b/storybook/stories/components/phone.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { Button } from 'reactstrap';

--- a/storybook/stories/form-components/date.stories.tsx
+++ b/storybook/stories/form-components/date.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Button } from 'reactstrap';

--- a/storybook/stories/form-components/form.stories.tsx
+++ b/storybook/stories/form-components/form.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Button } from 'reactstrap';

--- a/storybook/stories/form-components/select.stories.tsx
+++ b/storybook/stories/form-components/select.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Label, Button } from 'reactstrap';

--- a/storybook/stories/form-components/selectResources.stories.tsx
+++ b/storybook/stories/form-components/selectResources.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Button } from 'reactstrap';


### PR DESCRIPTION
This PR resolves errors/warnings that were output by the `react-select` and `react-select-async-paginate` components. 

The first issue was `AsyncPaginate` expected the `ref` to be passed as `selectRef`, but `react-select` uses ref forwarding. I added a check for when to send the ref as `ref` vs `selectRef`.

The other error was coming from when `cacheUniq` would be passed as a string, but an array was expected. I removed the `join` method which was converting the array to a string
