### PR TITLE
feat(form-upload): add totalMaxSize prop

### DIFF
--- a/docusaurus/docs/form/upload/upload.md
+++ b/docusaurus/docs/form/upload/upload.md
@@ -13,15 +13,7 @@ import Upload from '@availity/form-upload';
 
 const Example = () => (
   <Form initialValues={{ myFile: undefined }}>
-    <Upload
-      name="myFile"
-      btnText="Upload a claim"
-      clientId="a"
-      bucketId="b"
-      customerId="c"
-      multiple={false}
-      max={1}
-    />
+    <Upload name="myFile" btnText="Upload a claim" clientId="a" bucketId="b" customerId="c" multiple={false} max={1} />
   </Form>
 );
 ```
@@ -185,6 +177,10 @@ Use this prop together with `fileDeliveryMetadata` and `deliveryChannel` to defi
 #### `maxSize?: number`
 
 The maximum file size (in bytes) for a file to be uploaded.
+
+#### `totalMaxSize?: number`
+
+The total maximum combined file size (in bytes) for all the files to be uploaded.
 
 #### `max?: number`
 

--- a/packages/form-upload/src/Upload.js
+++ b/packages/form-upload/src/Upload.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useCallback, useMemo } from 'react';
+import React, { Suspense, useEffect, useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import UploadCore from '@availity/upload-core';
 import { avFilesDeliveryApi } from '@availity/api-axios';
@@ -36,6 +36,7 @@ const Upload = ({
   getDropRejectionMessage,
   max,
   maxSize,
+  totalMaxSize,
   multiple = true,
   name,
   onFileRemove,
@@ -51,6 +52,7 @@ const Upload = ({
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.touched && metadata.error && 'is-invalid'
   );
+  const [totalSize, setTotalSize] = useState(0);
 
   const fieldValue = useMemo(() => (Array.isArray(field.value) ? field.value : []), [field]);
 
@@ -135,6 +137,8 @@ const Upload = ({
     const newFiles = fieldValue.filter((file) => file.id !== fileId);
     if (newFiles.length !== fieldValue.length) {
       setFieldValue(name, newFiles, true);
+      const removedFile = fieldValue.find((file) => file.id === fileId);
+      if (!removedFile.error && !removedFile.errorMessage) setTotalSize(totalSize - removedFile.file.size);
       if (onFileRemove) onFileRemove(newFiles, fileId);
     }
   };
@@ -150,8 +154,10 @@ const Upload = ({
     }
 
     // eslint-disable-next-line unicorn/prefer-spread
-    const newFiles = fieldValue.concat(
-      selectedFiles.map((file) => {
+    let newFilesTotalSize = 0;
+    const newFiles = [
+      ...fieldValue,
+      ...selectedFiles.map((file) => {
         const upload = new UploadCore(file, {
           bucketId,
           customerId,
@@ -164,8 +170,11 @@ const Upload = ({
         upload.id = `${upload.id}-${uuid()}`;
         if (file.dropRejectionMessage) {
           upload.errorMessage = file.dropRejectionMessage;
+        } else if (totalMaxSize && totalSize + newFilesTotalSize + upload.file.size > totalMaxSize) {
+          upload.errorMessage = 'Total documents size is too large';
         } else {
           upload.start();
+          newFilesTotalSize += upload.file.size;
         }
         if (onFileUpload) {
           onFileUpload(upload);
@@ -183,9 +192,10 @@ const Upload = ({
         }
 
         return upload;
-      })
-    );
+      }),
+    ];
 
+    setTotalSize(totalSize + newFilesTotalSize);
     setFieldValue(name, newFiles, true);
   };
 
@@ -258,7 +268,7 @@ const Upload = ({
 
   return (
     <>
-      <FileList files={fieldValue} onRemoveFile={removeFile}>
+      <FileList files={fieldValue} onRemoveFile={removeFile} data-testid="file-list">
         {children}
       </FileList>
       {fileAddArea}
@@ -285,6 +295,7 @@ Upload.propTypes = {
   getDropRejectionMessage: PropTypes.func,
   max: PropTypes.number,
   maxSize: PropTypes.number,
+  totalMaxSize: PropTypes.number,
   multiple: PropTypes.bool,
   onDeliveryError: PropTypes.func,
   onDeliverySuccess: PropTypes.func,

--- a/packages/form-upload/tests/Upload.test.js
+++ b/packages/form-upload/tests/Upload.test.js
@@ -50,6 +50,54 @@ describe('Upload', () => {
     expect(inputNode.files.length).toBe(1);
   });
 
+  test('adding a file over maxSize', () => {
+    const { getByTestId, getByText } = renderUpload(
+      { initialValues: { upload: null } },
+      {
+        name: 'upload',
+        clientId: 'a',
+        bucketId: 'b',
+        customerId: 'c',
+        maxSize: 100,
+      }
+    );
+
+    const file = new Buffer.from('hello world'.split(''));
+    file.name = 'fileName.png';
+    file.size = 10000;
+    const fileEvent = { target: { files: [file] } };
+
+    const inputNode = getByTestId('file-picker');
+    fireEvent.change(inputNode, fileEvent);
+
+    expect(getByText('Document is too large')).toBeDefined();
+  });
+
+  test('adding a file over totalMaxSize', () => {
+    const { getByTestId, getByText } = renderUpload(
+      { initialValues: { upload: null } },
+      {
+        name: 'upload',
+        clientId: 'a',
+        bucketId: 'b',
+        customerId: 'c',
+        maxSize: 700,
+        totalMaxSize: 1000,
+      }
+    );
+
+    const file = new Buffer.from('hello world'.split(''));
+    file.name = 'fileName.png';
+    file.size = 600;
+    const fileEvent = { target: { files: [file] } };
+
+    const inputNode = getByTestId('file-picker');
+    fireEvent.change(inputNode, fileEvent);
+    fireEvent.change(inputNode, fileEvent);
+
+    expect(getByText('Total documents size is too large')).toBeDefined();
+  });
+
   test('removing a file', () => {
     const { getByTestId, queryByTestId } = renderUpload(
       { initialValues: { upload: null } },

--- a/packages/form-upload/types/Upload.d.ts
+++ b/packages/form-upload/types/Upload.d.ts
@@ -16,6 +16,7 @@ export interface UploadProps {
   onDeliveryError?: Function;
   fileDeliveryMetadata?: object | Function;
   maxSize?: number;
+  totalMaxSize?: number;
   max?: number;
   multiple?: boolean;
   children?: Function;


### PR DESCRIPTION
`totalMaxSize` is similar to `maxSize` prop, but stops additional files from being uploaded once the combined file size is over the `totalMaxSize`