### PR TITLE
docs: default panel position to bottom

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+
+addons.setConfig({
+  showPanel: true,
+  panelPosition: 'bottom',
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,22 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-import { themes } from '@storybook/theming';
-
 import './config.scss';
-
-export const parameters = {
-  docs: {
-    theme: themes.dark,
-  },
-  options: {
-    name: 'availity-react',
-    url: 'https://github.com/availity/availity-react',
-    goFullScreen: false,
-    showStoriesPanel: true,
-    showAddonPanel: true,
-    showSearchBox: false,
-    addonPanelInRight: true,
-  },
-};
 
 // Make sure we are in the browser before starting
 if (typeof global.process === 'undefined') {


### PR DESCRIPTION
Moves the default position for the addon bar in storybook to the bottom
