### PR TITLE
feat(removable-badge): add removable-badge component

### DIFF
--- a/docusaurus/docs/components/removable-badge.mdx
+++ b/docusaurus/docs/components/removable-badge.mdx
@@ -1,0 +1,103 @@
+---
+title: Removable Badge
+---
+
+This is a removable badge component, utilizing ReactStrap Badge.
+
+[![Version](https://img.shields.io/npm/v/@availity/removable-badge.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
+
+### Installation
+
+```bash
+npx install-peerdeps @availity/removable-badge --save
+```
+
+##  Removable Badge
+
+### Example
+
+```jsx
+import React from 'react';
+import RemovableBadge from '@availity/removable-badge';
+
+const Example = () => (
+    <RemovableBadge key={badge.value} color={badge.color} value={badge.value} onRemove={remove}>
+        {displayText}
+    </RemovableBadge>
+);
+```
+
+#### Live example: <a href="https://availity.github.io/availity-react/storybook/?path=/story/components-header--default"> Storybook</a>
+
+### `RemovableBadge` Props
+
+`<RemovableBadge/>` contains all of the `BadgeProp` from Reacstrap, in addition to the following.
+
+#### `value: string`
+
+This is a unique value for the badge, which is passed up to the `onRemove` function to describe which badge is being removed.
+
+#### `onRemove: (value: string) => void`
+
+This is the function that is called whenever the 'X' icon is clicked. It passes the value of the specified badge to the parent component.
+
+## Removable Badge List
+
+This component allows you to specify a list of badges and handles removing the badge from the badge list 
+
+### Example
+
+```jsx
+import React from 'react';
+import { RemovableBadgeList, BadgeItem } from '@availity/removable-badge';
+
+const Example = () => (
+   const defaultBadgeList: BadgeItem[] = [
+        { value: '1', color: 'primary', displayText: 'Test 1' },
+        { value: '2', color: 'success', displayText: 'Test 2' },
+        { value: '3', color: 'danger', displayText: 'Test 3' },
+        { value: '4', color: 'warning', displayText: 'Test 4' },
+        { value: '5', color: 'info', displayText: 'Test 5' },
+        { value: '6', color: 'light', displayText: 'Test 6' },
+        { value: '7', color: 'dark', displayText: 'Test 7' },
+        { value: '8', displayText: 'Test 9' },
+  ];
+  const [badgeList, setBadgeList] = useState<BadgeItem[]>(defaultBadgeList);
+
+  const remove = () => {
+    setBadgeList(defaultBadgeList);
+  }
+
+  const onRemoveBadge = (badgeList: BadgeItem[]) => {
+    setBadgeList(badgeList);
+  }
+
+  return (
+      <RemovableBadgeList badges={badgeList} onRemove={onRemoveBadge}/>
+  );
+);
+```
+
+### `RemovableBadgeList` Props
+
+#### `onRemove: (badges: BadgeItem[]) => void`
+
+This is the function that is called whenever a badge in the list has been removed. It passes in the current badge list, after the badge has been removed. 
+
+### `BadgeItem` Props
+
+#### `value: string`
+
+This is a unique value for the badge, which is passed up to the `onRemove` function to describe which badge is being removed.
+
+#### `displayText: string`
+
+This is the text that will be displayed in the badge.
+
+#### `color: string`
+
+The color of the badge. Refer to the ReactStrap documentation to determine which colors are available. 
+
+#### `order: number`
+
+Optionally display the badges in a specified order.

--- a/docusaurus/docs/components/removable-badge.mdx
+++ b/docusaurus/docs/components/removable-badge.mdx
@@ -2,7 +2,7 @@
 title: Removable Badge
 ---
 
-This is a removable badge component, utilizing ReactStrap Badge.
+This is a removable badge component, utilizing Reactstrap Badge.
 
 [![Version](https://img.shields.io/npm/v/@availity/removable-badge.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
 
@@ -31,7 +31,7 @@ const Example = () => (
 
 ### `RemovableBadge` Props
 
-`<RemovableBadge/>` contains all of the `BadgeProp` from Reacstrap, in addition to the following.
+`<RemovableBadge/>` contains all of the `BadgeProp` from Reactstrap, in addition to the following.
 
 #### `value: string`
 
@@ -43,7 +43,7 @@ This is the function that is called whenever the 'X' icon is clicked. It passes 
 
 ## Removable Badge List
 
-This component allows you to specify a list of badges and handles removing the badge from the badge list 
+This component allows you to specify a list of badges and handles removing the badge from the badge list. 
 
 ### Example
 
@@ -96,7 +96,7 @@ This is the text that will be displayed in the badge.
 
 #### `color: string`
 
-The color of the badge. Refer to the ReactStrap documentation to determine which colors are available. 
+The color of the badge. Refer to the Reactstrap documentation to determine which colors are available. 
 
 #### `order: number`
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -101,6 +101,7 @@ module.exports = {
               'components/pagination/context',
             ],
           },
+          'components/removable-badge',
           'components/progress',
           {
             type: 'category',

--- a/packages/removable-badge/.npmignore
+++ b/packages/removable-badge/.npmignore
@@ -1,0 +1,2 @@
+**/*test.js
+**/*.stories.tsx

--- a/packages/removable-badge/README.md
+++ b/packages/removable-badge/README.md
@@ -1,0 +1,25 @@
+# @availity/removable-badge
+
+> Removable Badge Component
+
+[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removeable-badge)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removeable-badge)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/training-link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/removeable-badge/package.json)
+
+## Installation
+
+### NPM
+
+```bash
+npm install @availity/removeable-badge
+```
+
+### Yarn
+
+```bash
+yarn add @availity/removeable-badge
+```
+
+## Documentation
+
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/removeable-badge)

--- a/packages/removable-badge/README.md
+++ b/packages/removable-badge/README.md
@@ -2,9 +2,9 @@
 
 > Removable Badge Component
 
-[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
-[![NPM Downloads](https://img.shields.io/npm/dt/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
-[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/training-link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/removable-badge/package.json)
+[![Version](https://img.shields.io/npm/v/@availity/removable-badge.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/removable-badge.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
+[![Dependency Status](https://img.shields.io/librariesio/release/npm/@availity/removable-badge?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/removable-badge/package.json)
 
 ## Installation
 

--- a/packages/removable-badge/README.md
+++ b/packages/removable-badge/README.md
@@ -2,24 +2,24 @@
 
 > Removable Badge Component
 
-[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removeable-badge)
-[![NPM Downloads](https://img.shields.io/npm/dt/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removeable-badge)
-[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/training-link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/removeable-badge/package.json)
+[![Version](https://img.shields.io/npm/v/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
+[![NPM Downloads](https://img.shields.io/npm/dt/@availity/training-link.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/removable-badge)
+[![Dependecy Status](https://img.shields.io/librariesio/release/npm/@availity/training-link?style=for-the-badge)](https://github.com/Availity/availity-react/blob/master/packages/removable-badge/package.json)
 
 ## Installation
 
 ### NPM
 
 ```bash
-npm install @availity/removeable-badge
+npm install @availity/removable-badge
 ```
 
 ### Yarn
 
 ```bash
-yarn add @availity/removeable-badge
+yarn add @availity/removable-badge
 ```
 
 ## Documentation
 
-Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/removeable-badge)
+Check out more documentation at [availity.github.io](https://availity.github.io/availity-react/components/removable-badge)

--- a/packages/removable-badge/package.json
+++ b/packages/removable-badge/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@availity/removable-badge",
+  "version": "1.4.2",
+  "description": "Removable Badge Component",
+  "keywords": [
+    "react",
+    "availity",
+    "removable-badge"
+  ],
+  "homepage": "https://availity.github.io/availity-react/components/removable-badge",
+  "bugs": {
+    "url": "https://github.com/Availity/availity-react/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Availity/availity-react.git",
+    "directory": "packages/removable-badge"
+  },
+  "license": "MIT",
+  "author": "Ashlee Zeigler <ashlee.zeigler@availity.com>",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@availity/icon": "^0.10.2",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=16.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/removable-badge/package.json
+++ b/packages/removable-badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/removable-badge",
-  "version": "1.4.2",
+  "version": "1.0.0",
   "description": "Removable Badge Component",
   "keywords": [
     "react",

--- a/packages/removable-badge/src/RemovableBadge.tsx
+++ b/packages/removable-badge/src/RemovableBadge.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Badge, BadgeProps } from 'reactstrap';
+import Icon from '@availity/icon';
+
+export type RemovableBadgeProps = {
+  children: string;
+  value: string;
+  onRemove: (value: string) => void;
+} & BadgeProps;
+
+const RemovableBadge = ({ children, value, onRemove, ...rest }: RemovableBadgeProps): JSX.Element => (
+  <Badge data-testid="removable_badge" {...rest}>
+    <Icon data-testid="removable_badge_remove" name="cancel" onClick={() => onRemove(value)} />
+    {children}
+  </Badge>
+);
+
+export default RemovableBadge;

--- a/packages/removable-badge/src/RemovableBadgeList.tsx
+++ b/packages/removable-badge/src/RemovableBadgeList.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { BadgeProps } from 'reactstrap';
+import find from 'lodash/find';
+import without from 'lodash/without';
+import orderBy from 'lodash/orderBy';
+import RemovableBadge from './RemovableBadge';
+
+export type BadgeItem = {
+  displayText: string;
+  value: string;
+  order?: number;
+} & BadgeProps;
+
+export type Props = {
+  id?: string;
+  onRemove?: (badgeList: BadgeItem[]) => void;
+  badges: BadgeItem[];
+} & React.HTMLAttributes<HTMLElement>;
+
+const RemovableBadgeList = ({ id, badges, onRemove, ...rest }: Props): JSX.Element => {
+  const [badgeList, setBadgeList] = useState(badges);
+
+  useEffect(() => {
+    setBadgeList(badges);
+  }, [badges]);
+
+  const handleBadgeRemoved = (value: string) => {
+    const badgeToRemove = find(badgeList, (badge) => badge.value === value);
+
+    const newBadges = without(badgeList, badgeToRemove) as BadgeItem[];
+    setBadgeList(newBadges);
+
+    if (onRemove) {
+      onRemove(newBadges);
+    }
+  };
+
+  return (
+    <section data-testid="removable_badge_list_section" {...rest}>
+      {orderBy(badgeList, ['order'], ['asc']).map((badge, key) => (
+        <RemovableBadge
+          data-testid="removable_badge_list_item"
+          id={`${id || 'removable_badge_list'}_${badge.value}`}
+          key={`${badge.value}${key.toString()}`}
+          color={badge.color}
+          className="ml-1"
+          value={badge.value}
+          onRemove={handleBadgeRemoved}
+        >
+          {badge.displayText}
+        </RemovableBadge>
+      ))}
+    </section>
+  );
+};
+export default RemovableBadgeList;

--- a/packages/removable-badge/src/index.ts
+++ b/packages/removable-badge/src/index.ts
@@ -1,0 +1,2 @@
+export { default, RemovableBadgeProps } from './RemovableBadge';
+export { default as RemovableBadgeList, BadgeItem } from './RemovableBadgeList';

--- a/packages/removable-badge/src/tests/RemovableBadgeList.test.tsx
+++ b/packages/removable-badge/src/tests/RemovableBadgeList.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { BadgeItem, RemovableBadgeList } from '..';
+
+const badgeList: BadgeItem[] = [
+  { value: '1', color: 'primary', displayText: 'Test 1' },
+  { value: '2', color: 'success', displayText: 'Test 2' },
+  { value: '3', color: 'danger', displayText: 'Test 3' },
+  { value: '4', color: 'warning', displayText: 'Test 4' },
+  { value: '5', color: 'info', displayText: 'Test 5' },
+  { value: '6', color: 'light', displayText: 'Test 6' },
+  { value: '7', color: 'dark', displayText: 'Test 7' },
+  { value: '8', displayText: 'Test 9' },
+];
+
+describe('Removable Badge List', () => {
+  test('should render', async () => {
+    const { container, getByTestId, getAllByTestId } = render(<RemovableBadgeList badges={badgeList} />);
+
+    expect(container).toBeDefined();
+    expect(container).toMatchSnapshot();
+
+    const badgeListElement = await waitFor(() => getByTestId('removable_badge_list_section'));
+    expect(badgeListElement).not.toBeNull();
+
+    const badgeListItemElements = await waitFor(() => getAllByTestId('removable_badge_list_item'));
+    expect(badgeListItemElements.length).toBe(badgeList.length);
+  });
+
+  test('should call onRemove onClick', async () => {
+    const onRemove = jest.fn();
+
+    const { container, getByTestId, getAllByTestId } = render(
+      <RemovableBadgeList badges={badgeList} onRemove={onRemove} />
+    );
+
+    expect(container).toBeDefined();
+
+    const badgeListElement = await waitFor(() => getByTestId('removable_badge_list_section'));
+    expect(badgeListElement).not.toBeNull();
+
+    const badgeListItemElements = await waitFor(() => getAllByTestId('removable_badge_list_item'));
+    expect(badgeListItemElements).not.toBeNull();
+
+    const firstBadgeElement = getAllByTestId('removable_badge_remove');
+    fireEvent.click(firstBadgeElement[0]);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/removable-badge/src/tests/RemoveableBadge.test.tsx
+++ b/packages/removable-badge/src/tests/RemoveableBadge.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import RemovableBadge from '../RemovableBadge';
+
+describe('Removable Badge', () => {
+  test('should render', async () => {
+    const onRemove = jest.fn();
+    const displayText = 'My Badge';
+    const color = 'primary';
+
+    const { container, getByTestId } = render(
+      <RemovableBadge onRemove={onRemove} value="badgeValue" color={color}>
+        {displayText}
+      </RemovableBadge>
+    );
+
+    expect(container).toBeDefined();
+    expect(container).toMatchSnapshot();
+
+    const badgeElement = await waitFor(() => getByTestId('removable_badge'));
+    expect(badgeElement).not.toBeNull();
+    expect(badgeElement.textContent).toBe(displayText);
+    expect(badgeElement.className).toContain(color);
+  });
+
+  test('should call onRemove onClick', async () => {
+    const onRemove = jest.fn();
+    const displayText = 'My Badge';
+    const color = 'primary';
+
+    const { container, getByTestId } = render(
+      <RemovableBadge onRemove={onRemove} value="badgeValue" color={color}>
+        {displayText}
+      </RemovableBadge>
+    );
+
+    expect(container).toBeDefined();
+
+    const badgeElement = await waitFor(() => getByTestId('removable_badge'));
+    expect(badgeElement).not.toBeNull();
+
+    const removeIcon = await waitFor(() => getByTestId('removable_badge_remove'));
+    expect(removeIcon).not.toBeNull();
+    fireEvent.click(removeIcon);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/removable-badge/src/tests/__snapshots__/RemovableBadgeList.test.tsx.snap
+++ b/packages/removable-badge/src/tests/__snapshots__/RemovableBadgeList.test.tsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Removable Badge List should render 1`] = `
+<div>
+  <section
+    data-testid="removable_badge_list_section"
+  >
+    <span
+      class="ml-1 badge badge-primary"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_1"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 1
+    </span>
+    <span
+      class="ml-1 badge badge-success"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_2"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 2
+    </span>
+    <span
+      class="ml-1 badge badge-danger"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_3"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 3
+    </span>
+    <span
+      class="ml-1 badge badge-warning"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_4"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 4
+    </span>
+    <span
+      class="ml-1 badge badge-info"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_5"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 5
+    </span>
+    <span
+      class="ml-1 badge badge-light"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_6"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 6
+    </span>
+    <span
+      class="ml-1 badge badge-dark"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_7"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 7
+    </span>
+    <span
+      class="ml-1 badge badge-secondary"
+      data-testid="removable_badge_list_item"
+      id="removable_badge_list_8"
+    >
+      <i
+        aria-hidden="true"
+        class="icon icon-cancel"
+        data-testid="removable_badge_remove"
+        style="cursor: pointer;"
+      />
+      Test 9
+    </span>
+  </section>
+</div>
+`;

--- a/packages/removable-badge/src/tests/__snapshots__/RemoveableBadge.test.tsx.snap
+++ b/packages/removable-badge/src/tests/__snapshots__/RemoveableBadge.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Removable Badge should render 1`] = `
+<div>
+  <span
+    class="badge badge-primary"
+    data-testid="removable_badge"
+  >
+    <i
+      aria-hidden="true"
+      class="icon icon-cancel"
+      data-testid="removable_badge_remove"
+      style="cursor: pointer;"
+    />
+    My Badge
+  </span>
+</div>
+`;

--- a/packages/removable-badge/stories/RemovableBadge.stories.tsx
+++ b/packages/removable-badge/stories/RemovableBadge.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+import { Button } from 'reactstrap';
+import RemovableBadge, { BadgeItem, RemovableBadgeProps } from '../src';
+
+export default {
+  title: 'Components/Removable Badge',
+  parameters: {
+    docs: {},
+  },
+} as Meta;
+
+export const Default: Story<RemovableBadgeProps> = ({ value, color, displayText }) => {
+  const [badgeList, setBadgeList] = useState<BadgeItem[]>([{ value, color, displayText }]);
+
+  const remove = () => {
+    setBadgeList([]);
+  };
+
+  const onReset = () => {
+    setBadgeList([{ value, color, displayText }]);
+  };
+
+  return (
+    <>
+      {badgeList.map((badge) => (
+        <RemovableBadge key={badge.value} color={badge.color} value={badge.value} onRemove={remove}>
+          {displayText}
+        </RemovableBadge>
+      ))}
+
+      <section>
+        <Button color="secondary" onClick={onReset}>
+          Reset Badge
+        </Button>
+      </section>
+    </>
+  );
+};
+Default.storyName = 'default';
+Default.args = {
+  value: '1',
+  color: 'primary',
+  displayText: 'This is my button',
+};

--- a/packages/removable-badge/stories/RemovableBadgeList.stories.tsx
+++ b/packages/removable-badge/stories/RemovableBadgeList.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+import { Button } from 'reactstrap';
+import { RemovableBadgeList, BadgeItem, RemovableBadgeProps } from '../src';
+
+export default {
+  title: 'Components/Removable Badge/List',
+  parameters: {
+    docs: {},
+  },
+} as Meta;
+
+export const Default: Story<RemovableBadgeProps> = () => {
+  const defaultBadgeList: BadgeItem[] = [
+    { value: '1', color: 'primary', displayText: 'Test 1' },
+    { value: '2', color: 'success', displayText: 'Test 2' },
+    { value: '3', color: 'danger', displayText: 'Test 3' },
+    { value: '4', color: 'warning', displayText: 'Test 4' },
+    { value: '5', color: 'info', displayText: 'Test 5' },
+    { value: '6', color: 'light', displayText: 'Test 6' },
+    { value: '7', color: 'dark', displayText: 'Test 7' },
+    { value: '8', displayText: 'Test 9' },
+  ];
+  const [badgeList, setBadgeList] = useState<BadgeItem[]>(defaultBadgeList);
+
+  const remove = () => {
+    setBadgeList(defaultBadgeList);
+  };
+
+  const onRemoveBadge = (badgeList: BadgeItem[]) => {
+    setBadgeList(badgeList);
+  };
+
+  return (
+    <>
+      <RemovableBadgeList badges={badgeList} onRemove={onRemoveBadge} />
+      <section>
+        <Button color="secondary" onClick={remove}>
+          Reset Badges
+        </Button>
+      </section>
+    </>
+  );
+};
+Default.storyName = 'default';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import postcss from 'rollup-plugin-postcss';
 
-const packages = ['authorize', 'icon', 'training-link', 'table'];
+const packages = ['authorize', 'icon', 'removable-badge', 'training-link', 'table'];
 
 // rollup.config.js
 /**


### PR DESCRIPTION
We have built some component in our RCM specific libraries that can be placed here, as they are not product specific and potentially can be utilized by others. You might see more components being added here shortly :)


This is a removable badge component (or dismissible) that utilizes the ReactStrap badge. We use these for search filters, where removing them kicks off a search.

Thinking through this a bit more...would it make sense to just have this component be @availity/badge with options to make it removable? Just pulled this over from our stuff and trying to think what makes most sense in the long term. Open to opinions! :)