### PR TITLE
fix(select): set new colors due to accessibility issue when error cha…

### DIFF
--- a/packages/reactstrap-validation-select/src/AvSelect.js
+++ b/packages/reactstrap-validation-select/src/AvSelect.js
@@ -339,8 +339,8 @@ class AvSelect extends AvBaseInput {
           boxShadow: 0,
           colors: {
             ...theme.colors,
-            primary25: '#85a8dc',
-            primary: 'rgb(50 98 175)',
+            primary25: '#b8d4fb',
+            primary: '#85a8fc',
           },
         })}
         options={!attributes.loadOptions ? [...options, ...newOptions] : undefined}

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -352,8 +352,8 @@ const Select = ({
         boxShadow: 0,
         colors: {
           ...theme.colors,
-          primary25: '#85a8dc',
-          primary: 'rgb(50 98 175)',
+          primary25: '#b8d4fb',
+          primary: '#85a8fc',
         },
       })}
       {...attributes}


### PR DESCRIPTION
We discovered that the contrast ratio for selects with errors in the dropdown does not pass on hover.

We need to update the blues to the following colors:

Hover: #B8D4FB
Focus: #85a8fc

for more info check out SHI-1550