### PR TITLE
feat/select: Allow for customizable search term for RemoteSelect

### DIFF
--- a/docusaurus/docs/form/select/components/resource-select.md
+++ b/docusaurus/docs/form/select/components/resource-select.md
@@ -167,6 +167,9 @@ async function postGet(data, config, additionalPostGetArgs) {
   return super.postGet(data, config);
 }
 ```
+#### `searchTerm?: string`
+
+If present, this will serve as the argument name for the typed search value when sending the request to the API. This defaults to `q`. 
 
 ### Pre-made Resource Selects
 

--- a/packages/select/src/ResourceSelect.js
+++ b/packages/select/src/ResourceSelect.js
@@ -89,7 +89,7 @@ const ResourceSelect = ({
         variables: {
           perPage: itemsPerPage,
           filters: {
-            q: encodeURIComponent(inputValue),
+            [searchTerm]: encodeURIComponent(inputValue),
           },
         },
       };
@@ -108,9 +108,8 @@ const ResourceSelect = ({
         data.query = graphqlConfig.query;
       }
     } else {
-      const searchParam = searchTerm || 'q';
-      params[searchParam] = encodeURIComponent(inputValue);
       params = {
+        [searchTerm]: encodeURIComponent(inputValue),
         limit: itemsPerPage,
         customerId: rest.customerId,
       };

--- a/packages/select/src/ResourceSelect.js
+++ b/packages/select/src/ResourceSelect.js
@@ -29,6 +29,7 @@ const ResourceSelect = ({
   additionalPostGetArgs,
   pageAll,
   pageAllSearchBy,
+  searchTerm,
   ...rest
 }) => {
   const { setFieldValue } = useFormikContext();
@@ -107,8 +108,9 @@ const ResourceSelect = ({
         data.query = graphqlConfig.query;
       }
     } else {
+      const searchParam = searchTerm || 'q';
+      params[searchParam] = encodeURIComponent(inputValue);
       params = {
-        q: encodeURIComponent(inputValue),
         limit: itemsPerPage,
         customerId: rest.customerId,
       };
@@ -339,6 +341,7 @@ ResourceSelect.propTypes = {
   pageAll: PropTypes.bool,
   pageAllSearchBy: PropTypes.func,
   onError: PropTypes.func,
+  searchTerm: PropTypes.string,
 };
 
 ResourceSelect.defaultProps = {
@@ -349,6 +352,7 @@ ResourceSelect.defaultProps = {
   defaultToFirstOption: false,
   shouldSearch: true,
   pageAll: false,
+  searchTerm: 'q',
 };
 
 const ucFirst = (str) => str && str.charAt(0).toUpperCase() + str.slice(1);

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -586,6 +586,70 @@ describe('ResourceSelect', () => {
     expect(avRegionsApi.postGet).toHaveBeenCalledTimes(1);
     expect(avRegionsApi.postGet.mock.calls[0][0]).toBe('q=flo&limit=50&offset=0');
   });
+
+  it('sends appropriate searchTerm parameter to API when searchTerm is provided', async () => {
+    avRegionsApi.post.mockResolvedValueOnce({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'TX',
+            value: 'Texas',
+          },
+          {
+            id: 'WA',
+            value: 'Washington',
+          },
+        ],
+      },
+    });
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          'test-form-input': undefined,
+        }}
+        onSubmit={onSubmit}
+      >
+        <ResourceSelect
+          name="test-form-input"
+          resource={avRegionsApi}
+          classNamePrefix="test__regions"
+          labelKey="value"
+          valueKey="id"
+          getResult="regions"
+          method="POST"
+          searchTerm="myCustomSearchParam"
+          minCharsToSearch={3}
+        />
+      </Form>
+    );
+
+    const regionsSelect = container.querySelector('.test__regions__control');
+
+    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+
+    fireEvent.keyDown(regionsSelect, {
+      key: 'w',
+      keyCode: 87,
+    });
+
+    await waitFor(() => expect(getByText('Florida')).toBeDefined());
+
+    waitFor(async () => {
+      expect(avRegionsApi.post).toHaveBeenCalledTimes(1);
+      expect(avRegionsApi.post.mock.calls[0][0]).toStrictEqual({
+        myCustomSearchParam: '',
+        limit: 50,
+        customerId: undefined,
+        offset: 0,
+      });
+    });
+  });
 });
 
 // -----
@@ -694,7 +758,6 @@ it('Sends custom parameters to API with method=POST', async () => {
     offset: 0,
   });
 });
-
 // ---
 
 // -----

--- a/packages/select/types/ResourceSelect.d.ts
+++ b/packages/select/types/ResourceSelect.d.ts
@@ -25,7 +25,7 @@ export interface ResourceSelectProps<T> extends SelectFieldProps<T> {
   debounceTimeout?: number;
   customerId?: string;
   parameters?: object | ((params: any) => void);
-  method?: 'POST';
+  method?: string;
   itemsPerPage?: number;
   onPageChange?: Function;
   requiredParams?: any[];
@@ -42,6 +42,7 @@ export interface ResourceSelectProps<T> extends SelectFieldProps<T> {
   pageAll?: boolean;
   pageAllSearchBy?: (previousOptions: any[], inputValue: string) => any[];
   onError?: (error: Error) => void;
+  searchTerm?: string;
 }
 
 declare class ResourceSelect<T> extends React.Component<ResourceSelectProps<T>> {

--- a/packages/select/types/ResourceSelect.d.ts
+++ b/packages/select/types/ResourceSelect.d.ts
@@ -25,7 +25,7 @@ export interface ResourceSelectProps<T> extends SelectFieldProps<T> {
   debounceTimeout?: number;
   customerId?: string;
   parameters?: object | ((params: any) => void);
-  method?: string;
+  method?: 'POST';
   itemsPerPage?: number;
   onPageChange?: Function;
   requiredParams?: any[];


### PR DESCRIPTION
We have a need to use the RemoteSelect on RCM, but our API's do not expect 'q' as the search term.

To be able to utilize the RemoteSelect, I have add a `searchTerm` prop that will allow you to specify the name of the parameter that should apply to the typed searchTerm value.

By defaulting this to 'q' this should be backwards compatible.