### PR TITLE
fix(badge): updated removable badge to be a named import

### DIFF
--- a/packages/badge/src/index.ts
+++ b/packages/badge/src/index.ts
@@ -1,2 +1,2 @@
-export { default, RemovableBadgeProps } from './RemovableBadge';
+export { default as RemovableBadge, RemovableBadgeProps } from './RemovableBadge';
 export { default as RemovableBadgeList, BadgeItem } from './RemovableBadgeList';


### PR DESCRIPTION
Since this package will potentially contain more than just the removable badge, this updates this to be a named import vs a default import. I missed this in the initial code review. 
