### PR TITLE
fix(dateRange): address 'cannot read properties of undefined' console error when selecting a Range in DateRange

### DIFF
--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { InputGroup, Input, Button, Row, Col } from 'reactstrap';
 import { DateRangePicker } from '@availity/react-dates';
@@ -71,8 +71,6 @@ const DateRange = ({
   const { setFieldValue, setFieldTouched, validateField } = useFormikContext();
   const [{ value = {} }, metadata] = useField({ name, validate });
   const [focusedInput, setFocusedInput] = useState(null);
-
-  const calendarIconRef = useRef();
 
   const startId = `${(id || name).replace(/[^\da-z]/gi, '')}-start`;
   const endId = `${(id || name).replace(/[^\da-z]/gi, '')}-end`;
@@ -220,12 +218,6 @@ const DateRange = ({
                 });
 
                 setFocusedInput(null);
-
-                // Focus the calendar icon once clicked because we don't
-                // want to get back in the loop of opening the calendar
-                if (calendarIconRef && calendarIconRef.current) {
-                  calendarIconRef.current.parentElement.focus();
-                }
               }}
             >
               {relativeRange}

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -223,7 +223,9 @@ const DateRange = ({
 
                 // Focus the calendar icon once clicked because we don't
                 // want to get back in the loop of opening the calendar
-                calendarIconRef.current.parentElement.focus();
+                if (calendarIconRef && calendarIconRef.current) {
+                  calendarIconRef.current.parentElement.focus();
+                }
               }}
             >
               {relativeRange}


### PR DESCRIPTION
Kept this as a separate branch/issue because it is separate from my other date change...hopefully doesn't annoy anyone too much....

Whenever you click on any defined preset ranges in the DateRange DatePicker, you always get a console error:

![image](https://user-images.githubusercontent.com/8000861/148268551-a1735157-5997-4949-8025-3aa53eb4d94b.png)

I initially thought this was due to some implementation issue on my end, but I also see it in the StoryBook documentation.

This PR will be to address this issue.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/availity/availity-react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Make sure your code passed the conventional commits check. Read more about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
