### PR TITLE
feat: add prop to allow inputValue to not be encoded

### DIFF
--- a/packages/reactstrap-validation-select/src/AvResourceSelect.js
+++ b/packages/reactstrap-validation-select/src/AvResourceSelect.js
@@ -42,7 +42,7 @@ class AvResourceSelect extends Component {
         variables: {
           perPage: this.props.itemsPerPage,
           filters: {
-            q: encodeURIComponent(inputValue),
+            q: this.props.encodeSearchValue ? encodeURIComponent(inputValue) : inputValue,
           },
         },
       };
@@ -62,7 +62,7 @@ class AvResourceSelect extends Component {
       }
     } else {
       params = {
-        q: encodeURIComponent(inputValue),
+        q: this.props.encodeSearchValue ? encodeURIComponent(inputValue) : inputValue,
         limit: this.props.itemsPerPage,
         customerId: this.props.customerId,
       };
@@ -260,11 +260,13 @@ AvResourceSelect.propTypes = {
   minCharsToSearch: PropTypes.number,
   onFocus: PropTypes.func,
   waitUntilFocused: PropTypes.bool,
+  encodeSearchValue: PropTypes.bool,
 };
 
 AvResourceSelect.defaultProps = {
   delay: 350,
   itemsPerPage: 50,
+  encodeSearchValue: true,
 };
 
 export default AvResourceSelect;

--- a/packages/reactstrap-validation-select/types/AvResourceSelect.d.ts
+++ b/packages/reactstrap-validation-select/types/AvResourceSelect.d.ts
@@ -30,6 +30,7 @@ export interface AvResourceSelectProps {
   graphqlConfig?: GraphQLConfigType;
   minCharsToSearch?: number;
   waitUntilFocused?: boolean;
+  encodeSearchValue?: boolean;
 }
 
 declare const AvResourceSelect: React.ComponentType<AvResourceSelectProps>;

--- a/packages/select/src/ResourceSelect.js
+++ b/packages/select/src/ResourceSelect.js
@@ -30,6 +30,7 @@ const ResourceSelect = ({
   pageAll,
   pageAllSearchBy,
   searchTerm,
+  encodeSearchValue,
   ...rest
 }) => {
   const { setFieldValue } = useFormikContext();
@@ -89,7 +90,7 @@ const ResourceSelect = ({
         variables: {
           perPage: itemsPerPage,
           filters: {
-            [searchTerm]: encodeURIComponent(inputValue),
+            [searchTerm]: encodeSearchValue ? encodeURIComponent(inputValue) : inputValue,
           },
         },
       };
@@ -109,7 +110,7 @@ const ResourceSelect = ({
       }
     } else {
       params = {
-        [searchTerm]: encodeURIComponent(inputValue),
+        [searchTerm]: encodeSearchValue ? encodeURIComponent(inputValue) : inputValue,
         limit: itemsPerPage,
         customerId: rest.customerId,
       };
@@ -341,6 +342,7 @@ ResourceSelect.propTypes = {
   pageAllSearchBy: PropTypes.func,
   onError: PropTypes.func,
   searchTerm: PropTypes.string,
+  encodeSearchValue: PropTypes.bool,
 };
 
 ResourceSelect.defaultProps = {
@@ -352,6 +354,7 @@ ResourceSelect.defaultProps = {
   shouldSearch: true,
   pageAll: false,
   searchTerm: 'q',
+  encodeSearchValue: true,
 };
 
 const ucFirst = (str) => str && str.charAt(0).toUpperCase() + str.slice(1);

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -651,6 +651,114 @@ describe('ResourceSelect', () => {
     });
   });
 
+  it('does encode the search value when encodeSearchValue is true', async () => {
+    avRegionsApi.post.mockResolvedValueOnce({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'TX',
+            value: 'Texas',
+          },
+          {
+            id: 'WA',
+            value: 'Washington',
+          },
+        ],
+      },
+    });
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          'test-form-input': undefined,
+        }}
+        onSubmit={onSubmit}
+      >
+        <ResourceSelect
+          name="test-form-input"
+          resource={avRegionsApi}
+          classNamePrefix="test__regions"
+          labelKey="value"
+          valueKey="id"
+          getResult="regions"
+          method="POST"
+          searchTerm="myCustomSearchParam"
+          inputValue="test example"
+          encodeSearchValue
+        />
+      </Form>
+    );
+
+    const regionsSelect = container.querySelector('.test__regions__control');
+
+    fireEvent.focus(regionsSelect);
+    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+
+    await waitFor(() => expect(getByText('Florida')).toBeDefined());
+
+    expect(avRegionsApi.post).toHaveBeenCalledTimes(1);
+    expect(avRegionsApi.post.mock.calls[0][0].myCustomSearchParam).toEqual('test%20example');
+  });
+
+  it('does not encode the search value when encodeSearchValue is false', async () => {
+    avRegionsApi.post.mockResolvedValueOnce({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'TX',
+            value: 'Texas',
+          },
+          {
+            id: 'WA',
+            value: 'Washington',
+          },
+        ],
+      },
+    });
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          'test-form-input': undefined,
+        }}
+        onSubmit={onSubmit}
+      >
+        <ResourceSelect
+          name="test-form-input"
+          resource={avRegionsApi}
+          classNamePrefix="test__regions"
+          labelKey="value"
+          valueKey="id"
+          getResult="regions"
+          method="POST"
+          searchTerm="myCustomSearchParam"
+          inputValue="test example"
+          encodeSearchValue={false}
+        />
+      </Form>
+    );
+
+    const regionsSelect = container.querySelector('.test__regions__control');
+
+    fireEvent.focus(regionsSelect);
+    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+
+    await waitFor(() => expect(getByText('Florida')).toBeDefined());
+
+    expect(avRegionsApi.post).toHaveBeenCalledTimes(1);
+    expect(avRegionsApi.post.mock.calls[0][0].myCustomSearchParam).toEqual('test example');
+  });
+
   it('applies valueKey override', async () => {
     const { container, getByText } = renderSelect({
       resource: { all: async () => [{ label: 'test', test: 'value' }] },

--- a/packages/select/types/ResourceSelect.d.ts
+++ b/packages/select/types/ResourceSelect.d.ts
@@ -43,6 +43,7 @@ export interface ResourceSelectProps<T> extends SelectFieldProps<T> {
   pageAllSearchBy?: (previousOptions: any[], inputValue: string) => any[];
   onError?: (error: Error) => void;
   searchTerm?: string;
+  encodeSearchValue?: boolean;
 }
 
 declare class ResourceSelect<T> extends React.Component<ResourceSelectProps<T>> {


### PR DESCRIPTION
Currently the search term a user enters will be encoded before it is sent to the api. I added a prop, `encodeSearchValue`, which will allow users to turn off this behavior. I made the default value `true` in order to not break current implementations
