### PR TITLE
docs: fix issues with examples and refine docs

### DIFF
--- a/docusaurus/docs/components/analytics/analytics.md
+++ b/docusaurus/docs/components/analytics/analytics.md
@@ -9,7 +9,7 @@ Component allowing page and click events to be tracked.
 ```jsx
 import React from 'react';
 import { Button } from 'reactstrap';
-import Analytics from '@availity/Analytics';
+import Analytics from '@availity/analytics';
 
 const plugin = {
   trackEvent: (e) => {

--- a/docusaurus/docs/components/authorize.mdx
+++ b/docusaurus/docs/components/authorize.mdx
@@ -104,7 +104,7 @@ Returns `[authorized, loading, currentRegion]`
 import React from 'react';
 import { useAuthorize } from '@availity/authorize';
 
-const Component () => {
+const Component = () => {
   const [authorized, loading] = useAuthorized(['1234', '5678'], {
     region: 'FL',
   });

--- a/docusaurus/docs/components/favorites/heart.md
+++ b/docusaurus/docs/components/favorites/heart.md
@@ -26,7 +26,7 @@ The unique id of the favorite item to be fetched from API.
 
 #### `name: string`
 
-Name of item to be favorited. *Used to generate unique name of control, needed for accessibility.*
+Name of item to be favorited. _Used to generate unique name of control, needed for accessibility._
 
 #### `onChange?: (isFavorited: boolean, event?: Event) => void`
 

--- a/docusaurus/docs/components/favorites/hook.md
+++ b/docusaurus/docs/components/favorites/hook.md
@@ -11,7 +11,8 @@ Hook that allows you to "hook" into the favorites logic and create a custom comp
 ### Example
 
 ```jsx
-import React, { useState } from 'react';
+import React from 'react';
+import Icon from '@availity/icon';
 import { useFavorites } from '@availity/favorites';
 
 const Example = () => {

--- a/docusaurus/docs/components/feature.mdx
+++ b/docusaurus/docs/components/feature.mdx
@@ -69,7 +69,7 @@ The content that renders when the features are enabled.
 
 Negate the feature. If the feature specified is enabled, it acts as if it were disabled (by rendering the `whenDisabled` prop content). If the feature specified is disabled, it acts as if it were enabled (by rendering the `children` prop content).
 
-### `isFeatureEnabled`
+### isFeatureEnabled
 
 Function that validates the environment's features to determine if children content should be shown.
 
@@ -95,7 +95,7 @@ async () => {
 };
 ```
 
-### `generate-features-json (CLI)
+### generate-features-json (CLI)
 
 `generate-features-json` is a CLI tool that takes a `features.json` file and outputs environment specific `features.json` files to be used depending on which environment it's currently in. Note: This is where OpenShift comes into play. OpenShift ensures the right file (based on the ENV) is placed in the right location when the pod starts.
 

--- a/docusaurus/docs/components/feedback/form.md
+++ b/docusaurus/docs/components/feedback/form.md
@@ -59,7 +59,7 @@ Static (non-user-entered) key/value pairs to be sent in feedback submission.
 
 #### `autoFocusFeedbackButton?: bool`
 
-Default: ```true```. When set to false, the first feedback button is not focused. This is to avoid issues with focus causing other elements to close (e.g. dropdowns)
+Default: `true`. When set to false, the first feedback button is not focused. This is to avoid issues with focus causing other elements to close (e.g. dropdowns)
 
 #### `modalHeaderProps?: ModalHeaderProps`
 

--- a/docusaurus/docs/components/help.mdx
+++ b/docusaurus/docs/components/help.mdx
@@ -50,10 +50,11 @@ The page level help type: ie.: provider | vendor | payer | insight. **Required**
 ```jsx
 import React from 'react';
 import { FieldHelpIcon } from '@availity/help';
+import { Label } from 'reactstrap';
 
 const Example = () => (
   <div>
-    <Label id="provider-label">Select A Provider </Label>
+    <Label id="provider-label">Select A Provider</Label>
     <FieldHelpIcon id="1234-5678-910" labelId="provider-label" />
   </div>
 );

--- a/docusaurus/docs/components/pagination/controls.md
+++ b/docusaurus/docs/components/pagination/controls.md
@@ -51,5 +51,4 @@ When true, this will show pagination text next to the controls describing the cu
 
 #### `populatePaginationText?: (lower: number, upper: number, total: number) => string`
 
-When `showPaginationText` is true, this function allows for customization of the pagination text that is displayed. 
-
+When `showPaginationText` is true, this function allows for customization of the pagination text that is displayed.

--- a/docusaurus/docs/components/pagination/hook.md
+++ b/docusaurus/docs/components/pagination/hook.md
@@ -25,17 +25,17 @@ const PageSetter = () => {
 
 ### Returns
 
-```js
-{
-    pageCount: Number,
-    total: Number,
-    page: Array,
-    currentPage: Number,
-    lower: Number,
-    upper: Number,
-    setPage: (page: number) => void,
-    loading: Boolean,
-    error: Any,
-    setError: (error: any) => void
-}
+```ts
+type Return = {
+  pageCount: number;
+  total: number;
+  page: Array;
+  currentPage: number;
+  lower: number;
+  upper: number;
+  setPage: (page: number) => void;
+  loading: boolean;
+  error: any;
+  setError: (error: any) => void;
+};
 ```

--- a/docusaurus/docs/components/pagination/pagination.md
+++ b/docusaurus/docs/components/pagination/pagination.md
@@ -7,14 +7,20 @@ This is the provider component needed for `@availity/pagination` components to w
 ### Example
 
 ```jsx
-import React from 'react';
+import React, { useState } from 'react';
 import Pagination from '@availity/pagination';
 
-const Example = () => (
-  <Pagination itemsPerPage={25} items={this.state.items}>
-    <Pagination.Content component={Component} />
-  </Pagination>
-);
+const Example = () => {
+  const [items, setItems] = useState([]);
+
+  // logic to get items
+
+  return (
+    <Pagination itemsPerPage={25} items={items}>
+      <Pagination.Content component={Component} />
+    </Pagination>
+  );
+};
 ```
 
 #### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-pagination--default"> Storybook</a>

--- a/docusaurus/docs/components/step-wizard/wizard.md
+++ b/docusaurus/docs/components/step-wizard/wizard.md
@@ -8,7 +8,11 @@ Container for the step wizard.
 
 ```jsx
 import React from 'react';
-import Wizard, { WizardStep, WizardStepTitle } from '@availity/step-wizard';
+import Wizard, {
+  WizardStep,
+  WizardStepBadge,
+  WizardStepTitle,
+} from '@availity/step-wizard';
 
 const Example = () => (
   <Wizard bar>

--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -20,22 +20,20 @@ import React from 'react';
 import Table from '@availity/table';
 import '@availity/table/style.scss';
 
-const myTableConfig = {
-    columns: [
-        {
-            Header: 'Column 1',
-            accessor: 'column1'
-        },
-        {
-            Header: 'Column 2',
-            accessor: 'column2' 
-        },
-                {
-            Header: 'Column 3',
-            accessor: 'column3' 
-        },
-    ]
-}
+const columns = [
+  {
+    Header: 'Column 1',
+    accessor: 'column1',
+  },
+  {
+    Header: 'Column 2',
+    accessor: 'column2',
+  },
+  {
+    Header: 'Column 3',
+    accessor: 'column3',
+  },
+];
 
 const Example = () => (
     <Table
@@ -69,7 +67,7 @@ This determines whether the table is selectable or not. If it is set to true, th
 
 #### `sortable?: boolean`
 
-This determines whether the table is sortable or not. 
+This determines whether the table is sortable or not.
 
 #### `initialState?: object`
 
@@ -77,7 +75,7 @@ This object definition sets the initial state of the table, including the defaul
 
 #### `additionalContent?: ReactNode`
 
-This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.  
+This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.
 
 #### `bodyProps?:object`
 
@@ -97,7 +95,7 @@ Any DOM properties that should be passed onto the `<tr>` element.
 
 #### `onRowClick?: (event: OnTableClickEvent) => void`
 
-Event handler for clicking on a row. 
+Event handler for clicking on a row.
 
 ##### OnTableClickEvent Props
 
@@ -115,7 +113,7 @@ The index of the row that was clicked.
 
 #### `onRowSelected?: (event: OnRowSelectedEvent) => void`
 
-Event handler for when a row is selected. 
+Event handler for when a row is selected.
 
 ##### OnRowSelectedEvent Props
 
@@ -130,22 +128,20 @@ import React from 'react';
 import Table, { Cell } from '@availity/table';
 import '@availity/table/style.scss';
 
-const myTableConfig = {
-    columns: [
-        {
-            Header: 'Column 1',
-            accessor: 'column1'
-        },
-        {
-            Header: 'Column 2',
-            accessor: 'column2' 
-        },
-                {
-            Header: 'Column 3',
-            accessor: 'column3' 
-        },
-    ]
-}
+const columns = [
+  {
+    Header: 'Column 1',
+    accessor: 'column1',
+  },
+  {
+    Header: 'Column 2',
+    accessor: 'column2',
+  },
+  {
+    Header: 'Column 3',
+    accessor: 'column3',
+  },
+];
 
 const Example = () => (
     <Table
@@ -155,16 +151,14 @@ const Example = () => (
 );
 ```
 
-
 ### Action Cell
 
-This is used to display an action menu in a cell. 
+This is used to display an action menu in a cell.
 
 #### Example
 
 ```jsx
-
- const columns = [
+const columns = [
   {
     id: 'actions',
     Header: 'Actions',
@@ -186,33 +180,33 @@ This is used to display an action menu in a cell.
         },
       ],
     }),
-  }];
+  },
+];
 ```
 
 ### Badge Cell
 
-This is used to display a Reactstrap Badge in a cell. See [Availity UI Kit](https://availity.github.io/availity-uikit/v3/components#Badges-Contextual-Variations) and [ReactStrap](https://reactstrap.github.io/components/badge/) for available stylings. 
+This is used to display a Reactstrap Badge in a cell. See [Availity UI Kit](https://availity.github.io/availity-uikit/v3/components#Badges-Contextual-Variations) and [ReactStrap](https://reactstrap.github.io/components/badge/) for available stylings.
 
 #### Usages
 
 ```jsx
+const columns = [
+  {
+    Header: 'Badge',
+    accessor: 'badge',
+    Cell: ({ row: { original } }) =>
+      original ? BadgeCell('success', original.badgeValue) : null,
+  },
+];
 
- const columns = [
-    {
-        Header: 'Badge',
-        accessor: 'badge',
-        Cell: ({ row: { original } }) =>
-        original ? BadgeCell('success', original.badgeValue) : null
-    }
-  ];
-
-   const columns = [
-    {
-        Header: 'Badge',
-        accessor: 'badge',
-        Cell: Badgecell('success')
-    }
-  ];
+const columns = [
+  {
+    Header: 'Badge',
+    accessor: 'badge',
+    Cell: Badgecell('success'),
+  },
+];
 ```
 
 ### Currency Cell
@@ -222,16 +216,17 @@ This is used to format currency in a cell. You can optionally pass it a default 
 #### Usages
 
 ```jsx
-
- const columns = [
-    {
-        Header: 'Currency',
-        accessor: 'currency',
-        Cell: CurrencyCell({defaultValue: '$0.00'})
-    }
-  ];
+const columns = [
+  {
+    Header: 'Currency',
+    accessor: 'currency',
+    Cell: CurrencyCell({ defaultValue: '$0.00' }),
+  },
+];
 ```
+
 #### Props
+
 `currency`
 
 Defaults to `USD`.
@@ -246,30 +241,26 @@ The locale of the currency. Defaults to `en-us`.
 
 ### Date Cell
 
-This is used to format a date in a cell by passing in a date format. 
+This is used to format a date in a cell by passing in a date format.
 
 #### Usages
 
 ```jsx
-
- const columns = [
-        {
-            Header: 'Service Date',
-            accessor: 'serviceDate',
-            Cell: DateCell({ dateFormat: 'MM/DD/yyyy' })
-        }
-  ];
+const columns = [
+  {
+    Header: 'Service Date',
+    accessor: 'serviceDate',
+    Cell: DateCell({ dateFormat: 'MM/DD/yyyy' }),
+  },
+];
 ```
 
 ### Icon Cell
 
-This is used to have an cell display an icon. This will only show the icon if the value for the cell is populated (or `true`). 
+This is used to have an cell display an icon. This will only show the icon if the value for the cell is populated (or `true`).
 In order to show an icon always and not conditionally you can utilize `BuildIcon` and supply it the name of the icon and title.
 
-
-See [Availity UI Kit](https://availity.github.io/availity-uikit/v3/icons) for available icons. 
-
-
+See [Availity UI Kit](https://availity.github.io/availity-uikit/v3/icons) for available icons.
 
 #### Usages
 
@@ -289,13 +280,16 @@ In the body of the table, the icon is displayed if the hasNotes property is set 
 If the title (tooltip) of the icon is dependent on the data of the record, it is possible to pass a function to the IconCell to populate the record.
 
 ```jsx
-    const columns = [
-            {
-                Header: <Icon name='flag' title='Flag for follup'/>,
-                accessor: 'followup',
-                Cell: IconCell({ name: 'flag', title: (value: { username: string; }) => `Assigned To ${value.username}`}),
-            }
-    ]
+const columns = [
+  {
+    Header: <Icon name="flag" title="Flag for follup" />,
+    accessor: 'followup',
+    Cell: IconCell({
+      name: 'flag',
+      title: (value: { username: string }) => `Assigned To ${value.username}`,
+    }),
+  },
+];
 ```
 
 ## Column Configuration Properties
@@ -320,7 +314,7 @@ Display a header as a static string:
     ]
 ```
 
-Display a formatted header, such as an Icon. 
+Display a formatted header, such as an Icon.
 
 ```jsx
   const columns = [
@@ -333,7 +327,7 @@ Display a formatted header, such as an Icon.
 
 #### `accessor`
 
-This is the property name from the record. 
+This is the property name from the record.
 
 #### `Cell`
 
@@ -375,8 +369,8 @@ $av-table-font-size: 12px;
 $av-table-selected-background-color: #ccdee2;
 
 @import '~@availity/table/styles.scss';
-
 ```
+
 The following are the available variables to utilize.
 
 ```
@@ -411,15 +405,16 @@ You can configure the table header to be sticky by setting the `headerProps.stic
 This works best when the table is wrapped in a `<ScrollableContainer/>`.
 
 ```jsx
-    <Table columns={columns} records={records}
-        headerProps={{
-            sticky: true
-        }}
-    />
-
+<Table
+  columns={columns}
+  records={records}
+  headerProps={{
+    sticky: true,
+  }}
+/>
 ```
 
-You can also can configure a column to be sticky either left or right. This can be configured on in the column definitions for the table. 
+You can also can configure a column to be sticky either left or right. This can be configured on in the column definitions for the table.
 
 ```jsx
 const columns = [
@@ -432,4 +427,4 @@ const columns = [
 
 ```
 
-Note that this is not supported in IE 11. 
+Note that this is not supported in IE 11.

--- a/docusaurus/docs/components/table/scrollableContainer.md
+++ b/docusaurus/docs/components/table/scrollableContainer.md
@@ -10,29 +10,24 @@ import React from 'react';
 import Table, { ScrollableContainer } from '@availity/table';
 import '@availity/table/style.scss';
 
-const myTableConfig = {
-    columns: [
-        {
-            Header: 'Column 1',
-            accessor: 'column1'
-        },
-        {
-            Header: 'Column 2',
-            accessor: 'column2' 
-        },
-        {
-            Header: 'Column 3',
-            accessor: 'column3' 
-        },
-    ]
-}
+const columns = [
+  {
+    Header: 'Column 1',
+    accessor: 'column1',
+  },
+  {
+    Header: 'Column 2',
+    accessor: 'column2',
+  },
+  {
+    Header: 'Column 3',
+    accessor: 'column3',
+  },
+];
 
 const Example = () => (
-    <ScrollableContainer>
-        <Table
-            columns={columns}
-            records={data}
-        />
-    </ScrollableContainer>
+  <ScrollableContainer>
+    <Table columns={columns} records={data} />
+  </ScrollableContainer>
 );
 ```

--- a/docusaurus/docs/components/training-link.mdx
+++ b/docusaurus/docs/components/training-link.mdx
@@ -2,18 +2,18 @@
 title: Training Link
 ---
 
+[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/training-link)
+
 Component for allowing link out to training in the Header component
 
 Provide a link for training videos for your app
-
-[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/training-link)
 
 ### Installation
 
 npm
 
 ```bash
-npm install @availity/training-link --save
+npm install @availity/training-link
 ```
 
 Yarn
@@ -22,9 +22,12 @@ Yarn
 yarn add @availity/training-link
 ```
 
-### Example
+### Usage
+
+#### Example
 
 ```jsx
+import React from 'react';
 import TrainingLink from '@availity/training-link';
 
 const Example = () => (
@@ -32,14 +35,13 @@ const Example = () => (
 );
 ```
 
-#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-training-link--default"> Storybook</a>
+#### Storybook
+
+Checkout the [Storybook](https://availity.github.io/availity-react/storybook/?path=/story/components-training-link--default) for interactive examples
 
 ### Props
 
-#### `link: string`
-
-Link to training video.
-
-#### `name: string`
-
-Name of your app to make the sentence complete.
+| name | required | type     | description                                     |
+| ---- | -------- | -------- | ----------------------------------------------- |
+| link | true     | `string` | Link to training video                          |
+| name | true     | `string` | Name of your app to make the sentence complete. |

--- a/docusaurus/docs/contributing.md
+++ b/docusaurus/docs/contributing.md
@@ -4,7 +4,7 @@ title: Contributing
 
 This is a monorepo managed using [lerna](https://github.com/lerna/lerna) in independent mode (each package is versioned and published individually).
 
-### Installation
+## Installation
 
 Ensure [yarn](https://yarnpkg.com/lang/en/) is installed
 
@@ -20,17 +20,33 @@ yarn install
 
 All subsequent installs should be quick after the first one.
 
-### Adding a New Package
+## Adding a New Package
 
 ```bash
 yarn new
 ```
 
-### Commits
+## Hooks
+
+This repo requires the components to be built for testing, linting, and releasing to work properly so we try to handle this for you where possible
+
+### pretest
+
+Run `yarn build:components` to make sure `jest` is running tests against the latest code
+
+### prerelease
+
+Run `yarn build:components` to create the `dist` where the packaged code can be accessed
+
+### postinstall
+
+Run `yarn build:components` after install to build the components and make sure they are up to date for use locally
+
+## Commits
 
 Commits should use the [Angular Commit Format](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type). Scope should one of un-prefixed names of the packages under `./packages/`. If a commit applies to multiple packages, leave out the scope.
 
-### Canary Releases
+## Canary Releases
 
 Useful for testing out changes. Canary releases do not impact the current `latest` tag version.
 

--- a/docusaurus/docs/form/components/feedback.md
+++ b/docusaurus/docs/form/components/feedback.md
@@ -9,6 +9,7 @@ Error message container for an input
 ```jsx
 import React from 'react';
 import { Form, Input, Feedback as FormFeedback } from '@availity/form';
+import { Button, Label, FormGroup } from 'reactstrap';
 
 const Example = () => (
   <Form

--- a/docusaurus/docs/form/components/label.md
+++ b/docusaurus/docs/form/components/label.md
@@ -32,8 +32,8 @@ const Example = () => (
   >
     <RequiredKey />
 
-    <Label for="hello" helpId="hello-help-id" required >
-        Hello
+    <Label for="hello" helpId="hello-help-id" required>
+      Hello
     </Label>
     <Input name="hello" />
     <Button type="submit" className="ml-1" color="primary">

--- a/docusaurus/docs/form/date/components/date-field.md
+++ b/docusaurus/docs/form/date/components/date-field.md
@@ -11,6 +11,7 @@ import React from 'react';
 import { Form } from '@availity/form';
 import { DateField } from '@availity/date';
 import { avDate } from '@availity/yup';
+import { Button } from 'reactstrap';
 import * as yup from 'yup';
 
 const Example = () => (
@@ -70,4 +71,3 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.
-

--- a/docusaurus/docs/form/date/components/date-range.mdx
+++ b/docusaurus/docs/form/date/components/date-range.mdx
@@ -20,16 +20,12 @@ const Example = () => (
     initialValues={{
       dateOfService: undefined,
     }}
-    onSubmit={values => console.log(values)}
+    onSubmit={(values) => console.log(values)}
     validationSchema={yup.object().shape({
       dateOfService: dateRange(
         {
-          min: moment()
-            .subtract(7, 'day')
-            .format('MM/DD/YYYY'),
-          max: moment()
-            .add(7, 'day')
-            .format('MM/DD/YYYY'),
+          min: moment().subtract(7, 'day').format('MM/DD/YYYY'),
+          max: moment().add(7, 'day').format('MM/DD/YYYY'),
           format: 'MM/DD/YYYY',
         },
         `Date must be between ${moment()
@@ -38,7 +34,7 @@ const Example = () => (
           .add(7, 'day')
           .format('MM/DD/YYYY')}`
       )
-        .typeError({message: 'This field is invalid.'})
+        .typeError({ message: 'This field is invalid.' })
         .required('This field is required.'),
     })}
   >
@@ -140,4 +136,3 @@ Set which direction the date picker renders. Possible values are `up` and `down`
 
 Defaults to false, with this behavior the onInputChange handler will not pass through invalid dates to formik. By setting this prop to true, you can allow formik to handle invalid dates.
 Very useful for getting errors from non-required date range components.
-

--- a/docusaurus/docs/form/index.mdx
+++ b/docusaurus/docs/form/index.mdx
@@ -1,9 +1,11 @@
 ---
-
 title: Getting Started
----Availity form components that are wired to be hooked up to formik
+summary: Availity form components that are wired to be hooked up to formik
+---
 
 [![Version](https://img.shields.io/npm/v/@availity/form.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/form)
+
+Availity form components that are wired to be hooked up to formik
 
 ### Installation
 

--- a/docusaurus/docs/form/phone/components/phone.md
+++ b/docusaurus/docs/form/phone/components/phone.md
@@ -70,11 +70,11 @@ Enable the phone extension field. This is `false` by default.
 
 Used to pass props to the extension field when it is enabled.
 
-```js
-extProps: {
-  name: '',
-  label: '',
-  extColProps: {},
+```json
+{
+  "name": "",
+  "label": "",
+  "extColProps": {}
 }
 ```
 
@@ -82,14 +82,13 @@ extProps: {
 
 Used to control props on the `<Col />` for the phone field, if needed. The phone column defaults to `xs: { size: 12 }` when not rendering an extension field, and defaults to `xs: { size: 10 }` when rendering an extension field.
 
-```js
-phoneColProps: {
-  xs: {
-    size: 9;
+```json
+{
+  "xs": {
+    "size": 9
   },
-
-  sm: {
-    size: 10;
+  "sm": {
+    "size": 10
   }
 }
 ```
@@ -98,14 +97,13 @@ phoneColProps: {
 
 Used to control props on `<Col />` for the extension field, if needed. The extension column has no default size value, so it's default will effectively be `size: { 12 - phoneColSize }` unless otherwise specified.
 
-```js
-extColProps: {
-  xs: {
-    size: 3;
+```json
+{
+  "xs": {
+    "size": 3
   },
-
-  sm: {
-    size: 2;
+  "sm": {
+    "size": 2
   }
 }
 ```

--- a/docusaurus/docs/form/phone/components/validate-phone.md
+++ b/docusaurus/docs/form/phone/components/validate-phone.md
@@ -1,6 +1,6 @@
 ---
 title: validatePhone
-summary:  Availity Phone component using Formik and Yup
+summary: Availity Phone component using Formik and Yup
 ---
 
 [![Version](https://img.shields.io/npm/v/@availity/phone.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/phone)
@@ -19,21 +19,27 @@ yarn add @availity/phone
 import * as yup from 'yup';
 import '@availity/phone/src/validatePhone';
 
-const laxSchema = yup.string().validatePhone('This phone number is not possible.');
-const strictSchema = yup.string().validatePhone('This phone number is invalid.', true, 'US');
+const laxSchema = yup
+  .string()
+  .validatePhone('This phone number is not possible.');
+const strictSchema = yup
+  .string()
+  .validatePhone('This phone number is invalid.', true, 'US');
 
-laxSchema.isValid('222-222-2222');    // true
+laxSchema.isValid('222-222-2222'); // true
 strictSchema.isValid('222-222-2222'); // false
-
 ```
 
 ## Props
 
 ### `msg?: string`
+
 Optional message to display when validation fails.
 
 ### `strict?: boolean`
+
 Controls whether or not strict phone number validation is used on the component. Defaults to `false`. [Benefits of not defaulting to strict validation](https://github.com/catamphetamine/libphonenumber-js/blob/master/README.md#using-phone-number-validation-feature).
 
 ### `country?: string`
+
 Default country for parsing national numbers. This is the [two letter ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). If no code is provided, the default is `'US'`.

--- a/docusaurus/docs/form/select/components/resource-select.md
+++ b/docusaurus/docs/form/select/components/resource-select.md
@@ -151,25 +151,21 @@ Function that is called when the api call returned an error. The error is return
 
 This object can be used to pass additional arguments to a resource's `postGet` call. These additional arguments are separate from the `parameters` that are supported by an API and may be used for filtering or other methods called inside a resource's `postGet` method. Example for the `organizations` resource that supports `additionalPostGetArgs`:
 
-```jsx
-async postGet(data, config, additionalPostGetArgs) {
+```js
+async function postGet(data, config, additionalPostGetArgs) {
+  if (additionalPostGetArgs) {
+    const { data: organizationsData } = await super.postGet(data, config);
 
-    if (additionalPostGetArgs) {
-      const { data: organizationsData } = await super.postGet(
-        data,
-        config
-      );
-
-      return this.getFilteredOrganizations(
-        organizationsData,
-        additionalPostGetArgs,
-        data
-      );
-    }
-
-    // Else return normal organizations call
-    return super.postGet(data, config);
+    return this.getFilteredOrganizations(
+      organizationsData,
+      additionalPostGetArgs,
+      data
+    );
   }
+
+  // Else return normal organizations call
+  return super.postGet(data, config);
+}
 ```
 
 ### Pre-made Resource Selects
@@ -236,9 +232,24 @@ const Example = () => (
       customerId={customerId}
       required
     />
-    <AvOrganizationSelect name="organization" label="Select a Organization" required />
-    <AvPermissionSelect name="permissions" label="Select a provider" customerId={customerId} isMulti required />
-    <AvNavigationSelect name="payerSpace" label="Select a Payer Space" customerId={customerId} required />
+    <AvOrganizationSelect
+      name="organization"
+      label="Select a Organization"
+      required
+    />
+    <AvPermissionSelect
+      name="permissions"
+      label="Select a provider"
+      customerId={customerId}
+      isMulti
+      required
+    />
+    <AvNavigationSelect
+      name="payerSpace"
+      label="Select a Payer Space"
+      customerId={customerId}
+      required
+    />
     <AvUserSelect name="user" label="Select a User" customerId={customerId} />
     <AvCodeSelect name="code" label="Select a Code" />
   </Form>

--- a/docusaurus/docs/form/upload/upload.md
+++ b/docusaurus/docs/form/upload/upload.md
@@ -13,7 +13,15 @@ import Upload from '@availity/form-upload';
 
 const Example = () => (
   <Form initialValues={{ myFile: undefined }}>
-    <Upload name="myFile" btnText="Upload a claim" clientId="a" bucketId="b" customerId="c" multiple={false} max={1} />
+    <Upload
+      name="myFile"
+      btnText="Upload a claim"
+      clientId="a"
+      bucketId="b"
+      customerId="c"
+      multiple={false}
+      max={1}
+    />
   </Form>
 );
 ```

--- a/docusaurus/docs/intro.md
+++ b/docusaurus/docs/intro.md
@@ -3,46 +3,26 @@ title: Introduction
 slug: /
 ---
 
-**Availity React is a repo of React components built for web projects on the Availity Portal**.
+Availity React is a repo of [React](https://beta.reactjs.org/) components built for web projects on the Availity Portal. This site contains documentation on how to use those components.
 
-#### You can browse these docs to help find the React component(s) you're looking to import.
-
-Many of the packages provided by `availity-react` are wrappers around common `reactstrap` components. If you can't find what you're looking for in these docs, we recommend looking at [Reactstrap documentation here](https://reactstrap.github.io).
+Many of the packages provided by `availity-react` are wrappers around common `reactstrap` components. If you can't find what you're looking for in these docs, we recommend looking at the [Reactstrap documentation](https://reactstrap.github.io).
 
 :::note
 If you can't find what you are looking for on any of the left sub menus try out the `search bar` at the top of every page that leverages [Algolia](https://www.algolia.com/) to provide lightning fast searches across all of our docs.
 :::
 
-## Installation
-
-For this example we'll use the [icon](/components/icon) component.
-
-npm
-
-```bash
-npm install @availity/icon --save
-```
-
-Yarn
-
-```bash
-yarn add @availity/icon
-```
-
-## Usage
-
-Import your component and you're good to go.
-
-```jsx
-import React from 'react';
-import Icon from '@availity/icon';
-
-const Example = () => <Icon name="home" size="3x" color="primary" />;
-```
-
 ## Supported Browsers
 
+Packages in this repository are designed to work with the following browsers
+
 - Google Chrome
-- Mozilla Firefox
 - Microsoft Edge
-- Internet Explorer 11+ (Internet Explorer will no longer be supported starting August 21st, 2021)
+- Mozilla Firefox
+
+### Internet Explorer Support
+
+Active support for Internet Explorer was dropped in August 2021.
+
+If you still need support for IE 11, you can use [`@availity/workflow >=8.5.0 && <9.0.0`](https://github.com/Availity/availity-workflow/blob/master/packages/workflow/CHANGELOG.md#850-2021-04-07). This will transpile _all_ your code and add polyfills needed for IE 11 support.
+
+If you do not want to, or can't, use `@availity/workflow`, then you can use your own `babel` configuration to polyfill the necessary code

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -13,7 +13,8 @@
     "docusaurus": "docusaurus",
     "serve": "docusaurus serve",
     "start": "docusaurus start",
-    "swizzle": "docusaurus swizzle"
+    "swizzle": "docusaurus swizzle",
+    "format": "prettier '**/*' --write --ignore-unknown"
   },
   "browserslist": {
     "production": [
@@ -34,5 +35,11 @@
     "clsx": "^1.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "prettier": {
+    "printWidth": 80,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "tabWidth": 2
   }
 }

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -3,13 +3,11 @@ module.exports = {
     'React Docs': [
       'intro',
       'contributing',
-      // {
-      //   type: 'link',
-      //   label: 'Storybook', // The label that should be displayed (string).
-      //   href:
-      //     'https://availity.github.io/availity-react/storybook/?path=/story/components-analytics--default', // The target URL (string).
-      // },
-
+      {
+        type: 'link',
+        label: 'Storybook', // The label that should be displayed (string).
+        href: 'https://availity.github.io/availity-react/storybook/', // The target URL (string).
+      },
       {
         type: 'category',
         label: 'Components',
@@ -17,7 +15,11 @@ module.exports = {
           {
             type: 'category',
             label: 'Analytics',
-            items: ['components/analytics/index', 'components/analytics/analytics', 'components/analytics/hook'],
+            items: [
+              'components/analytics/index',
+              'components/analytics/analytics',
+              'components/analytics/hook',
+            ],
           },
           'components/app-icon',
           'components/authorize',
@@ -37,7 +39,11 @@ module.exports = {
           {
             type: 'category',
             label: 'Feedback',
-            items: ['components/feedback/index', 'components/feedback/feedback', 'components/feedback/form'],
+            items: [
+              'components/feedback/index',
+              'components/feedback/feedback',
+              'components/feedback/form',
+            ],
           },
           'components/help',
           {
@@ -110,7 +116,10 @@ module.exports = {
           {
             type: 'category',
             label: 'Table',
-            items: ['components/table/index', 'components/table/scrollableContainer'],
+            items: [
+              'components/table/index',
+              'components/table/scrollableContainer',
+            ],
           },
           'components/training-link',
           {
@@ -154,7 +163,11 @@ module.exports = {
           {
             type: 'category',
             label: 'Phone',
-            items: ['form/phone/index', 'form/phone/components/phone', 'form/phone/components/validate-phone'],
+            items: [
+              'form/phone/index',
+              'form/phone/components/phone',
+              'form/phone/components/validate-phone',
+            ],
           },
           {
             type: 'category',

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -2,7 +2,11 @@ module.exports = {
   someSidebar: {
     'React Docs': [
       'intro',
-      'contributing',
+      {
+        type: 'link',
+        label: 'Contributing',
+        href: 'https://github.com/Availity/availity-react/blob/master/.github/CONTRIBUTING.md',
+      },
       {
         type: 'link',
         label: 'Storybook', // The label that should be displayed (string).


### PR DESCRIPTION
I did a quick pass over the docs to try to clean them up. I fixed some typos in issues, added imports, and updated the formatting. I set the `printWidth` to `80` because `120` width was requiring users to scroll horizontally to see the whole example.
