### PR TITLE
build: fix how worker is started

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { themes } from '@storybook/theming';
 
-import { worker } from '../packages/mock/src/browser';
 import './config.scss';
 
 export const parameters = {
@@ -19,6 +18,9 @@ export const parameters = {
   },
 };
 
-if (worker) {
+// Make sure we are in the browser before starting
+if (typeof global.process === 'undefined') {
+  const { worker } = require('../packages/mock/src');
+
   worker.start();
 }

--- a/packages/mock/src/index.js
+++ b/packages/mock/src/index.js
@@ -5,6 +5,6 @@ import { handlers } from './handlers';
 
 // Export the worker instance, so we can await the activation on Storybook's runtime.
 // You can use this reference to start the worker for local development as well.
-const worker = typeof global.process === 'undefined' && setupWorker(...handlers);
+const worker = setupWorker(...handlers);
 
 export { worker, rest };


### PR DESCRIPTION
fix issue with `msw` not running when deployed
