### PR TITLE
Fix/graphql string

### DIFF
--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -328,6 +328,10 @@ Spaces.defaultProps = {
         }
 
         ... on Navigation {
+          icons {
+            dashboard
+            navigation
+          }
           images {
             promotional
           }

--- a/packages/spaces/src/Spaces.js
+++ b/packages/spaces/src/Spaces.js
@@ -328,9 +328,6 @@ Spaces.defaultProps = {
         }
 
         ... on Navigation {
-          icons {
-
-          }
           images {
             promotional
           }


### PR DESCRIPTION
Fixing the graphql query string that is used for spaces, which is currently invalid.