### PR TITLE
fix(date): fix DateRangePicker props on element definition so that they are customizable and not hardcoded

### DIFF
--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -167,6 +167,8 @@ const AvDate = ({
       >
         <SingleDatePicker
           renderMonthElement={renderMonthElement}
+          autoComplete="date"
+          numberOfMonths={1}
           {...datePickerProps}
           disabled={attributes.disabled}
           id={pickerId}
@@ -175,11 +177,9 @@ const AvDate = ({
           onDateChange={onPickerChange}
           focused={isFocused}
           onFocusChange={onFocusChange}
-          numberOfMonths={1}
           isOutsideRange={isOutsideRange(min, max)}
           navPosition="navPositionBottom"
           openDirection={openDirection}
-          autoComplete="date"
         />
       </InputGroup>
     </>

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -293,6 +293,8 @@ const DateRange = ({
           minimumNights={0}
           ariaDescribedBy={ariaDescribedBy}
           enableOutsideDays
+          autoComplete="date"
+          numberOfMonths={2}
           {...datepickerProps}
           startDate={getDateValue(startValue)}
           startDateId={startId}
@@ -306,10 +308,8 @@ const DateRange = ({
           renderCalendarInfo={renderDateRanges}
           customArrowIcon={customArrowIcon}
           isOutsideRange={isOutsideRange(min, max, format)}
-          numberOfMonths={2}
           navPosition="navPositionBottom"
           openDirection={openDirection}
-          autoComplete="date"
         />
       </InputGroup>
     </>


### PR DESCRIPTION
We keep running into issues where we are trying to set a datePickerProps  and they don't get respected because it is hard-coded later down the element (after the {...datePickerProps} spread).

This PR adds more properties (autoComplete, numberOfMonths) before the spread of `{...datePickerProps}` so that we can set those and them actually propagate down to the the DateRangePicker and SingleDatePicker. We had to do this same thing before 'enableOutsideDays' and are going through and fixing some of our bugs and noticed these other ones that we need to override. 