### PR TITLE
Fix/table checkboxes -  Fix issue where checkbox checks are not showing up in UI Kit v4

### DIFF
--- a/packages/table/src/IndeterminateCheckbox.tsx
+++ b/packages/table/src/IndeterminateCheckbox.tsx
@@ -37,10 +37,7 @@ const IndeterminateCheckbox = React.forwardRef(
 
     return (
       <>
-        <label className="custom-control custom-checkbox">
-          <input type="checkbox" ref={combinedRef} {...rest} className="custom-control-input" />
-          <span className="custom-control-label" />
-        </label>
+          <input type="checkbox" ref={combinedRef} {...rest} />
       </>
     );
   }

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -591,21 +591,13 @@ exports[`Table should render selectable table 1`] = `
           <div
             class="text-center"
           >
-            <label
-              class="custom-control custom-checkbox"
-            >
-              <input
-                aria-label="Select all records"
-                class="custom-control-input"
-                data-testid="table_header_select_all"
-                style="cursor: pointer;"
-                title="Toggle All Rows Selected"
-                type="checkbox"
-              />
-              <span
-                class="custom-control-label"
-              />
-            </label>
+            <input
+              aria-label="Select all records"
+              data-testid="table_header_select_all"
+              style="cursor: pointer;"
+              title="Toggle All Rows Selected"
+              type="checkbox"
+            />
           </div>
         </th>
         <th
@@ -654,21 +646,13 @@ exports[`Table should render selectable table 1`] = `
           <div
             class="text-center"
           >
-            <label
-              class="custom-control custom-checkbox"
-            >
-              <input
-                aria-label="Select record"
-                class="custom-control-input"
-                data-testid="table_header_select_row_0"
-                style="cursor: pointer;"
-                title="Toggle Row Selected"
-                type="checkbox"
-              />
-              <span
-                class="custom-control-label"
-              />
-            </label>
+            <input
+              aria-label="Select record"
+              data-testid="table_header_select_row_0"
+              style="cursor: pointer;"
+              title="Toggle Row Selected"
+              type="checkbox"
+            />
           </div>
         </td>
         <td
@@ -704,21 +688,13 @@ exports[`Table should render selectable table 1`] = `
           <div
             class="text-center"
           >
-            <label
-              class="custom-control custom-checkbox"
-            >
-              <input
-                aria-label="Select record"
-                class="custom-control-input"
-                data-testid="table_header_select_row_1"
-                style="cursor: pointer;"
-                title="Toggle Row Selected"
-                type="checkbox"
-              />
-              <span
-                class="custom-control-label"
-              />
-            </label>
+            <input
+              aria-label="Select record"
+              data-testid="table_header_select_row_1"
+              style="cursor: pointer;"
+              title="Toggle Row Selected"
+              type="checkbox"
+            />
           </div>
         </td>
         <td
@@ -754,21 +730,13 @@ exports[`Table should render selectable table 1`] = `
           <div
             class="text-center"
           >
-            <label
-              class="custom-control custom-checkbox"
-            >
-              <input
-                aria-label="Select record"
-                class="custom-control-input"
-                data-testid="table_header_select_row_2"
-                style="cursor: pointer;"
-                title="Toggle Row Selected"
-                type="checkbox"
-              />
-              <span
-                class="custom-control-label"
-              />
-            </label>
+            <input
+              aria-label="Select record"
+              data-testid="table_header_select_row_2"
+              style="cursor: pointer;"
+              title="Toggle Row Selected"
+              type="checkbox"
+            />
           </div>
         </td>
         <td


### PR DESCRIPTION
This is a workaround to an issue where the white check in the checkbox does not show up when it is selected.

The checkbox utilizes classes from availity-ukit ^4.0.0, which seems to be the issue. Version 4 loads the checks via an SVG, which is different than how it was loaded in version 3. 
http://availity.github.io/availity-uikit/v4/components#Forms-Checkboxes 

This change just updates it to not utilize those classes until we have appropriate time to research the issue. 

Issue: 
![image](https://user-images.githubusercontent.com/8000861/171674308-0f6462fc-df52-4b7c-8e1d-4770d8f1b78a.png)

After Fix:
![image](https://user-images.githubusercontent.com/8000861/171674226-7be180d5-dfbc-4df6-9e20-42c1a4064156.png)
