### PR TITLE
docs: add or update links to docs site

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,24 +1,25 @@
-/* eslint-disable unicorn/no-array-push-push */
 const path = require('path');
 
 module.exports = {
   stories: ['../packages/**/*.stories.tsx'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-a11y'],
   webpackFinal: async (config) => {
-    config.module.rules.push({
-      test: /\.scss$/,
-      use: ['style-loader', 'css-loader', 'sass-loader'],
-      include: path.resolve(__dirname, '../'),
-    });
-
-    config.module.rules.push({
-      test: /\.(js|jsx|ts|tsx)$/,
-      loader: require.resolve('babel-loader'),
-      options: {
-        presets: [['react-app', { flow: false, typescript: true }]],
+    config.module.rules.push(
+      {
+        test: /\.scss$/,
+        use: ['style-loader', 'css-loader', 'sass-loader'],
+        include: path.resolve(__dirname, '../'),
       },
-      include: new RegExp(`node_modules[/\\\\](?=(@availity)).*`),
-    });
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        loader: require.resolve('babel-loader'),
+        options: {
+          presets: [['react-app', { flow: false, typescript: true }]],
+        },
+        include: new RegExp(`node_modules[/\\\\](?=(@availity)).*`),
+      }
+    );
+
     config.resolve.extensions.push('.ts', '.tsx');
 
     return config;

--- a/README.md
+++ b/README.md
@@ -1,29 +1,39 @@
-# availity-react
+# Availity React Component Library
 
 > React components using Availity UIKit and Bootstrap 4
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge&logo=MIT)](http://opensource.org/licenses/MIT)
-[![Dependency Status](https://img.shields.io/david/dev/Availity/availity-react.svg?style=for-the-badge)](https://david-dm.org/Availity/availity-react)
+[![Build](https://img.shields.io/github/workflow/status/availity/sdk-js/Publish%20Release?style=for-the-badge)](https://github.com/Availity/sdk-js/actions/workflows/deploy.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Availity/availity-react?style=for-the-badge)](https://codecov.io/gh/Availity/availity-react)
-
-## Supported Browsers
-
-- Google Chrome
-- Mozilla Firefox
-- Microsoft Edge
-- Internet Explorer 11+ (Internet Explorer will no longer be supported starting August 21st, 2021)
+[![Activity](https://img.shields.io/github/commit-activity/m/availity/availity-react?style=for-the-badge)](https://availity.github.io/availity-react/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge&logo=MIT)](http://opensource.org/licenses/MIT)
 
 ## Storybook
 
-https://availity.github.io/availity-react/storybook
+We have a [Storybook](https://availity.github.io/availity-react/storybook) setup where you can see the components in action.
 
-## Availity Docs
+## Documentation
 
-https://availity.github.io/availity-react
+Check out our [documentation site](https://availity.github.io/availity-react)!
 
 ## Contributing
 
-[Contributing Guide](./.github/CONTRIBUTING.md)
+See our [contributing guide](./.github/CONTRIBUTING.md) on how to become a contributor for the repo
+
+## Supported Browsers
+
+Packages in this repository are designed to work with the following browsers
+
+- Google Chrome
+- Microsoft Edge
+- Mozilla Firefox
+
+### Internet Explorer Support
+
+Active support for Internet Explorer was dropped in August 2021.
+
+If you still need support for IE 11, you can use [`@availity/workflow >=8.5.0 && <9.0.0`](https://github.com/Availity/availity-workflow/blob/master/packages/workflow/CHANGELOG.md#850-2021-04-07). This will transpile _all_ your code and add polyfills needed for IE 11 support.
+
+If you do not want to, or can't, use `@availity/workflow`, then you can use your own `babel` configuration to polyfill the necessary code
 
 ## Additional Notes
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "release:ci": "lerna publish --yes",
     "start": "yarn start:storybook",
     "start:docs": "yarn workspace @availity/dinosaurdocs start",
-    "start:storybook": "start-storybook -p 6006",
+    "start:storybook": "start-storybook -p 6006 -s ./static",
     "pretest": "yarn build:components",
     "test": "jest",
     "test:ci": "jest --runInBand --collectCoverage",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react",
     "ui"
   ],
-  "homepage": "https://github.com/Availity/availity-react#readme",
+  "homepage": "https://availity.github.io/availity-react/",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
@@ -21,7 +21,6 @@
     "tyson warner (https://github.com/nylon22)",
     "robert mcguinness (https://github.com/robmcguinness)"
   ],
-  "main": "index.js",
   "workspaces": {
     "packages": [
       "packages/*",
@@ -45,6 +44,7 @@
     "clean:docs": "rimraf docusaurus/build docusaurus/.docusaurus",
     "clean:locks": "rimraf 'yarn.lock'",
     "clean:storybook": "rimraf storybook-docs",
+    "nuke": "yarn clean && yarn clean:locks && yarn clean:builds && yarn clean:docs && yarn clean:storybook",
     "codecov:ci": "codecov",
     "deploy:ci": "yarn build:deploy",
     "deploy:docs": "yarn workspace @availity/dinosaurdocs deploy",
@@ -56,7 +56,6 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "new": "plop",
-    "nuke": "yarn clean && yarn clean:locks && yarn clean:builds && yarn clean:docs && yarn clean:storybook",
     "prerelease:ci": "yarn build:components",
     "release:ci": "lerna publish --yes",
     "start": "yarn start:storybook",

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -3,5 +3,23 @@
 > track click and page events for the user
 
 [![Version](https://img.shields.io/npm/v/@availity/analytics.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/analytics)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/analytics.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/analytics)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/analytics?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/analytics/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/analytics/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/analytics
+```
+
+### Yarn
+
+```bash
+yarn add @availity/analytics
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/analytics/index)

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -7,12 +7,14 @@
     "availity",
     "analytics"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/analytics/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/analytics"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@gmail.com>",

--- a/packages/app-icon/README.md
+++ b/packages/app-icon/README.md
@@ -3,5 +3,23 @@
 > Availity UI Kit application icon react component.
 
 [![Version](https://img.shields.io/npm/v/@availity/app-icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/app-icon)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/app-icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/app-icon)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/app-icon?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/app-icon/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/app-icon)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/app-icon
+```
+
+### Yarn
+
+```bash
+yarn add @availity/app-icon
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/app-icon)

--- a/packages/app-icon/package.json
+++ b/packages/app-icon/package.json
@@ -4,14 +4,17 @@
   "description": "Availity UI Kit application icon react component.",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "app-icon"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/app-icon",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/app-icon"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/authorize/README.md
+++ b/packages/authorize/README.md
@@ -3,5 +3,23 @@
 > Check user permissions to see if the current user is authorized to see your content.
 
 [![Version](https://img.shields.io/npm/v/@availity/authorize.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/authorize)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/authorize.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/authorize)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/authorize?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/authorize/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/authorize)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/authorize
+```
+
+### Yarn
+
+```bash
+yarn add @availity/authorize
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/authorize)

--- a/packages/authorize/package.json
+++ b/packages/authorize/package.json
@@ -4,14 +4,17 @@
   "description": "Check user permissions to see if the current user is authorized to see your content.",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "authorize"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/authorize",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/authorize"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@gmail.com>",

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -3,5 +3,23 @@
 > Availity user avatar component
 
 [![Version](https://img.shields.io/npm/v/@availity/avatar.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/avatar)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/avatar.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/avatar)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/avatar?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/avatar/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/avatar)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/avatar
+```
+
+### Yarn
+
+```bash
+yarn add @availity/avatar
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/avatar)

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -7,12 +7,14 @@
     "availity",
     "avatar"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/avatar",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/avatar"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -3,5 +3,23 @@
 > Availity breadcrumbs
 
 [![Version](https://img.shields.io/npm/v/@availity/breadcrumbs.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/breadcrumbs)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/breadcrumbs.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/breadcrumbs)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/breadcrumbs?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/breadcrumbs/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/breadcrumbs)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/breadcrumbs
+```
+
+### Yarn
+
+```bash
+yarn add @availity/breadcrumbs
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/breadcrumbs)

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -4,14 +4,17 @@
   "description": "Availity breadcrumbs",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "breadcrumbs"
   ],
+  "homepage": "https://availity.github.io/availity-react/form/date/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/breadcrumbs"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -2,4 +2,24 @@
 
 > Wrapper for [react-dates](https://github.com/airbnb/react-dates) to work with [formik](https://github.com/jaredpalmer/formik)
 
-## [Documentation](https://availity.github.io/availity-react/form/date/index)
+[![Version](https://img.shields.io/npm/v/@availity/date.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/date)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/date.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/date)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/date?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/date/package.json)
+
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/date
+```
+
+### Yarn
+
+```bash
+yarn add @availity/date
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/form/date/index)

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -4,17 +4,17 @@
   "description": "Wrapper for react-dates to work with formik",
   "keywords": [
     "availity",
-    "reactstrap",
-    "validation",
+    "formik",
     "date"
   ],
-  "homepage": "https://github.com/Availity/availity-react/tree/master/packages/date#readme",
+  "homepage": "https://availity.github.io/availity-react/form/date/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/date"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/favorites/README.md
+++ b/packages/favorites/README.md
@@ -3,5 +3,23 @@
 > Favorite Heart for favoriting items such as resources/applications etc.
 
 [![Version](https://img.shields.io/npm/v/@availity/favorites.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/favorites)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/favorites.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/favorites)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/favorites?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/favorites/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/favorites/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/favorites
+```
+
+### Yarn
+
+```bash
+yarn add @availity/favorites
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/favorites/index)

--- a/packages/favorites/package.json
+++ b/packages/favorites/package.json
@@ -4,14 +4,17 @@
   "description": "Favorite Heart for favoriting items such as links/resources etc.",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "favorites"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/favorites/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/favorites"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/feature/README.md
+++ b/packages/feature/README.md
@@ -3,5 +3,23 @@
 > Check environment features for the current environment to determine if a particular feature is enabled.
 
 [![Version](https://img.shields.io/npm/v/@availity/feature.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feature)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/feature.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feature)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/feature?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/feature/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/feature)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/feature
+```
+
+### Yarn
+
+```bash
+yarn add @availity/feature
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/feature)

--- a/packages/feature/package.json
+++ b/packages/feature/package.json
@@ -4,14 +4,17 @@
   "description": "Check if a feature is enabled or disabled before doing something.",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "feature"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/feature",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/feature"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@gmail.com>",

--- a/packages/feedback/README.md
+++ b/packages/feedback/README.md
@@ -3,5 +3,23 @@
 > Availity feedback with smiley faces react component.
 
 [![Version](https://img.shields.io/npm/v/@availity/feedback.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feedback)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/feedback.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/feedback)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/feedback?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/feedback/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/feedback/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/feedback
+```
+
+### Yarn
+
+```bash
+yarn add @availity/feedback
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/feedback/index)

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -4,14 +4,17 @@
   "description": "Availity feedback with smiley faces react component.",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "feedback"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/feedback/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/feedback"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/form-upload/README.md
+++ b/packages/form-upload/README.md
@@ -2,6 +2,24 @@
 
 > Availity upload component for uploading files, compatible with @availity/form
 
-[![Version](https://img.shields.io/npm/v/@availity/upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form-upload)
+[![Version](https://img.shields.io/npm/v/@availity/form-upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form-upload)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/form-upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form-upload)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/form-upload?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/form-upload/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/form/upload/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/form-upload
+```
+
+### Yarn
+
+```bash
+yarn add @availity/form-upload
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/form/upload/index)

--- a/packages/form-upload/package.json
+++ b/packages/form-upload/package.json
@@ -7,13 +7,14 @@
     "availity",
     "upload"
   ],
-  "homepage": "https://github.com/Availity/availity-react/tree/master/packages/upload#readme",
+  "homepage": "https://availity.github.io/availity-react/form/upload/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/form-upload"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -3,5 +3,23 @@
 > Availity form components that are wired to be hooked up to [formik](https://github.com/jaredpalmer/formik)
 
 [![Version](https://img.shields.io/npm/v/@availity/form.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/form.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/form?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/form/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/form/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/form
+```
+
+### Yarn
+
+```bash
+yarn add @availity/form
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/form/index)

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -4,14 +4,18 @@
   "description": "Form Wrapper around formik using reactstrap components",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "form",
+    "formik"
   ],
+  "homepage": "https://availity.github.io/availity-react/form/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/form"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/help/README.md
+++ b/packages/help/README.md
@@ -1,78 +1,25 @@
----
-title: Help
----
+# @availity/help
 
-> Context Provider to assist with Help Menu on Portal for specific pages
-> Field Help Icon to import and access field level support
+> Context Provider to assist with Help Menu on Portal for specific pages and Field Help Icon to import and access field level support
 
 [![Version](https://img.shields.io/npm/v/@availity/favorites.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/help)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/help.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/help)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/help?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/help/package.json)
 
 ## Installation
 
-npm
+### NPM
 
 ```bash
-npm install @availity/help --save
+npm install @availity/help
 ```
 
-Yarn
+### Yarn
 
 ```bash
 yarn add @availity/help
 ```
 
-## Page Level Help Example
+## Documentation
 
-```jsx
-import React from 'react';
-import HelpProvider, { Help } from '@availity/help';
-
-const Example = () => (
-  <HelpProvider>
-    <Help type="provider" id="1234-5678-9101-1213">
-      Some Content You May need documentation for.
-    </Help>
-  </HelpProvider>
-);
-```
-
-## Page Level Help Props
-
-### `id: string`
-
-The page level help ID **Required**
-
-### `type: string`
-
-The page level help type: ie.: provider | vendor | payer | insight. **Required**
-
-## Field Level Help Icon Example
-
-```jsx
-import React from 'react';
-import { FieldHelpIcon } from '@availity/help';
-
-const Example = () => (
-  <div id="testId">
-    Select A Provider <FieldHelpIcon id="1234-5678-910" labelId="testId" />
-  </div>
-);
-```
-
-## Field Help Props
-
-### `id: string`
-
-The field Help ID **Required**
-
-### `color?: string`
-
-The bootstrap 3 color of the icon. **Default:**`primary`
-
-### `size?: string`
-
-The size of the help icon. **Default:** `1x`
-
-### `labelId?: string`
-
-The id of the label for accessibility (aria-describedby). **Default:** ''
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/help)

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -4,14 +4,17 @@
   "description": "Context Provider to assist with Help Menu on Portal for specific pages",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "help"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/help",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/help"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -3,5 +3,23 @@
 > Re-usable hooks for components and apps.
 
 [![Version](https://img.shields.io/npm/v/@availity/hooks.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/hooks)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/hooks.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/hooks)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/hooks?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/hooks/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/hooks/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/hooks
+```
+
+### Yarn
+
+```bash
+yarn add @availity/hooks
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/hooks/index)

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -4,14 +4,17 @@
   "description": "A group of pre-built hooks that are common in most apps",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "hooks"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/hooks/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/hooks"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -1,7 +1,25 @@
 # @availity/icon
 
-> Simple icon component that is a wrapper for the icons in the availity uikit. **[Icon List](http://availity.github.io/availity-uikit/v3/icons)**
+> Simple icon component that is a wrapper for the icons in the availity uikit. **[Icon List](http://availity.github.io/availity-uikit/v4/icons)**
 
 [![Version](https://img.shields.io/npm/v/@availity/icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/icon)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/icon.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/icon)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/icon?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/icon/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/icon)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/icon
+```
+
+### Yarn
+
+```bash
+yarn add @availity/icon
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/icon)

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -4,14 +4,17 @@
   "description": "Simple Icon Component that uses classes from availity uikit",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "icon"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/icon",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/icon"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -3,5 +3,23 @@
 > Simple link component that renders an `<a>` tag with the `href` formatted to leverage loadApp so that when the link is opened in a new tab, it gets loaded inside the home page's iframe
 
 [![Version](https://img.shields.io/npm/v/@availity/link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/link)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/link)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/link/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/link)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/link
+```
+
+### Yarn
+
+```bash
+yarn add @availity/link
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/link)

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -4,14 +4,17 @@
   "description": "React component that renders an a tag with the `href` formatted to leverage loadApp",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "link"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/link",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/link"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/list-group-item/README.md
+++ b/packages/list-group-item/README.md
@@ -3,5 +3,23 @@
 > List Group Item with some Availity flair
 
 [![Version](https://img.shields.io/npm/v/@availity/list-group-item.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group-item)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/list-group-item.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group-item)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/list-group-item?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/list-group-item/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/list-group-item/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/list-group-item
+```
+
+### Yarn
+
+```bash
+yarn add @availity/list-group-item
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/list-group-item/index)

--- a/packages/list-group-item/package.json
+++ b/packages/list-group-item/package.json
@@ -4,14 +4,17 @@
   "description": "List Group Item with some Availity flair",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "list"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/list-group-item/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/list-group-item"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/list-group/README.md
+++ b/packages/list-group/README.md
@@ -3,5 +3,23 @@
 > List Group with some Availity flair
 
 [![Version](https://img.shields.io/npm/v/@availity/list-group.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/list-group.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/list-group)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/list-group?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/list-group/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/list-group)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/list-group
+```
+
+### Yarn
+
+```bash
+yarn add @availity/list-group
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/list-group)

--- a/packages/list-group/package.json
+++ b/packages/list-group/package.json
@@ -4,14 +4,17 @@
   "description": "List Group with some Availity flair",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "list"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/list-group",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/list-group"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -5,14 +5,17 @@
   "description": "Contains xhr mocks for storybook and gatsby docs",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "mock"
   ],
+  "homepage": "https://github.com/Availity/availity-react/tree/master/packages/mock#readme",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/Availity/availity-react.git"
+    "url": "git+ssh://git@github.com/Availity/availity-react.git",
+    "directory": "packages/mock"
   },
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",

--- a/packages/page-header/README.md
+++ b/packages/page-header/README.md
@@ -3,5 +3,23 @@
 > The standard page header for Availity Portal Applications
 
 [![Version](https://img.shields.io/npm/v/@availity/page-header.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/page-header)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/page-header.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/page-header)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/page-header?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/page-header/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/page-header)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/page-header
+```
+
+### Yarn
+
+```bash
+yarn add @availity/page-header
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/page-header)

--- a/packages/page-header/package.json
+++ b/packages/page-header/package.json
@@ -4,14 +4,18 @@
   "description": "The standard page header for Availity Portal Applications",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "page",
+    "header"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/page-header",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/page-header"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -3,5 +3,23 @@
 > Pagination, the Availity way.
 
 [![Version](https://img.shields.io/npm/v/@availity/pagination.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/pagination)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/pagination.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/pagination)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/pagination?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/pagination/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/pagination/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/pagination
+```
+
+### Yarn
+
+```bash
+yarn add @availity/pagination
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/pagination/index)

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,14 +1,20 @@
 {
   "name": "@availity/pagination",
   "version": "2.13.1",
-  "description": "",
-  "keywords": [],
+  "description": "component for displaying paginated data",
+  "keywords": [
+    "availity",
+    "react",
+    "pagination"
+  ],
+  "homepage": "https://availity.github.io/availity-react/components/pagination/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/pagination"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/payer-logo/README.md
+++ b/packages/payer-logo/README.md
@@ -3,6 +3,8 @@
 > THIS PACKAGE HAS BEEN DEPRECATED IN FAVOR OF `@availity/spaces`
 
 [![Version](https://img.shields.io/npm/v/@availity/payer-logo.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/payer-logo)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/payer-logo.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/payer-logo)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/payer-logo?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/payer-logo/package.json)
 
 Easy to use component to display the payer&#x27;s logo given the payer&#x27;s ID
 
@@ -20,16 +22,8 @@ import PayerLogo from '@availity/payer-logo';
 
 const Example = () => (
   <>
-    <PayerLogo
-      spaceId="73162546201441126239486200007187"
-      clientId="my-client-id"
-      alt="The word 'Payer' in green"
-    />
-    <PayerLogo
-      payerId="PayerID"
-      clientId="my-client-id"
-      alt="The word 'Payer' in green"
-    />
+    <PayerLogo spaceId="73162546201441126239486200007187" clientId="my-client-id" alt="The word 'Payer' in green" />
+    <PayerLogo payerId="PayerID" clientId="my-client-id" alt="The word 'Payer' in green" />
   </>
 );
 ```

--- a/packages/payer-logo/package.json
+++ b/packages/payer-logo/package.json
@@ -4,14 +4,17 @@
   "description": "Easy to use component to display the payer&#x27;s logo given the payer&#x27;s ID",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "logo"
   ],
+  "homepage": "https://github.com/Availity/availity-react/tree/master/packages/payer-logo#readme",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/payer-logo"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/phone/README.md
+++ b/packages/phone/README.md
@@ -3,5 +3,23 @@
 > Availity Phone component using Formik and Yup
 
 [![Version](https://img.shields.io/npm/v/@availity/phone.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/phone)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/phone.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/phone)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/phone?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/phone/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/form/phone/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/phone
+```
+
+### Yarn
+
+```bash
+yarn add @availity/phone
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/form/phone/index)

--- a/packages/phone/package.json
+++ b/packages/phone/package.json
@@ -2,7 +2,20 @@
   "name": "@availity/phone",
   "version": "1.2.2",
   "description": "Availity Phone component using Formik and Yup",
-  "keywords": [],
+  "keywords": [
+    "availity",
+    "yup",
+    "formik"
+  ],
+  "homepage": "https://availity.github.io/availity-react/form/phone/index",
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/phone"
+  },
   "license": "MIT",
   "author": "Christopher Havekost <Christopher.Havekost@availity.com>",
   "main": "index.js",

--- a/packages/progress/README.md
+++ b/packages/progress/README.md
@@ -3,5 +3,23 @@
 > Availity Progress Bar
 
 [![Version](https://img.shields.io/npm/v/@availity/progress.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/progress)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/progress.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/progress)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/progress?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/progress/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/progress)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/progress
+```
+
+### Yarn
+
+```bash
+yarn add @availity/progress
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/progress)

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -7,12 +7,14 @@
     "availity",
     "progress"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/progress",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/progress"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/reactstrap-validation-date/README.md
+++ b/packages/reactstrap-validation-date/README.md
@@ -3,16 +3,18 @@
 > Wrapper for react-date-range to work with availity-reactstrap-validation.
 
 [![Version](https://img.shields.io/npm/v/@availity/reactstrap-validation-date.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-date)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/reactstrap-validation-date.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-date)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/reactstrap-validation-date?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/reactstrap-validation-date/package.json)
 
 ## Installation
 
-npm
+### NPM
 
 ```bash
 npm install @availity/reactstrap-validation-date availity-reactstrap-validation reactstrap --save
 ```
 
-Yarn
+### Yarn
 
 ```bash
 yarn add @availity/reactstrap-validation-date availity-reactstrap-validation reactstrap
@@ -87,6 +89,7 @@ Like `AvField`, but for dates with a date picker
 #### AvDateField Props
 
 See availity-reactstrap-validation for additional props, such as `name`, `validate`, `min`, `max`, and more.
+
 - **`min`**: string. Optional. Minimum date to allow the datepicker and input to take. You can either pass the `min` here or in the `validate` object if you want a custom error message with it.
 - **`max`**: string. Optional. Max date to allow the datepicker and input to take. You can either pass the `max` here or in the `validate` object if you want a custom error message with it.
 

--- a/packages/reactstrap-validation-date/package.json
+++ b/packages/reactstrap-validation-date/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/reactstrap-validation-date"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/reactstrap-validation-select/README.md
+++ b/packages/reactstrap-validation-select/README.md
@@ -3,6 +3,8 @@
 > Wrapper for react-select (with async pagination) to work with availity-reactstrap-validation.
 
 [![Version](https://img.shields.io/npm/v/@availity/reactstrap-validation-select.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-select)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/reactstrap-validation-select.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/reactstrap-validation-select)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/reactstrap-validation-select?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/reactstrap-validation-select/package.json)
 
 ## Installation
 

--- a/packages/reactstrap-validation-select/package.json
+++ b/packages/reactstrap-validation-select/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/reactstrap-validation-select"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -2,4 +2,24 @@
 
 > Wrapper for [react-select-async-paginate](https://github.com/vtaits/react-select-async-paginate) to work with [formik](https://github.com/jaredpalmer/formik)
 
-## [Documentation](https://availity.github.io/availity-react/form/select/index)
+[![Version](https://img.shields.io/npm/v/@availity/select.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/select)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/select.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/select)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/select?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/select/package.json)
+
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/select
+```
+
+### Yarn
+
+```bash
+yarn add @availity/select
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/form/select/index)

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -4,17 +4,17 @@
   "description": "Wrapper for react-select to work with formik",
   "keywords": [
     "availity",
-    "reactstrap",
-    "validation",
+    "formik",
     "select"
   ],
-  "homepage": "https://github.com/Availity/availity-react/tree/master/packages/select#readme",
+  "homepage": "https://availity.github.io/availity-react/form/select/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/select"
   },
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",

--- a/packages/spaces/README.md
+++ b/packages/spaces/README.md
@@ -3,5 +3,23 @@
 > Easy to use spaces components
 
 [![Version](https://img.shields.io/npm/v/@availity/spaces.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/spaces)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/spaces.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/spaces)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/spaces?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/spaces/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/spaces/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/spaces
+```
+
+### Yarn
+
+```bash
+yarn add @availity/spaces
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/spaces/index)

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -4,14 +4,17 @@
   "description": "Easy to use spaces components",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "spaces"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/spaces/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/spaces"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/step-wizard/README.md
+++ b/packages/step-wizard/README.md
@@ -3,5 +3,23 @@
 > Step Wizard - the Availity Way
 
 [![Version](https://img.shields.io/npm/v/@availity/step-wizard.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/step-wizard)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/step-wizard.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/step-wizard)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/step-wizard?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/step-wizard/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/step-wizard/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/step-wizard
+```
+
+### Yarn
+
+```bash
+yarn add @availity/step-wizard
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/step-wizard/index)

--- a/packages/step-wizard/package.json
+++ b/packages/step-wizard/package.json
@@ -8,12 +8,14 @@
     "step",
     "wizard"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/step-wizard/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/step-wizard"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/training-link/README.md
+++ b/packages/training-link/README.md
@@ -3,5 +3,23 @@
 > Component for allowing link out to training in the Header component
 
 [![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/training-link)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/training-link)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/training-link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/training-link/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/training-link)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/training-link
+```
+
+### Yarn
+
+```bash
+yarn add @availity/training-link
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/training-link)

--- a/packages/training-link/package.json
+++ b/packages/training-link/package.json
@@ -4,14 +4,17 @@
   "description": "Component for allowing link out to training in the Header component",
   "keywords": [
     "react",
-    "availity"
+    "availity",
+    "training-link"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/training-link",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/training-link"
   },
   "license": "MIT",
   "author": "Andrew Bauer <andrew.bauer@availity.com>",

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -3,5 +3,23 @@
 > Availity typography components
 
 [![Version](https://img.shields.io/npm/v/@availity/typography.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/typography)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/typography.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/typography)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/typography?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/typography/package.json)
 
-## [Documentation](https://availity.github.io/availity-react/components/typography/index)
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/typography
+```
+
+### Yarn
+
+```bash
+yarn add @availity/typography
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/typography/index)

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -7,12 +7,14 @@
     "availity",
     "typography"
   ],
+  "homepage": "https://availity.github.io/availity-react/components/typography/index",
   "bugs": {
     "url": "https://github.com/Availity/availity-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/typography"
   },
   "license": "MIT",
   "author": "Tyson Warner <tyson.warner@availity.com>",

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -3,6 +3,8 @@
 > Availity component for uploading files
 
 [![Version](https://img.shields.io/npm/v/@availity/upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/upload)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/upload.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/upload)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/upload?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/upload/package.json)
 
 ## Installation
 

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-react.git"
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/upload"
   },
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
This is a housekeeping PR with the aim to make working with our packages and their docs easier. It has updates for the following

- Update links to docs
- add `homepage` property to `package.json` for each package
- add `directory` to the `repository` field in `package.json`
- update `README` files with correct links
- add badges to `README` files. `README` should now have npm version, number of downloads, and whether dependencies are up to date
- I also updated the badges in the root `README` to have build status and test coverage
