### PR TITLE
fix(select,reactstrap-validation-select): fixed select color to fix c…

### DIFF
--- a/packages/reactstrap-validation-select/src/AvSelect.js
+++ b/packages/reactstrap-validation-select/src/AvSelect.js
@@ -340,7 +340,7 @@ class AvSelect extends AvBaseInput {
           colors: {
             ...theme.colors,
             primary25: '#b8d4fb',
-            primary: '#85a8fc',
+            primary: '#3262af',
           },
         })}
         options={!attributes.loadOptions ? [...options, ...newOptions] : undefined}

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -353,7 +353,7 @@ const Select = ({
         colors: {
           ...theme.colors,
           primary25: '#b8d4fb',
-          primary: '#85a8fc',
+          primary: '#3262af',
         },
       })}
       {...attributes}


### PR DESCRIPTION
After making the previous color change, I noticed when you select an option, the color of the text is white (which is the default for the select component) but the new background color used (#85a8fc) against the white font only has a contrast ratio of 2.3. Spoke w/ Teresa and verified I can revert to the old darker bg color just for select (converted it from RGB to hex for consistency of colors) #3262AF.
![image](https://user-images.githubusercontent.com/38148103/141816237-7fe190e3-658d-4be0-9563-67ee19d25f2d.png)
