### PR TITLE
feat(pagination): add option for pagination text in PaginationControl

### DIFF
--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -45,3 +45,11 @@ Add bootstrap styles to list element.
 
 Allows for custom aria-label.
 
+#### `showPaginationText?: boolean`
+
+When true, this will show pagination text next to the controls describing the current page and page range. This defaults to the following: 1-50 of 100.
+
+#### `showPaginationText?: (lower: number, upper: number, total: number) => string`
+
+When `showPaginationText` is true, this function allows for customization of the pagination text that is displayed. 
+

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -49,7 +49,7 @@ Allows for custom aria-label.
 
 When true, this will show pagination text next to the controls describing the current page and page range. This defaults to the following: 1-50 of 100.
 
-#### `showPaginationText?: (lower: number, upper: number, total: number) => string`
+#### `populatePaginationText?: (lower: number, upper: number, total: number) => string`
 
 When `showPaginationText` is true, this function allows for customization of the pagination text that is displayed. 
 

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/pagination",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/pagination",
-  "version": "2.13.0",
+  "version": "2.12.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -8,8 +8,17 @@ import { usePagination } from './Pagination';
 const leftCaret = '\u2039'; // ‹
 const rightCaret = '\u203A'; // ›
 
-const PaginationControls = ({ directionLinks, autoHide, pageRange, marginPages, breakLabel, ...rest }) => {
-  const { pageCount, currentPage, setPage } = usePagination();
+const PaginationControls = ({
+  directionLinks,
+  autoHide,
+  pageRange,
+  marginPages,
+  breakLabel,
+  showPaginationText,
+  populatePaginationText,
+  ...rest
+}) => {
+  const { pageCount, currentPage, setPage, lower, upper, total } = usePagination();
 
   const createItem = (pageNumber) => (
     <PaginationItem key={pageNumber} active={currentPage === pageNumber} data-testid={`control-page-${pageNumber}`}>
@@ -130,6 +139,11 @@ const PaginationControls = ({ directionLinks, autoHide, pageRange, marginPages, 
       ) : (
         ''
       )}
+      {showPaginationText && (
+        <div data-testid="pagination-text" className="pagination-text pt-1 pl-2 pr-2">
+          {populatePaginationText ? populatePaginationText(lower, upper, total) : `${lower}-${upper} of ${total}`}
+        </div>
+      )}
     </Pagination>
   ) : (
     ''
@@ -144,6 +158,8 @@ PaginationControls.propTypes = {
   breakLabel: PropTypes.bool,
   listClassName: PropTypes.string,
   'aria-label': PropTypes.string,
+  showPaginationText: PropTypes.string,
+  populatePaginationText: PropTypes.func,
 };
 
 PaginationControls.defaultProps = {
@@ -152,6 +168,7 @@ PaginationControls.defaultProps = {
   pageRange: 5,
   marginPages: 2,
   breakLabel: true,
+  showPaginationText: false,
 };
 
 export default PaginationControls;

--- a/packages/pagination/src/PaginationControls.js
+++ b/packages/pagination/src/PaginationControls.js
@@ -158,7 +158,7 @@ PaginationControls.propTypes = {
   breakLabel: PropTypes.bool,
   listClassName: PropTypes.string,
   'aria-label': PropTypes.string,
-  showPaginationText: PropTypes.string,
+  showPaginationText: PropTypes.bool,
   populatePaginationText: PropTypes.func,
 };
 

--- a/packages/pagination/stories/pagination.stories.tsx
+++ b/packages/pagination/stories/pagination.stories.tsx
@@ -121,17 +121,19 @@ Default.args = {
   pageRange: 5,
   showLoader: false,
   unstyled: false,
+  showPaginationText: false
 };
 Default.storyName = 'default';
 
-export const Controls: Story = ({ autoHide, directionLinks }) => (
+export const Controls: Story = ({ autoHide, directionLinks, showPaginationText,  }) => (
   <Pagination items={paginationData}>
-    <PaginationControls directionLinks={directionLinks} autoHide={autoHide} />
+    <PaginationControls directionLinks={directionLinks} autoHide={autoHide} showPaginationText={showPaginationText} />
   </Pagination>
 );
 Controls.args = {
   autoHide: true,
   directionLinks: true,
+  showPaginationText: true
 };
 Controls.storyName = 'controls';
 

--- a/packages/pagination/tests/PaginationControls.test.js
+++ b/packages/pagination/tests/PaginationControls.test.js
@@ -243,4 +243,54 @@ describe('Pagination Controls', () => {
       expect(pageBreakEllipsisLink).toHaveAttribute('aria-label', 'Jump forwards to page 6');
     });
   });
+
+  test('should show pagination text', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls pageRange={5} marginPages={1} directionLinks showPaginationText />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageText = getByTestId('pagination-text');
+      expect(pageText).toBeDefined();
+
+      expect(pageText.textContent).toBe('1-1 of 5');
+    });
+  });
+
+  test('should show pagination text with populatePaginationText', async () => {
+    const items = [
+      { value: '1', key: 1 },
+      { value: '2', key: 2 },
+      { value: '3', key: 3 },
+      { value: '4', key: 4 },
+      { value: '5', key: 5 },
+    ];
+
+    const { getByTestId } = render(
+      <Pagination items={items} itemsPerPage={1}>
+        <PaginationControls
+          pageRange={5}
+          marginPages={1}
+          directionLinks
+          showPaginationText
+          populatePaginationText={(lower, upper, total) => `Show me ${lower} thru ${upper} of ${total}`}
+        />
+      </Pagination>
+    );
+    await waitFor(() => {
+      const pageText = getByTestId('pagination-text');
+      expect(pageText).toBeDefined();
+
+      expect(pageText.textContent).toBe('Show me 1 thru 1 of 5');
+    });
+  });
 });

--- a/packages/pagination/types/PaginationControls.d.ts
+++ b/packages/pagination/types/PaginationControls.d.ts
@@ -5,6 +5,8 @@ export interface PaginationControlsProps extends PaginationProps {
   autoHide?: boolean;
   marginPages?: number;
   pageRange?: number;
+  showPaginationText?: boolean;
+  populatePaginationText?: (lower: number, upper: number, total: number) => string;
 }
 
 declare const PaginationControls: React.FC<PaginationControlsProps>;


### PR DESCRIPTION
We have a requirement in RCM for our pagers to show text, ie: 1-50 of 100.

With this change, you can optionally display this in the PaginationControls.

You can also pass in a function to allow you to format the text however is needed with populatePaginationText. 