### PR TITLE
feat(select): associate help and error messages to input

### DIFF
--- a/docusaurus/docs/form/select/components/select-field.md
+++ b/docusaurus/docs/form/select/components/select-field.md
@@ -67,6 +67,10 @@ Class names to pass to the `Label`.
 
 Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility).
 
+#### `helpMessage?: string`
+
+Adds help message below input.
+
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.

--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -83,6 +83,14 @@ The key of the value to return when selected. **Default:** `"value"`
 
 The key of the label to render in the dropdown for the user to see. **Default:** `"label"`
 
+#### `helpMessage?: string`
+
+Adds hidden help message to placeholder so it is read with `aria-describedby` (should match visible help message).
+
+#### `feedback?: boolean`
+
+Will add default `<Feedback />` id to `aria-errormessage`.
+
 #### `maxLength?: number`
 
 The maximum number of options that can be selected ( when `isMulti` is `true`)

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -79,7 +79,7 @@ const Select = ({
   placeholder,
   ...attributes
 }) => {
-  const [{ onChange, value: fieldValue, ...field }, { touched, error }] = useField({
+  const [{ onChange, value: fieldValue, ...field }, { touched, error: fieldError }] = useField({
     name,
     validate,
   });
@@ -97,7 +97,7 @@ const Select = ({
     <>
       {placeholder || 'Select...'}
       <span className="sr-only">
-        {(touched && error) || null} {helpMessage || null}
+        {(touched && fieldError) || null} {helpMessage || null}
       </span>
     </>
   );
@@ -273,14 +273,14 @@ const Select = ({
         className,
         'av-select',
         touched ? 'is-touched' : 'is-untouched',
-        error ? 'av-invalid' : 'av-valid',
-        touched && error && 'is-invalid'
+        fieldError ? 'av-invalid' : 'av-valid',
+        touched && fieldError && 'is-invalid'
       )}
       getOptionLabel={getOptionLabel}
       getOptionValue={getOptionValue}
       closeMenuOnSelect={!attributes.isMulti}
-      aria-invalid={error && touched}
-      aria-errormessage={feedback && fieldValue && error && touched ? `${name}-feedback`.toLowerCase() : ''}
+      aria-invalid={fieldError && touched}
+      aria-errormessage={feedback && fieldValue && fieldError && touched ? `${name}-feedback`.toLowerCase() : ''}
       placeholder={placeholder}
       components={components}
       options={selectOptions}
@@ -295,7 +295,7 @@ const Select = ({
               borderColor: '#ced4da',
             };
           }
-          const showError = touched && error && !state.focused;
+          const showError = touched && fieldError && !state.focused;
 
           return {
             ...provided,
@@ -320,7 +320,7 @@ const Select = ({
               backgroundColor: '#e9ecef',
             };
           }
-          const showError = touched && error;
+          const showError = touched && fieldError;
 
           return {
             ...provided,
@@ -350,7 +350,7 @@ const Select = ({
           if (state.isDisabled) {
             return provided;
           }
-          const showError = touched && error && !state.focused;
+          const showError = touched && fieldError && !state.focused;
 
           return {
             ...provided,

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -79,7 +79,7 @@ const Select = ({
   placeholder,
   ...attributes
 }) => {
-  const [{ onChange, value: fieldValue, ...field }, { touched, error: hasError }] = useField({
+  const [{ onChange, value: fieldValue, ...field }, { touched, error }] = useField({
     name,
     validate,
   });
@@ -97,7 +97,7 @@ const Select = ({
     <>
       {placeholder || 'Select...'}
       <span className="sr-only">
-        {(touched && hasError) || null} {helpMessage || null}
+        {(touched && error) || null} {helpMessage || null}
       </span>
     </>
   );
@@ -273,14 +273,14 @@ const Select = ({
         className,
         'av-select',
         touched ? 'is-touched' : 'is-untouched',
-        hasError ? 'av-invalid' : 'av-valid',
-        touched && hasError && 'is-invalid'
+        error ? 'av-invalid' : 'av-valid',
+        touched && error && 'is-invalid'
       )}
       getOptionLabel={getOptionLabel}
       getOptionValue={getOptionValue}
       closeMenuOnSelect={!attributes.isMulti}
-      aria-invalid={hasError && touched}
-      aria-errormessage={feedback && fieldValue && hasError && touched ? `${name}-feedback`.toLowerCase() : ''}
+      aria-invalid={error && touched}
+      aria-errormessage={feedback && fieldValue && error && touched ? `${name}-feedback`.toLowerCase() : ''}
       placeholder={placeholder}
       components={components}
       options={selectOptions}
@@ -295,7 +295,7 @@ const Select = ({
               borderColor: '#ced4da',
             };
           }
-          const showError = touched && hasError && !state.focused;
+          const showError = touched && error && !state.focused;
 
           return {
             ...provided,
@@ -320,7 +320,7 @@ const Select = ({
               backgroundColor: '#e9ecef',
             };
           }
-          const showError = touched && hasError;
+          const showError = touched && error;
 
           return {
             ...provided,
@@ -350,7 +350,7 @@ const Select = ({
           if (state.isDisabled) {
             return provided;
           }
-          const showError = touched && hasError && !state.focused;
+          const showError = touched && error && !state.focused;
 
           return {
             ...provided,

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -76,6 +76,7 @@ const Select = ({
   waitUntilFocused,
   helpMessage,
   feedback,
+  placeholder,
   ...attributes
 }) => {
   const [{ onChange, value: fieldValue, ...field }, { touched, error: hasError }] = useField({
@@ -92,9 +93,9 @@ const Select = ({
     _cacheUniq = [_cacheUniq];
   }
 
-  attributes.placeholder = (
+  placeholder = (
     <>
-      {attributes.placeholder || 'Select...'}
+      {placeholder || 'Select...'}
       <span className="sr-only">
         {(touched && hasError) || null} {helpMessage || null}
       </span>
@@ -280,6 +281,7 @@ const Select = ({
       closeMenuOnSelect={!attributes.isMulti}
       aria-invalid={hasError && touched}
       aria-errormessage={feedback && fieldValue && hasError && touched ? `${name}-feedback`.toLowerCase() : ''}
+      placeholder={placeholder}
       components={components}
       options={selectOptions}
       defaultOptions={waitUntilFocused ? [] : true}
@@ -397,6 +399,7 @@ Select.propTypes = {
   waitUntilFocused: PropTypes.bool,
   helpMessage: PropTypes.string,
   feedback: PropTypes.bool,
+  placeholder: PropTypes.string,
 };
 
 components.Option.propTypes = {

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -74,6 +74,8 @@ const Select = ({
   creatable,
   allowSelectAll,
   waitUntilFocused,
+  helpMessage,
+  feedback,
   ...attributes
 }) => {
   const [{ onChange, value: fieldValue, ...field }, { touched, error: hasError }] = useField({
@@ -89,6 +91,15 @@ const Select = ({
   if (!Array.isArray(_cacheUniq)) {
     _cacheUniq = [_cacheUniq];
   }
+
+  attributes.placeholder = (
+    <>
+      {attributes.placeholder || 'Select...'}
+      <span className="sr-only">
+        {(touched && hasError) || null} {helpMessage || null}
+      </span>
+    </>
+  );
 
   const getOptionLabel = (option) => {
     if (option.__isNew__) {
@@ -267,6 +278,8 @@ const Select = ({
       getOptionLabel={getOptionLabel}
       getOptionValue={getOptionValue}
       closeMenuOnSelect={!attributes.isMulti}
+      aria-invalid={hasError && touched}
+      aria-errormessage={feedback && fieldValue && hasError && touched ? `${name}-feedback`.toLowerCase() : ''}
       components={components}
       options={selectOptions}
       defaultOptions={waitUntilFocused ? [] : true}
@@ -382,6 +395,8 @@ Select.propTypes = {
   autofill: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   allowSelectAll: PropTypes.bool,
   waitUntilFocused: PropTypes.bool,
+  helpMessage: PropTypes.string,
+  feedback: PropTypes.bool,
 };
 
 components.Option.propTypes = {

--- a/packages/select/src/SelectField.js
+++ b/packages/select/src/SelectField.js
@@ -43,7 +43,7 @@ const SelectField = ({
   return (
     <FormGroup className={groupClass} for={name} disabled={attributes.disabled}>
       {thisLabel}
-      <Select name={name} feedback required={required} {...attributes} />
+      <Select name={name} feedback helpMessage={helpMessage} required={required} {...attributes} />
       <Feedback className={classNames('d-block', feedbackClass)} name={name} />
       {helpMessage ? <FormText id={`${name}-helpmessage`.toLowerCase()}>{helpMessage}</FormText> : null}
     </FormGroup>

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -748,7 +748,7 @@ describe('Select', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const hiddenPlaceholderMessage = container.querySelector('.av__placeholder .sr-only');
@@ -775,7 +775,7 @@ describe('Select', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const hiddenPlaceholderMessage = container.querySelector('.av__placeholder .sr-only');
@@ -806,7 +806,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 1');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(select).toHaveAttribute('aria-invalid', 'true');
@@ -815,7 +815,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 2');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(select).not.toHaveAttribute('aria-invalid');

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -734,4 +734,92 @@ describe('Select', () => {
       expect(optionOne).toHaveAttribute('name');
     });
   });
+  test('renders error message in placeholder with invalid', async () => {
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select name="singleSelect" options={options} data-testid="single-select" />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      const hiddenPlaceholderMessage = container.querySelector('.av__placeholder .sr-only');
+
+      expect(hiddenPlaceholderMessage.innerHTML).toContain('This field is required.');
+    });
+  });
+  test('renders help message in placeholder', async () => {
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          helpMessage="This is a help message."
+          data-testid="single-select"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      const hiddenPlaceholderMessage = container.querySelector('.av__placeholder .sr-only');
+
+      expect(hiddenPlaceholderMessage.innerHTML).toContain('This is a help message.');
+    });
+  });
+
+  test('renders aria attributes when invalid', async () => {
+    const onSubmit = jest.fn();
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          multiSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={multiValueSchema('multiSelect', true, 2, 3)}
+      >
+        <Select name="multiSelect" isMulti feedback options={options} data-testid="multi-select" />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const select = container.querySelector('.av__input');
+
+    expect(select).not.toHaveAttribute('aria-invalid');
+    expect(select).toHaveAttribute('aria-errormessage', '');
+
+    await selectItem(container, getByText, 'Option 1');
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(select).toHaveAttribute('aria-invalid', 'true');
+      expect(select).toHaveAttribute('aria-errormessage', 'multiselect-feedback');
+    });
+
+    await selectItem(container, getByText, 'Option 2');
+
+    await fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(select).not.toHaveAttribute('aria-invalid');
+      expect(select).toHaveAttribute('aria-errormessage', '');
+    });
+  });
 });

--- a/packages/select/types/Select.d.ts
+++ b/packages/select/types/Select.d.ts
@@ -22,6 +22,8 @@ export interface SelectProps<T> extends Props<{}> {
   validate?: FieldValidator;
   autofill?: boolean | object;
   creatable?: boolean;
+  helpMessage?: string;
+  feedback?: boolean;
 }
 
 declare class Select<T> extends React.Component<SelectProps<T>> {}


### PR DESCRIPTION
react-select sets the `aria-describedby` to be the placeholder element. added hidden screenreader element to placeholder to include feedback and help message in input description.
Once there is a selection the placeholder element and `aria-describedby` attribute are removed. feedback id is then added to the less supported `aria-errormessage` once the placeholder is gone.
