### PR TITLE
feat(hooks): add useWindowDimensions Hook

### DIFF
--- a/docusaurus/docs/components/hooks/use-window-dimensions.md
+++ b/docusaurus/docs/components/hooks/use-window-dimensions.md
@@ -1,0 +1,22 @@
+---
+title: useWindowDimensions
+---
+
+Hook that returns the window's current dimensions
+
+### Example
+
+```jsx
+import React from 'react';
+import { useWindowDimensions } from '@availity/hooks';
+
+const Example = () => {
+  const { height, width } = useWindowDimensions();
+  return (
+    <div>
+      {' '}
+      Current Window Dimensions: height: {height}, width: {width}
+    </div>
+  );
+};
+```

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -74,6 +74,7 @@ module.exports = {
               'components/hooks/use-permissions',
               'components/hooks/use-organizations',
               'components/hooks/use-providers',
+              'components/hooks/use-window-dimensions',
             ],
           },
           'components/icon',

--- a/packages/hooks/index.d.ts
+++ b/packages/hooks/index.d.ts
@@ -7,3 +7,4 @@ export { default as useCurrentUser } from './types/useCurrentUser';
 export { default as useProviders } from './types/useProviders';
 export { default as usePermissions } from './types/usePermissions';
 export { default as useOrganizations } from './types/useOrganizations';
+export { default as useWindowDimensions } from './types/useWindowDimensions';

--- a/packages/hooks/index.js
+++ b/packages/hooks/index.js
@@ -7,3 +7,4 @@ export { default as useCurrentUser } from './src/useCurrentUser';
 export { default as useProviders } from './src/useProviders';
 export { default as usePermissions } from './src/usePermissions';
 export { default as useOrganizations } from './src/useOrganizations';
+export { default as useWindowDimensions } from './src/useWindowDimensions';

--- a/packages/hooks/src/useWindowDimensions.js
+++ b/packages/hooks/src/useWindowDimensions.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const getWindowDimensions = () => {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+};
+
+const useWindowDimensions = () => {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowDimensions(getWindowDimensions());
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+};
+
+export default useWindowDimensions;

--- a/packages/hooks/stories/useWindowDimensions.stories.tsx
+++ b/packages/hooks/stories/useWindowDimensions.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { useWindowDimensions } from '..';
+
+const ListenerComponent = () => {
+  const { height, width } = useWindowDimensions();
+  return (
+    <div>
+      {' '}
+      Current Window Dimensions: height: {height}, width: {width}
+    </div>
+  );
+};
+
+export default {
+  title: 'Hooks/useWindowDimensions',
+  parameters: {
+    docs: {},
+  },
+} as Meta;
+
+export const Default: Story = () => <ListenerComponent />;
+Default.storyName = 'default';

--- a/packages/hooks/tests/useWindowDimensions.test.js
+++ b/packages/hooks/tests/useWindowDimensions.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, waitFor, act, fireEvent } from '@testing-library/react';
+import { useWindowDimensions } from '..';
+
+const Component = () => {
+  const { height, width } = useWindowDimensions();
+  return (
+    <div data-testid="window_dimensions">
+      {' '}
+      <span data-testid="window_height">{height}</span>
+      <span data-testid="window_width">{width}</span>
+    </div>
+  );
+};
+
+describe('useWindowDimensions', () => {
+  test('should show window dimensions', async () => {
+    const { getByTestId } = render(<Component />);
+
+    const element = getByTestId('window_dimensions');
+    expect(element).not.toBeNull();
+
+    act(() => {
+      window.innerWidth = 500;
+      window.innerHeight = 500;
+
+      fireEvent(window, new Event('resize'));
+    });
+
+    const heightEl = getByTestId('window_height');
+    const widthEl = getByTestId('window_width');
+
+    await waitFor(() => {
+      expect(heightEl.textContent).toBe('500');
+      expect(widthEl.textContent).toBe('500');
+    });
+  });
+});

--- a/packages/hooks/types/useWindowDimensions.d.ts
+++ b/packages/hooks/types/useWindowDimensions.d.ts
@@ -1,0 +1,9 @@
+export type Dimensions = {
+    width: number;
+    height: number
+};
+
+  declare function useWindowDimensions(): Dimensions;
+  
+  export default useWindowDimensions;
+  

--- a/packages/hooks/types/useWindowDimensions.d.ts
+++ b/packages/hooks/types/useWindowDimensions.d.ts
@@ -1,9 +1,8 @@
 export type Dimensions = {
-    width: number;
-    height: number
+  width: number;
+  height: number;
 };
 
-  declare function useWindowDimensions(): Dimensions;
-  
-  export default useWindowDimensions;
-  
+declare function useWindowDimensions(): Dimensions;
+
+export default useWindowDimensions;


### PR DESCRIPTION
This PR adds  a useWindowDimensions hook to @availity/hook. This hook listens to the window resize event and reports on the windows height and width. 