### PR TITLE
refactor(spaces): add note about multiple spaces being associated wit…

### DIFF
--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -149,6 +149,10 @@ const Spaces = ({ query, variables, clientId, spaceIds, payerIds, children, spac
         }
       }
 
+      // Note: If a payerId is associated with more than one payer space, the
+      // order in which they are returned should not be relied upon.If a
+      // specific payer space is required, you'll need to filter the list that
+      // is returned.
       if (payerIdsToQuery.size > 0) {
         const vars = { ...variables, payerIDs: [...payerIdsToQuery.keys()] };
         const spacesByPayerIds = await getAllSpaces({


### PR DESCRIPTION
…h a payerId

BREAKING CHANGE: If a payerId is associated with more than one payer space, the order in which they are returned should not be relied upon.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/availity/availity-react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Make sure your code passed the conventional commits check. Read more about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
