### PR TITLE
fix(date): prevent loss of onChange handler when date value is manually cleared

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -74,15 +74,15 @@ const AvDate = ({
   };
 
   const onPickerChange = (value) => {
-    if (value === null) return;
-
     let val = value;
-    if (val instanceof Object && val.isValid()) {
-      val = val.format(isoDateFormat);
-    }
+    if (val !== null) {
+      if (val instanceof Object && val.isValid()) {
+        val = val.format(isoDateFormat);
+      }
 
-    setFieldValue(name, val, false);
-    setFieldTouched(name, true, false);
+      setFieldValue(name, val, false);
+      setFieldTouched(name, true, false);
+    }
 
     if (onChange) {
       onChange(val);

--- a/packages/date/tests/Date.test.js
+++ b/packages/date/tests/Date.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Button } from 'reactstrap';
 import { Form } from '@availity/form';
 import { avDate } from '@availity/yup';
@@ -65,6 +66,31 @@ describe('Date', () => {
 
     await waitFor(() => {
       expect(onChange.mock.calls[0][0]).toBe('1997-01-04');
+    });
+  });
+
+  test('renders call on change when clearing out value manually', async () => {
+    const onSubmit = jest.fn();
+    const onChange = jest.fn();
+
+    const { container } = render(
+      <Form
+        initialValues={{
+          singleDate: '01/04/1997',
+        }}
+        onSubmit={onSubmit}
+      >
+        <FormikDate name="singleDate" data-testid="single-select" onChange={onChange} />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const input = container.querySelector('.DateInput_input');
+    input.setSelectionRange(0, 10);
+    userEvent.type(input, '01/04/1997{backspace}');
+
+    await waitFor(() => {
+      expect(onChange.mock.calls[0][0]).toBeNull();
     });
   });
 


### PR DESCRIPTION
This issue addresses the following with the @availity/date date component:

**Current Issue:**
When there is an onChange handler provided for either `Date` or `DateField`, that onChange handler does not get called if the value is null. For example, I can select a value with the date picker. If I backspace and delete some of that date manually, it sets the value to null (even if there is only a "partial" date left after backspacing). This creates problems when we have to report form validity to a parent component, such as a modal where the submit button is not nested within the `<Form/>`.  We have rendered that Date Input invalid by backspacing, yet we can't report on that since the onChange handler call gets skipped. We should be calling onChange handlers when the input changes and just let it flow through like any other input would do. 
