### PR TITLE
fix(select): allow valueKey to work with ResourceSelect

### DIFF
--- a/docusaurus/docs/form/select/components/resource-select.md
+++ b/docusaurus/docs/form/select/components/resource-select.md
@@ -45,6 +45,8 @@ const Example = () => (
 
 Extends [SelectField Props](/form/select/components/select-field/#props).
 
+Note: the `valueKey` prop will only work if you also pass `false` to the `raw` prop.
+
 #### `name: string`
 
 The name of the field. Will be the key of the selected date that comes through in the values of the `onSubmit` callback.
@@ -75,7 +77,7 @@ When this prop changes, all cached options are cleared. (see [react-select-async
 
 #### `watchParams?: string[]`
 
-Provide a list of properties to listen to from the parameters prop. If present, the options reset when any of the parameters specified in the array change value. This is useful for when a customerId changes and you need to load a new list of options for the user to choose from. This list will be used to derive cacheUniq when the cacheUniq prop is not provided. When using `watchParams`, the `parameters` prop must must be populated with values that are in the `watchParams` object. 
+Provide a list of properties to listen to from the parameters prop. If present, the options reset when any of the parameters specified in the array change value. This is useful for when a customerId changes and you need to load a new list of options for the user to choose from. This list will be used to derive cacheUniq when the cacheUniq prop is not provided. When using `watchParams`, the `parameters` prop must must be populated with values that are in the `watchParams` object.
 
 #### `resource: AxiosResource`
 
@@ -167,9 +169,10 @@ async function postGet(data, config, additionalPostGetArgs) {
   return super.postGet(data, config);
 }
 ```
+
 #### `searchTerm?: string`
 
-If present, this will serve as the argument name for the typed search value when sending the request to the API. This defaults to `q`. 
+If present, this will serve as the argument name for the typed search value when sending the request to the API. This defaults to `q`.
 
 ### Pre-made Resource Selects
 

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -120,7 +120,7 @@ const Select = ({
     if (attributes.isMulti && digIfMulti && Array.isArray(value)) {
       return value.map((val) => prepValue(val));
     }
-    if (attributes.raw || attributes.loadOptions) {
+    if (attributes.raw || (attributes.loadOptions && !attributes.valueKey)) {
       return value;
     }
     const valueKey = getValueKey();

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -650,6 +650,29 @@ describe('ResourceSelect', () => {
       });
     });
   });
+
+  it('applies valueKey override', async () => {
+    const { container, getByText } = renderSelect({
+      resource: { all: async () => [{ label: 'test', test: 'value' }] },
+      pageAll: true,
+      valueKey: 'test',
+      raw: false,
+      classNamePrefix: 'test__value__key',
+    });
+
+    // query
+    const select = container.querySelector('.test__value__key__control');
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
+
+    const option = await waitFor(() => getByText('test'));
+    fireEvent.click(option);
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ 'test-form-input': 'value' }), expect.anything())
+    );
+  });
 });
 
 // -----

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -734,6 +734,7 @@ describe('Select', () => {
       expect(optionOne).toHaveAttribute('name');
     });
   });
+
   test('renders error message in placeholder with invalid', async () => {
     const { container, getByText } = render(
       <Form
@@ -756,6 +757,7 @@ describe('Select', () => {
       expect(hiddenPlaceholderMessage.innerHTML).toContain('This field is required.');
     });
   });
+
   test('renders help message in placeholder', async () => {
     const { container, getByText } = render(
       <Form


### PR DESCRIPTION
This fixes a bug where passing in `valueKey` would not work with `ResourceSelect`. The component will now use the prop correctly.