### PR TITLE
Feat/comp overrides select

### DIFF
--- a/packages/reactstrap-validation-select/src/AvSelect.js
+++ b/packages/reactstrap-validation-select/src/AvSelect.js
@@ -227,7 +227,15 @@ class AvSelect extends AvBaseInput {
   }
 
   render() {
-    const { className, selectRef, styles, creatable, options, ...attributes } = this.props;
+    const {
+      className,
+      selectRef,
+      styles,
+      creatable,
+      options,
+      components: componentsOverride,
+      ...attributes
+    } = this.props;
     const { newOptions } = this.state;
     const touched = this.context.FormCtrl && this.context.FormCtrl.isTouched(this.props.name);
     const hasError = this.context.FormCtrl && this.context.FormCtrl.hasError(this.props.name);
@@ -345,7 +353,7 @@ class AvSelect extends AvBaseInput {
         })}
         options={!attributes.loadOptions ? [...options, ...newOptions] : undefined}
         onCreateOption={this.handleCreate}
-        components={components}
+        components={{ ...components, ...componentsOverride }}
         {...attributes}
         {...this.getValidatorProps()}
         value={this.getViewValue()}

--- a/packages/reactstrap-validation-select/tests/AvResourceSelect.test.js
+++ b/packages/reactstrap-validation-select/tests/AvResourceSelect.test.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { fireEvent, waitFor, render, cleanup } from '@testing-library/react';
+import { fireEvent, waitFor, render } from '@testing-library/react';
 import { avRegionsApi, avProvidersApi, avCodesApi } from '@availity/api-axios';
 import { AvForm } from 'availity-reactstrap-validation';
 import { Button } from 'reactstrap';
@@ -18,7 +18,6 @@ const renderSelect = (props) =>
 
 describe('AvResourceSelect', () => {
   afterEach(() => {
-    cleanup();
     jest.clearAllMocks();
   });
 

--- a/packages/reactstrap-validation-select/tests/AvSelect.test.js
+++ b/packages/reactstrap-validation-select/tests/AvSelect.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { AvForm, AvInput } from 'availity-reactstrap-validation';
 import { Button } from 'reactstrap';
 
 import AvSelect from '..';
-
-afterEach(cleanup);
 
 const options = [
   { label: 'Option 1', value: 'value for option 1' },
@@ -97,7 +95,7 @@ describe('AvSelect', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     // Check for proper object format in payload
     await waitFor(() => {
@@ -159,7 +157,7 @@ describe('AvSelect', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     // Check that values got autofilled
     await waitFor(() => {
@@ -232,7 +230,7 @@ describe('AvSelect', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     // Check that values got autofilled
     await waitFor(() => {

--- a/packages/reactstrap-validation-select/tests/AvSelectField.test.js
+++ b/packages/reactstrap-validation-select/tests/AvSelectField.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { AvForm } from 'availity-reactstrap-validation';
 import { Button } from 'reactstrap';
 
 import { AvSelectField } from '..';
-
-afterEach(cleanup);
 
 const options = [
   { label: 'Option 1', value: 'value for option 1' },
@@ -33,6 +31,7 @@ describe('AvSelect', () => {
     const select = getByText('Hello World');
     expect(select).toBeDefined();
   });
+
   test('works with error message', async () => {
     const { getByText } = renderSelect({
       options,

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -77,6 +77,7 @@ const Select = ({
   helpMessage,
   feedback,
   placeholder,
+  components: componentOverrides,
   ...attributes
 }) => {
   const [{ onChange, value: fieldValue, ...field }, { touched, error: fieldError }] = useField({
@@ -282,7 +283,7 @@ const Select = ({
       aria-invalid={fieldError && touched}
       aria-errormessage={feedback && fieldValue && fieldError && touched ? `${name}-feedback`.toLowerCase() : ''}
       placeholder={placeholder}
-      components={components}
+      components={{ ...components, ...componentOverrides }}
       options={selectOptions}
       defaultOptions={waitUntilFocused ? [] : true}
       cacheUniqs={_cacheUniq}
@@ -400,6 +401,7 @@ Select.propTypes = {
   helpMessage: PropTypes.string,
   feedback: PropTypes.bool,
   placeholder: PropTypes.string,
+  components: PropTypes.object,
 };
 
 components.Option.propTypes = {

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { fireEvent, render, waitFor, cleanup } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { avRegionsApi, avProvidersApi, avCodesApi } from '@availity/api-axios';
 import { Button } from 'reactstrap';
 import { Form } from '@availity/form';
+
 import { ResourceSelect } from '..';
 import { AvProviderSelect, AvRegionSelect } from '../resources';
 
@@ -35,7 +36,6 @@ const renderSelect = (props) => {
 describe('ResourceSelect', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    cleanup();
   });
 
   it('returns resource options', async () => {
@@ -70,7 +70,7 @@ describe('ResourceSelect', () => {
 
     fireEvent.click(regionsOption);
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -277,7 +277,7 @@ describe('ResourceSelect', () => {
 
     fireEvent.click(regionsOption);
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -317,7 +317,7 @@ describe('ResourceSelect', () => {
         expect(avRegionsApi.postGet).toHaveBeenCalled();
       });
 
-      await fireEvent.click(getByText('Submit'));
+      fireEvent.click(getByText('Submit'));
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -367,7 +367,7 @@ describe('ResourceSelect', () => {
         expect(avRegionsApi.postGet).toHaveBeenCalledTimes(1);
       });
 
-      await fireEvent.click(getByText('Submit'));
+      fireEvent.click(getByText('Submit'));
       await waitFor(() => {
         const testFormInput = onSubmit.mock.calls[0][0]['test-form-input'];
         expect(testFormInput).toEqual({
@@ -377,13 +377,13 @@ describe('ResourceSelect', () => {
       });
 
       // Change what cache uniq is
-      await fireEvent.click(getByTestId('btn-toggle-cacheUniq'));
+      fireEvent.click(getByTestId('btn-toggle-cacheUniq'));
 
       await waitFor(() => {
         expect(avRegionsApi.postGet).toHaveBeenCalledTimes(2);
       });
 
-      await fireEvent.click(getByText('Submit'));
+      fireEvent.click(getByText('Submit'));
 
       await waitFor(() => {
         const testFormInput = onSubmit.mock.calls[1][0]['test-form-input'];
@@ -423,7 +423,7 @@ describe('ResourceSelect', () => {
         expect(avRegionsApi.postGet).toHaveBeenCalled();
       });
 
-      await fireEvent.click(getByText('Submit'));
+      fireEvent.click(getByText('Submit'));
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -464,7 +464,7 @@ describe('ResourceSelect', () => {
           expect(avRegionsApi.postGet).toHaveBeenCalled();
         });
 
-        await fireEvent.click(getByText('Submit'));
+        fireEvent.click(getByText('Submit'));
         await waitFor(() => {
           expect(onSubmit).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -814,7 +814,7 @@ describe('Custom Resources', () => {
 
       const { getByText } = render(<RegionComponent regionProps={regionProps} />);
 
-      await fireEvent.click(getByText('Submit'));
+      fireEvent.click(getByText('Submit'));
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Button } from 'reactstrap';
+import { components } from 'react-select';
 import * as yup from 'yup';
 import { Form, Input } from '@availity/form';
-import Select from '..';
 
-afterEach(cleanup);
+import Select from '..';
 
 const singleValueSchema = (name) =>
   yup.object().shape({
@@ -76,7 +76,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 1');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 1');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -134,7 +134,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 1');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -164,7 +164,7 @@ describe('Select', () => {
     await selectItem(container, getByText, 'Option 1');
     await selectItem(container, getByText, 'Option 2');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -193,7 +193,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Select all');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -222,7 +222,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Select all');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -251,7 +251,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Select all');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -277,7 +277,7 @@ describe('Select', () => {
       </Form>
     );
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       const select = container.querySelector('.av-select');
@@ -308,7 +308,7 @@ describe('Select', () => {
     // This will not get added
     await selectItem(container, getByText, 'Option 3');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -337,7 +337,7 @@ describe('Select', () => {
 
     await selectItem(container, getByText, 'Option 1');
 
-    await fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -408,7 +408,7 @@ describe('Select', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     // Check that values got autofilled
     await waitFor(() => {
@@ -490,7 +490,7 @@ describe('Select', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     // Check that values got autofilled
     await waitFor(() => {
@@ -561,7 +561,7 @@ describe('Select', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -637,7 +637,7 @@ describe('Select', () => {
     const submitButton = getByText('Submit');
     expect(submitButton).toBeDefined();
 
-    await fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -821,5 +821,34 @@ describe('Select', () => {
       expect(select).not.toHaveAttribute('aria-invalid');
       expect(select).toHaveAttribute('aria-errormessage', '');
     });
+  });
+
+  test('allow component overrides', async () => {
+    // Display 'Foo' as the selected value instead of the given option
+    const SingleValue = (props) => <components.SingleValue {...props}>Foo</components.SingleValue>;
+
+    const onSubmit = jest.fn();
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={onSubmit}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select name="singleSelect" options={options} data-testid="single-select" components={{ SingleValue }} />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const select = container.querySelector('.av__control');
+
+    // Open the dropdown
+    fireEvent.click(select);
+    // Hover down to the first option and select
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.keyDown(select, { key: 'Enter', keyCode: 13 });
+
+    expect(getByText('Foo')).toBeDefined();
   });
 });

--- a/packages/select/tests/SelectField.test.js
+++ b/packages/select/tests/SelectField.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Button } from 'reactstrap';
 import { Form } from '@availity/form';
-import { SelectField } from '..';
 
-afterEach(cleanup);
+import { SelectField } from '..';
 
 describe('Select', () => {
   test('renders with Label', async () => {


### PR DESCRIPTION
This allows users to pass in `components` and not lose the `aria` labels we have in place for compliance