### PR TITLE
fix(reactstrap-validation-date,date): removed date icon to fix access…

### DIFF
--- a/docusaurus/docs/form/date/components/date-range.mdx
+++ b/docusaurus/docs/form/date/components/date-range.mdx
@@ -103,10 +103,6 @@ Function to be run when focus on the input changes. `focusedInput` contains the 
 - `endId` - the id of the end field. `"<name>-end"`
 - `undefined` - the date range was unfocused
 
-#### `calendarIcon?: ReactNode`
-
-Override the default icon that appears. Default: `<Icon name="calendar" />
-
 #### `format?: string`
 
 How to format date value in `onSubmit` callback. Must be a format recognized by [moment](https://momentjs.com/docs/#/displaying/format/). **Default: `MM/DD/YYYY`**

--- a/docusaurus/docs/form/date/components/date.md
+++ b/docusaurus/docs/form/date/components/date.md
@@ -78,10 +78,6 @@ Used in conjunction with `min` to derive `isOutsideRange` prop from `react-dates
 }
 ```
 
-#### `calendarIcon?: ReactNode`
-
-Override the default icon that appears. Default: `<Icon name="calendar" />
-
 #### `onPickerFocusChange?: ({ focused: boolean }) => void`
 
 Function to be run when focus on the input changes.

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/Availity/availity-react/tree/master/packages/date#readme",
   "dependencies": {
-    "@availity/icon": "^0.10.0",
     "@availity/react-dates": "^21.10.0",
     "@types/react-dates": "^21.8.2",
     "classnames": "^2.3.1",

--- a/packages/date/src/Date.d.ts
+++ b/packages/date/src/Date.d.ts
@@ -19,12 +19,10 @@ export type DateProps = {
   className?: string;
   min?: string | limitType | limitTypeAlt;
   max?: string | limitType | limitTypeAlt;
-  calendarIcon?: React.ReactNode;
   onChange?: (date: string) => void;
   onPickerFocusChange?: (arg: { focused: boolean }) => void;
   innerRef?: Function | string;
   format?: string;
-  datepicker?: boolean;
   datePickerProps?: SingleDatePickerShape;
   validate?: FieldValidator;
   openDirection?: 'down' | 'up';

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { useField, useFormikContext } from 'formik';
 import '@availity/react-dates/initialize';
 import { SingleDatePicker } from '@availity/react-dates';
-import Icon from '@availity/icon';
 import { InputGroup, Input, Row, Col } from 'reactstrap';
 import moment from 'moment';
 import '../polyfills';
@@ -21,13 +20,11 @@ const yearPickerStyles = {
 const AvDate = ({
   className,
   name,
-  calendarIcon,
   innerRef,
   onChange,
   onPickerFocusChange,
   min,
   max,
-  datepicker,
   format,
   validate,
   datePickerProps,
@@ -46,7 +43,6 @@ const AvDate = ({
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.touched && metadata.error && 'is-invalid',
     !field.value && 'current-day-highlight',
-    datepicker && 'av-calendar-show'
   );
 
   const pickerId = `${(attributes.id || name).replace(/[^\da-z]/gi, '')}-picker`;
@@ -195,22 +191,18 @@ AvDate.propTypes = {
   className: PropTypes.string,
   min: limitPropType,
   max: limitPropType,
-  calendarIcon: PropTypes.node,
   onChange: PropTypes.func,
   onPickerFocusChange: PropTypes.func,
   innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   format: PropTypes.string,
   'data-testid': PropTypes.string,
-  datepicker: PropTypes.bool,
   validate: PropTypes.func,
   datePickerProps: PropTypes.object,
   openDirection: PropTypes.string,
 };
 
 AvDate.defaultProps = {
-  calendarIcon: <Icon name="calendar" />,
   format: 'MM/DD/YYYY',
-  datepicker: true,
   openDirection: 'down',
 };
 

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -181,9 +181,6 @@ const AvDate = ({
           onFocusChange={onFocusChange}
           numberOfMonths={1}
           isOutsideRange={isOutsideRange(min, max)}
-          customInputIcon={datepicker ? calendarIcon : undefined}
-          showDefaultInputIcon={datepicker}
-          inputIconPosition="after"
           navPosition="navPositionBottom"
           openDirection={openDirection}
         />

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -313,20 +313,6 @@ const DateRange = ({
           renderCalendarInfo={renderDateRanges}
           customArrowIcon={customArrowIcon}
           isOutsideRange={isOutsideRange(min, max, format)}
-          customInputIcon={
-            datepicker
-              ? React.cloneElement(calendarIcon, {
-                  ref: calendarIconRef,
-                  onClick: () => {
-                    if (focusedInput) {
-                      setFocusedInput();
-                    }
-                  },
-                })
-              : undefined
-          }
-          showDefaultInputIcon={datepicker}
-          inputIconPosition="after"
           numberOfMonths={2}
           navPosition="navPositionBottom"
           openDirection={openDirection}

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import Icon from '@availity/icon';
 import { InputGroup, Input, Button, Row, Col } from 'reactstrap';
 import { DateRangePicker } from '@availity/react-dates';
 import classNames from 'classnames';
@@ -59,10 +58,8 @@ const DateRange = ({
   innerRef,
   className,
   format,
-  calendarIcon,
   datepickerProps,
   'data-testid': dataTestId,
-  datepicker,
   autoSync,
   ranges: propsRanges,
   customArrowIcon,
@@ -97,7 +94,6 @@ const DateRange = ({
     metadata.touched ? 'is-touched' : 'is-untouched',
     metadata.touched && metadata.error && 'is-invalid',
     !startValue && !endValue && 'current-day-highlight',
-    datepicker && 'av-calendar-show'
   );
 
   // Should only run validation once per real change to component, instead of each time setFieldValue/Touched is called.
@@ -332,10 +328,8 @@ DateRange.propTypes = {
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   onPickerFocusChange: PropTypes.func,
-  calendarIcon: PropTypes.node,
   innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   format: PropTypes.string,
-  datepicker: PropTypes.bool,
   datepickerProps: PropTypes.object,
   'data-testid': PropTypes.string,
   autoSync: PropTypes.bool,
@@ -345,9 +339,7 @@ DateRange.propTypes = {
 };
 
 DateRange.defaultProps = {
-  calendarIcon: <Icon name="calendar" data-testid="calendar-icon" />,
   format: isoDateFormat,
-  datepicker: true,
   openDirection: 'down',
 };
 

--- a/packages/date/styles.scss
+++ b/packages/date/styles.scss
@@ -91,12 +91,6 @@
   }
 }
 
-.av-calendar-show .SingleDatePicker input.DateInput_input {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: none;
-}
-
 .DateRangePickerInput .DateInput:nth-of-type(1) input.DateInput_input {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -108,16 +102,6 @@
   input.DateInput_input {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-}
-
-.av-calendar-show
-  .DateRangePickerInput
-  .DateRangePickerInput_arrow
-  ~ .DateInput
-  input.DateInput_input {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: none;
 }
 
 .CalendarDay__selected,

--- a/packages/date/tests/DateRange.test.js
+++ b/packages/date/tests/DateRange.test.js
@@ -345,7 +345,7 @@ describe('DateRange', () => {
       </Form>
     );
 
-    container.querySelector('.DateRangePickerInput_calendarIcon').click();
+    container.querySelector('.DateInput_input_1').focus();
 
     await waitFor(() => {
       expect(
@@ -354,7 +354,8 @@ describe('DateRange', () => {
     });
 
     // Simulate User hitting the 'Today' pre-set
-    container.querySelectorAll('.btn-default')[0].click();
+    container.querySelector('.CalendarDay__today').click();
+    container.querySelector('.CalendarDay__today').click();
 
     const today = moment().format('MM/DD/YYYY');
 

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -59,7 +59,6 @@ This is the underlying date without the `AvGroup`, `Label` or `AvFeedback`
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
 
 - **`datepicker`**: Boolean. Optional. Default: `true`. If `true`, the date picker button will be shown, clicking it activates the datepicker calendar. If `false`, only the date input field will be displayed (useful for date of birth fields).
-- **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 - **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 - **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
 
@@ -119,7 +118,6 @@ See availity-reactstrap-validation for additional props, such as `name`, `valida
 - **`start`**: Object. Required. and object which will be spread on the start date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 - **`end`**: Object. Required. and object which will be spread on the end date input. It must contain the `name` prop as required by availity-reactstrap-validation. It can contain additional validations as well.
 - **`distance`**: Object. Optional. Object containing the `min` and `max` distance the start and end dates are allowed to be apart from each other. See example below.
-- **`calendarIcon`**: Node. Optional. Default: `<Icon name="calendar" />`. You can optional change the icon the calendar renders in the case you don't use the `availity-uikit` icons.
 - **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 - **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
 - **`ranges`**: object, boolean, array. Optional. Renders list of ranges preset to the left of the calendar

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -58,7 +58,6 @@ This is the underlying date without the `AvGroup`, `Label` or `AvFeedback`
 
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
 
-- **`datepicker`**: Boolean. Optional. Default: `true`. If `true`, the date picker button will be shown, clicking it activates the datepicker calendar. If `false`, only the date input field will be displayed (useful for date of birth fields).
 - **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 - **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
 
@@ -88,8 +87,6 @@ Like `AvField`, but for dates with a date picker
 #### AvDateField Props
 
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
-
-- **`datepicker`**: Boolean. Optional. Default: `true`. If `true`, the date picker button will be shown, clicking it activates the datepicker calendar. If `false`, only the date input field will be displayed (useful for date of birth fields).
 - **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 - **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
 

--- a/packages/reactstrap-validation-date/package.json
+++ b/packages/reactstrap-validation-date/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/Availity/availity-react/tree/master/packages/reactstrap-validation-date#readme",
   "dependencies": {
-    "@availity/icon": "^0.10.0",
     "@availity/react-dates": "^21.10.0",
     "@types/react-dates": "^21.8.2",
     "classnames": "^2.3.1",

--- a/packages/reactstrap-validation-date/src/AvDate.js
+++ b/packages/reactstrap-validation-date/src/AvDate.js
@@ -9,7 +9,6 @@ import '@availity/react-dates/initialize';
 import '../polyfills';
 
 import { inputType, isoDateFormat } from 'availity-reactstrap-validation/lib/AvValidator/utils';
-import Icon from '@availity/icon';
 import { AvInput } from 'availity-reactstrap-validation';
 
 import { isOutsideRange, limitPropType } from './utils';
@@ -122,9 +121,7 @@ class AvDate extends Component {
 
   render() {
     const {
-      calendarIcon,
       className,
-      datepicker,
       datePickerProps,
       hideIcon,
       max,
@@ -153,7 +150,6 @@ class AvDate extends Component {
       hasError ? 'av-invalid' : 'av-valid',
       touched && hasError && 'is-invalid',
       !value && 'current-day-highlight',
-      datepicker && 'av-calendar-show'
     );
 
     const input = (
@@ -192,9 +188,6 @@ class AvDate extends Component {
             onFocusChange={this.onFocusChange}
             numberOfMonths={1}
             isOutsideRange={isOutsideRange(minDate, maxDate, format)}
-            customInputIcon={datepicker ? calendarIcon : undefined}
-            showDefaultInputIcon={datepicker}
-            inputIconPosition="after"
             onClose={this.onClose}
           />
         </InputGroup>
@@ -218,9 +211,7 @@ AvDate.contextTypes = {
 
 AvDate.defaultProps = {
   type: 'text',
-  datepicker: true,
   datePickerProps: {},
-  calendarIcon: <Icon name="calendar" />,
 };
 
 export default AvDate;

--- a/packages/reactstrap-validation-date/src/AvDate.js
+++ b/packages/reactstrap-validation-date/src/AvDate.js
@@ -198,7 +198,6 @@ class AvDate extends Component {
 
 AvDate.propTypes = {
   ...AvInput.propTypes,
-  calendarIcon: PropTypes.node,
   min: limitPropType,
   max: limitPropType,
   onPickerFocusChange: PropTypes.func,

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -424,7 +424,7 @@ class AvDateRange extends Component {
   };
 
   render() {
-    const { name, className, id, min, max, calendarIcon, validate, distance, ...attributes } = this.props;
+    const { name, className, id, min, max, validate, distance, ...attributes } = this.props;
     const { startValue, endValue, focusedInput, format } = this.state;
     const endValidate = {
       afterStart: this.afterStartValidate,

--- a/packages/reactstrap-validation-date/src/AvDateRange.js
+++ b/packages/reactstrap-validation-date/src/AvDateRange.js
@@ -8,7 +8,6 @@ import { AvInput } from 'availity-reactstrap-validation';
 import { DateRangePicker } from '@availity/react-dates';
 import '@availity/react-dates/initialize';
 import classNames from 'classnames';
-import Icon from '@availity/icon';
 
 import { isOutsideRange, limitPropType, isSameDay } from './utils';
 import '../polyfills';
@@ -425,7 +424,7 @@ class AvDateRange extends Component {
   };
 
   render() {
-    const { name, className, id, min, max, calendarIcon, datepicker, validate, distance, ...attributes } = this.props;
+    const { name, className, id, min, max, calendarIcon, validate, distance, ...attributes } = this.props;
     const { startValue, endValue, focusedInput, format } = this.state;
     const endValidate = {
       afterStart: this.afterStartValidate,
@@ -469,7 +468,6 @@ class AvDateRange extends Component {
       hasError ? 'av-invalid' : 'av-valid',
       validation.error && 'is-invalid',
       !startValue && !endValue && 'current-day-highlight',
-      datepicker && 'av-calendar-show'
     );
 
     return (
@@ -527,22 +525,7 @@ class AvDateRange extends Component {
             focusedInput={focusedInput}
             onFocusChange={this.onFocusChange}
             isOutsideRange={isOutsideRange(minDate, maxDate, format)}
-            customInputIcon={
-              datepicker
-                ? React.cloneElement(calendarIcon, {
-                    ref: this.calendarIconRef,
-                    onClick: () => {
-                      const { focusedInput } = this.state;
-                      if (focusedInput) {
-                        this.setState({ focusedInput: undefined });
-                      }
-                    },
-                  })
-                : undefined
-            }
-            inputIconPosition="after"
             customArrowIcon="-"
-            showDefaultInputIcon={datepicker}
             onClose={this.onClose}
             numberOfMonths={2}
             minimumNights={0}
@@ -568,8 +551,6 @@ AvDateRange.propTypes = {
   ranges: PropTypes.oneOfType([PropTypes.bool, PropTypes.array, PropTypes.object]),
   onPickerFocusChange: PropTypes.func,
   defaultValues: PropTypes.object,
-  calendarIcon: PropTypes.node,
-  datepicker: PropTypes.bool,
   autoSync: PropTypes.bool,
 };
 
@@ -577,8 +558,6 @@ AvDateRange.contextTypes = { FormCtrl: PropTypes.object.isRequired };
 
 AvDateRange.defaultProps = {
   type: 'text',
-  calendarIcon: <Icon name="calendar" />,
-  datepicker: true,
 };
 
 export default AvDateRange;

--- a/packages/reactstrap-validation-date/styles.scss
+++ b/packages/reactstrap-validation-date/styles.scss
@@ -91,35 +91,12 @@
   }
 }
 
-
-
-.av-calendar-show .SingleDatePicker input.DateInput_input {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: none;
-}
-
-.DateRangePickerInput .DateInput:nth-of-type(1) input.DateInput_input {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
 .DateRangePickerInput
   .DateRangePickerInput_arrow
   ~ .DateInput
   input.DateInput_input {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-}
-
-.av-calendar-show
-  .DateRangePickerInput
-  .DateRangePickerInput_arrow
-  ~ .DateInput
-  input.DateInput_input {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right: none;
 }
 
 .CalendarDay__selected,

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,8 +171,8 @@
 
 "@availity/react-dates@^21.10.0":
   version "21.10.0"
-  resolved "https://registry.yarnpkg.com/@availity/react-dates/-/react-dates-21.10.0.tgz#c0837875b7db7dfb7de353d1b26dae6e56bb6c06"
-  integrity sha512-mmd+mbW4Egq0z/f/8sUBd0cdwT4PrjXGJs8s8A8Oa1lpve+n4uRbS3xSGYnpPYL4BNvZlpm6Lklx7BDUu3vcHg==
+  resolved "https://packages.availity.com:443/artifactory/api/npm/availity-npm-all/@availity/react-dates/-/react-dates-21.10.0.tgz#c0837875b7db7dfb7de353d1b26dae6e56bb6c06"
+  integrity sha1-wIN4dbfbfft941PRsm2ubla7bAY=
   dependencies:
     airbnb-prop-types "^2.16.0"
     color2k "^1.1.1"
@@ -209,7 +209,7 @@
     core-js "^3.12.1"
     tus-js-client "1.7.1"
 
-"@availity/yup@3.2.0", "@availity/yup@^3.2.0":
+"@availity/yup@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@availity/yup/-/yup-3.2.0.tgz#b3bfa3fce6ccd51921e9bc90be90d3a178c30ff2"
   integrity sha512-iNVydznH51Sqdf0Q3RIbqQHAg9pulfW3b/XCKbZlDpKlzbkwLk7lv402+mVJ+YA7DST+2jGcUi2ORcjq/LP7DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,7 +209,7 @@
     core-js "^3.12.1"
     tus-js-client "1.7.1"
 
-"@availity/yup@^3.2.0":
+"@availity/yup@3.2.0", "@availity/yup@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@availity/yup/-/yup-3.2.0.tgz#b3bfa3fce6ccd51921e9bc90be90d3a178c30ff2"
   integrity sha512-iNVydznH51Sqdf0Q3RIbqQHAg9pulfW3b/XCKbZlDpKlzbkwLk7lv402+mVJ+YA7DST+2jGcUi2ORcjq/LP7DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,8 +171,8 @@
 
 "@availity/react-dates@^21.10.0":
   version "21.10.0"
-  resolved "https://packages.availity.com:443/artifactory/api/npm/availity-npm-all/@availity/react-dates/-/react-dates-21.10.0.tgz#c0837875b7db7dfb7de353d1b26dae6e56bb6c06"
-  integrity sha1-wIN4dbfbfft941PRsm2ubla7bAY=
+  resolved "https://registry.yarnpkg.com/@availity/react-dates/-/react-dates-21.10.0.tgz#c0837875b7db7dfb7de353d1b26dae6e56bb6c06"
+  integrity sha512-mmd+mbW4Egq0z/f/8sUBd0cdwT4PrjXGJs8s8A8Oa1lpve+n4uRbS3xSGYnpPYL4BNvZlpm6Lklx7BDUu3vcHg==
   dependencies:
     airbnb-prop-types "^2.16.0"
     color2k "^1.1.1"


### PR DESCRIPTION
We have multiple accessibility tickets for the date icon button (SHI-1283, SHI-1282). Instead of trying to fix them, I discussed w/ Teresa on UX and verified we can just remove the button since it serves no purpose because the same functionality is present when the inputs are focused. 

This PR removes the date icon on the right, fixes the styling so that the right border is now present, and fixes a test that was using the date icon to trigger the calender flyout.