### PR TITLE
fix(table): Add ability to designate hidden columns 

### DIFF
--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -372,6 +372,10 @@ This makes the column sticky to the right side of the table. This works best whe
 
 When there is an on OnRowClick event populated, this designates that the column should not be clickable and not call that event. This is helpful for actions columns or cells that contain links or special functions.
 
+#### `hidden`
+
+When this is true, the column will be hidden in the table.
+
 ## Styling the Table
 
 In order to get the out-of-the-box styles for the table you can import the table scss file. You can also supply classNames to `bodyProps`, `cellProps`, `headerProps`, or `rowProps`.

--- a/packages/table/src/Controls/BulkTableActions.tsx
+++ b/packages/table/src/Controls/BulkTableActions.tsx
@@ -25,10 +25,10 @@ const BulkTableActions = <T extends IdType>({
 
   const { selectedFlatRows: selectedRows, isAllRowsSelected, toggleAllRowsSelected } = instance as TableInstance<T>;
 
-  const [isSelectionDropdownOpen, setIsSelectionDropdownOpen] = useState<boolean>(false);
-  const [numberOfSelectedRows, setNumberOfSelectedRows] = useState<number>(0);
+  const [isSelectionDropdownOpen, setIsSelectionDropdownOpen] = useState(false);
+  const [numberOfSelectedRows, setNumberOfSelectedRows] = useState(0);
   const [selectionButtonText, setSelectionButtonText] = useState('Select');
-  const [isDisabled, setIsDisabled] = useState<boolean>(disabled || false);
+  const [isDisabled, setIsDisabled] = useState(disabled || false);
 
   useEffect(() => {
     setNumberOfSelectedRows(selectedRows?.length);

--- a/packages/table/src/Controls/TableControls.tsx
+++ b/packages/table/src/Controls/TableControls.tsx
@@ -8,7 +8,7 @@ type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 const TableControls = ({ id, disabled, children, ...rest }: Props): JSX.Element => {
-  const [isDisabled, setIsDisabled] = useState<boolean>(disabled || false);
+  const [isDisabled, setIsDisabled] = useState(disabled || false);
 
   useEffect(() => {
     setIsDisabled(disabled || false);

--- a/packages/table/src/Controls/TableSorter.tsx
+++ b/packages/table/src/Controls/TableSorter.tsx
@@ -38,10 +38,10 @@ const TableSorter = <T extends IdType>({
   const { sortableColumns, instance } = useTableContext();
   const { toggleSortBy, state } = instance as TableInstance<T>;
 
-  const [isSortingDropdownOpen, setIsSortingDropdownOpen] = useState<boolean>(false);
+  const [isSortingDropdownOpen, setIsSortingDropdownOpen] = useState(false);
   const [tableSort, setTableSort] = useState<TableSortOption | undefined>();
-  const [tableSortDesc, setTableSortDesc] = useState<boolean>(true);
-  const [isDisabled, setIsDisabled] = useState<boolean>(disabled || false);
+  const [tableSortDesc, setTableSortDesc] = useState(true);
+  const [isDisabled, setIsDisabled] = useState(disabled || false);
   const [displayedSortOptions, setDisplayedSortOptions] = useState<TableSortOption[]>();
 
   useEffect(() => {
@@ -55,7 +55,7 @@ const TableSorter = <T extends IdType>({
         availableSortOptions = [...availableSortOptions, ...sortOptions];
       }
 
-      setDisplayedSortOptions(sortBy(availableSortOptions, option => option.label.toUpperCase()));
+      setDisplayedSortOptions(sortBy(availableSortOptions, (option) => option.label.toUpperCase()));
     }
   }, [sortOptions, autoGenerateSortOptions, sortableColumns]);
 

--- a/packages/table/src/TableProvider.tsx
+++ b/packages/table/src/TableProvider.tsx
@@ -78,7 +78,10 @@ const TableProvider = <T extends IdType>({
         ),
       };
 
-      hooks.visibleColumns.push((columns: Column<T>[]) => [selectionColumn, ...columns]);
+      hooks.visibleColumns.push((columns: Column<T>[]) => [
+        selectionColumn,
+        ...filter(columns, (col) => col.hidden !== true),
+      ]);
     }
   ) as TableInstance<T>;
 

--- a/packages/table/src/TableProvider.tsx
+++ b/packages/table/src/TableProvider.tsx
@@ -32,7 +32,7 @@ const TableProvider = <T extends IdType>({
   ...rest
 }: TableProviderProps<T>): JSX.Element => {
   let selectionColumn: Column<T>;
-  const [isScrollable, setScrollable] = useState<boolean | undefined>(scrollable);
+  const [isScrollable, setScrollable] = useState(scrollable);
 
   const getSortableColumns = (): TableSortOption[] =>
     filter(columns, (column) => !column.disableSortBy && column.defaultCanSort).map((column) => {

--- a/packages/table/src/TableRow.tsx
+++ b/packages/table/src/TableRow.tsx
@@ -24,9 +24,9 @@ const TableRow = <T extends IdType>({
   ...rest
 }: Props<T>): JSX.Element => {
   const { AdditionalContent, additionalContentProps, scrollable, instance } = useTableContext();
-  const { selectedFlatRows: selectedRows, allColumns } = instance as TableInstance<T>;
+  const { selectedFlatRows: selectedRows, visibleColumns } = instance as TableInstance<T>;
 
-  const columns = allColumns as Column<T>[];
+  const columns = visibleColumns as Column<T>[];
 
   const definedRowProps = {
     className: classNames(`av-grid-row-${index % 2 === 0 ? 'even' : 'odd'}`, {

--- a/packages/table/src/tests/Table.test.tsx
+++ b/packages/table/src/tests/Table.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, queryByTestId } from '@testing-library/react';
 import basicData from './data/basicData.json';
 import formattedData from './data/needsFormattedData.json';
 import Table from '../Table';
@@ -54,7 +54,7 @@ const formattedColumns = [
     accessor: 'icon2',
     Cell: IconCell({
       name: 'doc-alt',
-      getTitle: () => 'test'
+      getTitle: () => 'test',
     }),
   },
   {
@@ -235,5 +235,30 @@ describe('Table', () => {
     await waitFor(() => {
       expect(onSort).toHaveBeenCalledTimes(1);
     });
+  });
+
+  test('should not display hidden columns', async () => {
+    const columnsToUse = [
+      ...basicColumns,
+      {
+        Header: 'Hidden',
+        accessor: 'aPropThatIsHidden',
+        hidden: true,
+      },
+    ];
+
+    const { container, queryByTestId } = render(
+      <TableProvider data={basicData} columns={columnsToUse}>
+        <Table />
+      </TableProvider>
+    );
+
+    expect(container).toBeDefined();
+
+    expect(container).toBeDefined();
+    expect(container).toMatchSnapshot();
+
+    const columnHeader = queryByTestId('table_header_row_0_cell_4_aPropThatIsHidden');
+    expect(columnHeader).toBeNull();
   });
 });

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -1,5 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Table should not display hidden columns 1`] = `
+<div>
+  <table
+    class="av-grid table"
+    role="table"
+  >
+    <thead
+      class="av-grid-row-header"
+      id="table_header"
+    >
+      <tr
+        data-testid="table_header_row_0"
+        id="table_header_row_0"
+        role="row"
+      >
+        <th
+          colspan="1"
+          data-testid="table_header_row_0_cell_0_first_name"
+          id="table_header_row_0_cell_0_first_name"
+          role="columnheader"
+          title="First Name"
+        >
+          First Name
+        </th>
+        <th
+          colspan="1"
+          data-testid="table_header_row_0_cell_1_last_name"
+          id="table_header_row_0_cell_1_last_name"
+          role="columnheader"
+          title="Last Name"
+        >
+          Last Name
+        </th>
+        <th
+          colspan="1"
+          data-testid="table_header_row_0_cell_2_email"
+          id="table_header_row_0_cell_2_email"
+          role="columnheader"
+          title="Email"
+        >
+          Email
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      role="rowgroup"
+    >
+      <tr
+        class="av-grid-row-even"
+        data-testid="table_row_0"
+        id="table_row_0"
+        role="row"
+      >
+        <td
+          data-testid="table_row_0_cell_0"
+          id="table_row_0_cell_0"
+          role="cell"
+        >
+          Barbra
+        </td>
+        <td
+          data-testid="table_row_0_cell_1"
+          id="table_row_0_cell_1"
+          role="cell"
+        >
+          Tull
+        </td>
+        <td
+          data-testid="table_row_0_cell_2"
+          id="table_row_0_cell_2"
+          role="cell"
+        >
+          btull0@usatoday.com
+        </td>
+      </tr>
+      <tr
+        class="av-grid-row-odd"
+        data-testid="table_row_1"
+        id="table_row_1"
+        role="row"
+      >
+        <td
+          data-testid="table_row_1_cell_0"
+          id="table_row_1_cell_0"
+          role="cell"
+        >
+          Karlis
+        </td>
+        <td
+          data-testid="table_row_1_cell_1"
+          id="table_row_1_cell_1"
+          role="cell"
+        >
+          Yurshev
+        </td>
+        <td
+          data-testid="table_row_1_cell_2"
+          id="table_row_1_cell_2"
+          role="cell"
+        >
+          kyurshev1@spotify.com
+        </td>
+      </tr>
+      <tr
+        class="av-grid-row-even"
+        data-testid="table_row_2"
+        id="table_row_2"
+        role="row"
+      >
+        <td
+          data-testid="table_row_2_cell_0"
+          id="table_row_2_cell_0"
+          role="cell"
+        >
+          Bordie
+        </td>
+        <td
+          data-testid="table_row_2_cell_1"
+          id="table_row_2_cell_1"
+          role="cell"
+        >
+          Marsy
+        </td>
+        <td
+          data-testid="table_row_2_cell_2"
+          id="table_row_2_cell_2"
+          role="cell"
+        >
+          bmarsy2@elegantthemes.com
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Table should render basic table 1`] = `
 <div>
   <table

--- a/packages/table/src/tests/data/basicData.json
+++ b/packages/table/src/tests/data/basicData.json
@@ -4,20 +4,23 @@
     "first_name": "Barbra",
     "last_name": "Tull",
     "email": "btull0@usatoday.com",
-    "isActive": true
+    "isActive": true,
+    "aPropThatIsHidden": "1"
   },
   {
     "id": 2,
     "first_name": "Karlis",
     "last_name": "Yurshev",
     "email": "kyurshev1@spotify.com",
-    "isActive": false
+    "isActive": false,
+    "aPropThatIsHidden": "1"
   },
   {
     "id": 3,
     "first_name": "Bordie",
     "last_name": "Marsy",
     "email": "bmarsy2@elegantthemes.com",
-    "isActive": true
+    "isActive": true,
+    "aPropThatIsHidden": "1"
   }
 ]

--- a/packages/table/src/types/ReactTable.ts
+++ b/packages/table/src/types/ReactTable.ts
@@ -34,6 +34,7 @@ export type Column<T extends IdType> = RtColumn<T> & {
   defaultCanSort?: boolean;
   disableSortBy?: boolean;
   label?: string;
+  hidden?: boolean;
 };
 
 export type Cell<T extends IdType> = RtCell<T> & {

--- a/packages/table/src/types/TableSortOption.ts
+++ b/packages/table/src/types/TableSortOption.ts
@@ -3,5 +3,4 @@ export type TableSortOption = {
   label: string;
   isDesc?: boolean;
   order?: number;
-  fieldMap?: string;
 };

--- a/packages/table/src/types/TableSortOption.ts
+++ b/packages/table/src/types/TableSortOption.ts
@@ -3,4 +3,5 @@ export type TableSortOption = {
   label: string;
   isDesc?: boolean;
   order?: number;
+  fieldMap?: string;
 };


### PR DESCRIPTION
This PR cleans up some of the previous PR comments, as well as adding the ability to designate hidden columns just by setting it as the default configuration. 