### PR TITLE
fix: update proptype and typedef for helpMessage

### DIFF
--- a/packages/reactstrap-validation-select/src/AvSelectField.js
+++ b/packages/reactstrap-validation-select/src/AvSelectField.js
@@ -76,7 +76,7 @@ AvSelectField.propTypes = {
   label: PropTypes.node,
   labelHidden: PropTypes.bool,
   id: PropTypes.string,
-  helpMessage: PropTypes.string,
+  helpMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   feedbackClass: PropTypes.string,
   groupClass: PropTypes.string,
   labelClass: PropTypes.string,

--- a/packages/reactstrap-validation-select/types/AvSelectField.d.ts
+++ b/packages/reactstrap-validation-select/types/AvSelectField.d.ts
@@ -1,15 +1,17 @@
+import { ComponentType, ReactNode } from 'react';
 import { AvSelectProps } from './AvSelect';
 
 export interface AvSelectFieldProps extends AvSelectProps {
-  label?: React.ReactNode;
+  label?: ReactNode;
   labelHidden?: boolean;
   id?: string;
   feedbackClass?: string;
   groupClass?: string;
   labelClass?: string;
   name: string;
+  helpMessage?: ReactNode;
 }
 
-declare const AvSelectField: React.ComponentType<AvSelectFieldProps>;
+declare const AvSelectField: ComponentType<AvSelectFieldProps>;
 
 export default AvSelectField;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -400,7 +400,7 @@ Select.propTypes = {
   autofill: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   allowSelectAll: PropTypes.bool,
   waitUntilFocused: PropTypes.bool,
-  helpMessage: PropTypes.string,
+  helpMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   feedback: PropTypes.bool,
   placeholder: PropTypes.string,
   components: PropTypes.object,

--- a/packages/select/src/SelectField.js
+++ b/packages/select/src/SelectField.js
@@ -55,7 +55,7 @@ SelectField.propTypes = {
   feedbackClass: PropTypes.string,
   groupClass: PropTypes.string,
   helpId: PropTypes.string,
-  helpMessage: PropTypes.string,
+  helpMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   label: PropTypes.node,
   labelClass: PropTypes.string,
   labelHidden: PropTypes.bool,

--- a/packages/select/types/Select.d.ts
+++ b/packages/select/types/Select.d.ts
@@ -22,7 +22,7 @@ export interface SelectProps<T> extends Props<{}> {
   validate?: FieldValidator;
   autofill?: boolean | object;
   creatable?: boolean;
-  helpMessage?: string;
+  helpMessage?: React.ReactNode;
   feedback?: boolean;
 }
 

--- a/packages/select/types/SelectField.d.ts
+++ b/packages/select/types/SelectField.d.ts
@@ -8,7 +8,6 @@ export interface SelectFieldProps<T> extends SelectProps<T> {
   groupClass?: string;
   helpId?: string;
   required?: boolean;
-  helpMessage?: string;
 }
 
 declare class SelectField<T = { [key: string]: any }> extends React.Component<SelectFieldProps<T>> {}


### PR DESCRIPTION
Update the PropType and TypeScript definition for the `helpMessage` prop to allow for JSX elements to be passed in
