### PR TITLE
On change for favorites provider

### DIFF
--- a/packages/favorites/src/FavoriteHeart.module.scss
+++ b/packages/favorites/src/FavoriteHeart.module.scss
@@ -22,6 +22,8 @@ $heartSize: 1.125rem;
 .root {
   height: $rootSize;
   width: $rootSize;
+  min-height: $rootSize;
+  min-width: $rootSize;
   position: relative;
 }
 
@@ -32,6 +34,8 @@ $heartSize: 1.125rem;
   margin: 0;
   height: $rootSize;
   width: $rootSize;
+  min-height: $rootSize;
+  min-width: $rootSize;
   display: block;
   border-radius: 0.25rem;
 }

--- a/packages/favorites/src/FavoriteHeart.tsx
+++ b/packages/favorites/src/FavoriteHeart.tsx
@@ -41,14 +41,25 @@ export const FavoriteHeart = ({
   name,
   onChange,
   onMouseDown,
+  size,
 }: {
   id: string;
+
+  /**
+   * @param {string} props.name The name of the item to be favorited. Used to create an accessible label.
+   */
   name: string;
   onChange?: (
     isFavorited: boolean,
     event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>
   ) => void;
   onMouseDown?: (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
+
+  /**
+   * @param {string} props.size  A CSS length unit like '2rem' or '32px' to be applied to the height and
+   * width of the outer container. Sizes smaller '1.5rem' or equivalent will have no effect.
+   */
+  size?: string;
 }): JSX.Element => {
   const { isFavorited, isLastClickedFavorite, status, toggleFavorite } = useFavorites(id);
 
@@ -79,7 +90,7 @@ export const FavoriteHeart = ({
     !isLastClickedFavorite && (status === 'initLoading' || status === 'reloading') ? 'not-allowed' : undefined;
 
   return (
-    <div className={css.root}>
+    <div className={css.root} style={{ height: size, width: size }}>
       <div className={css.icons}>{icons[iconKey]}</div>
       <span
         aria-live={isLastClickedFavorite && (status === 'reloading' || status === 'error') ? 'polite' : 'off'}
@@ -94,7 +105,7 @@ export const FavoriteHeart = ({
 
       <Tooltip content="Add to My Favorites" data-testid={`av-favorite-heart-${id}-tooltip`}>
         <input
-          style={{ cursor }}
+          style={{ cursor, height: size, width: size }}
           className={css.input}
           onKeyPress={handleKeyPress}
           type="checkbox"

--- a/packages/favorites/src/context/FavoritesProvider.tsx
+++ b/packages/favorites/src/context/FavoritesProvider.tsx
@@ -17,7 +17,13 @@ type FavoritesContextType = {
 
 const FavoritesContext = createContext<FavoritesContextType | null>(null);
 
-export const FavoritesProvider = ({ children }: { children: ReactNode }): JSX.Element => {
+export const FavoritesProvider = ({
+  children,
+  onFavoritesChange,
+}: {
+  children: ReactNode;
+  onFavoritesChange?: (favorites: Favorite[]) => void;
+}): JSX.Element => {
   const [lastClickedFavoriteId, setlastClickedFavoriteId] = useState<string>('');
 
   const queryClient = useQueryClient();
@@ -45,6 +51,7 @@ export const FavoritesProvider = ({ children }: { children: ReactNode }): JSX.El
       });
 
       sendUpdateMessage(response.favorites);
+      onFavoritesChange?.(response.favorites);
     }
   };
 
@@ -70,6 +77,7 @@ export const FavoritesProvider = ({ children }: { children: ReactNode }): JSX.El
     });
 
     sendUpdateMessage(response.favorites);
+    onFavoritesChange?.(response.favorites);
 
     const isFavorited = response.favorites.find((f) => f.id === id);
 

--- a/packages/favorites/tests/FavoriteHeart.test.js
+++ b/packages/favorites/tests/FavoriteHeart.test.js
@@ -513,4 +513,102 @@ describe('FavoriteHeart', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
+
+  test('should call onFavoritesChange when favorited', async () => {
+    const initialFavoritedId = 'my_favorite_id';
+
+    avSettingsApi.getApplication = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          settings: [
+            {
+              favorites: [],
+            },
+          ],
+        },
+      })
+    );
+
+    avSettingsApi.setApplication = jest.fn().mockResolvedValue({
+      data: {
+        favorites: [
+          {
+            id: initialFavoritedId,
+            pos: 0,
+          },
+        ],
+      },
+    });
+
+    const handleFavoritesChange = jest.fn(() => {});
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <Favorites onFavoritesChange={handleFavoritesChange}>
+          <FavoriteHeart id={initialFavoritedId} />
+        </Favorites>
+      </QueryClientProvider>
+    );
+
+    const heart = container.querySelector(`#av-favorite-heart-${initialFavoritedId}`);
+
+    expect(heart).toBeDefined();
+
+    await waitFor(() => expect(heart).not.toBeChecked());
+
+    fireEvent.click(heart);
+
+    await waitFor(() => expect(heart).toBeChecked());
+
+    expect(handleFavoritesChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('should call onFavoritesChange when unfavorited', async () => {
+    const initialFavoritedId = 'my_favorite_id';
+
+    avSettingsApi.getApplication = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          settings: [
+            {
+              favorites: [
+                {
+                  id: initialFavoritedId,
+                  pos: 0,
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    avSettingsApi.setApplication = jest.fn().mockResolvedValue({
+      data: {
+        favorites: [],
+      },
+    });
+
+    const handleFavoritesChange = jest.fn(() => {});
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <Favorites onFavoritesChange={handleFavoritesChange}>
+          <FavoriteHeart id={initialFavoritedId} />
+        </Favorites>
+      </QueryClientProvider>
+    );
+
+    const heart = container.querySelector(`#av-favorite-heart-${initialFavoritedId}`);
+
+    expect(heart).toBeDefined();
+
+    await waitFor(() => expect(heart).toBeChecked());
+
+    fireEvent.click(heart);
+
+    await waitFor(() => expect(heart).not.toBeChecked());
+
+    expect(handleFavoritesChange).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
- Add `onFavoritesChange` handler prop to FavoritesProvider which is called after adding or removing a favorites is completed
- Add tests for `onFavoritesChange`
- Add `size` prop to FavoritesHeart. Can be used to override the overall size of the heart icon container. I'm using this to adjust the size to match the height of the styled link displayed next to it.
