### PR TITLE
feat(hooks): add new hook for 508 compliant event handlers for tabs

### DIFF
--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -116,4 +116,4 @@ The currently active tab.
 
 ### `options?: {customFindFn?: CustomFindFunction, customSelector?: string}`
 
-Optional overrides for certain features, customFindFn if you have a tab list of objects you may need to use a function like Lodash's isEqual. Or a custom selector to override the id's we are checking in some cases. If you need additional overrides PR's are welcome.
+Optional overrides for certain features, customFindFn if you have a tab list of objects you will need to use a function like Lodash's isEqual or your own custom find logic, see tests for examples. Or a custom selector to override the id's we are checking in some cases. If you need additional overrides PR's are welcome.

--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -11,27 +11,36 @@ import * as React from 'react';
 import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
 import classnames from 'classnames';
 
-const Example = ({initialActive}) => {
+const Example = ({ initialActive }) => {
   const [activeTab, setActiveTab] = useState(initialActive);
 
-  const toggle = tab => {
-    if(activeTab !== tab) setActiveTab(tab);
-  }
-  const tabs = ['1', '2']
+  const toggle = (tab) => {
+    if (activeTab !== tab) setActiveTab(tab);
+  };
+  const tabs = ['one', 'two'];
 
-  const {handleKeys: firstHandler, handleFocus: navHandler} = useTabsEventHandlers('1', tabs, setActiveTab, activeTab)
-  const {handleKeys: secondHandler} = useTabsEventHandlers('2', tabs, setActiveTab, activeTab)
+  const { handleKeys: firstHandler, handleFocus: navHandler } = useTabsEventHandlers(
+    'one',
+    tabs,
+    setActiveTab,
+    activeTab
+  );
+  const { handleKeys: secondHandler } = useTabsEventHandlers('two', tabs, setActiveTab, activeTab);
   return (
     <>
-    <button type='button' id='sibling-above' tabIndex={0}>Some Stuff</button>
-      <Nav onFocus={navHandler} id='tabListParentNav' tabs>
+      <Button type="button" id="sibling-above" tabIndex={0}>
+        Some Stuff
+      </Button>
+      <Nav onFocus={navHandler} id="tabListParentNav" tabs>
         <NavItem>
           <NavLink
-            id='1-tab'
+            id="one-tab"
             tabIndex={0}
-            onKeyDown = {firstHandler}
-            className={classnames({ active: activeTab === '1' })}
-            onClick={() => { toggle('1'); }}
+            onKeyDown={firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => {
+              toggle('one');
+            }}
           >
             Tab1
           </NavLink>
@@ -40,23 +49,25 @@ const Example = ({initialActive}) => {
           <NavLink
             onKeyDown={secondHandler}
             tabIndex={0}
-            id='2-tab'
-            className={classnames({ active: activeTab === '2' })}
-            onClick={() => { toggle('2'); }}
+            id="two-tab"
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => {
+              toggle('two');
+            }}
           >
-          More Tabs
+            More Tabs
           </NavLink>
         </NavItem>
       </Nav>
-      <TabContent data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
-        <TabPane tabId="1">
+      <TabContent tabIndex={0} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
+        <TabPane tabId="one">
           <Row>
             <Col sm="12">
               <h4>Tab 1 Contents</h4>
             </Col>
           </Row>
         </TabPane>
-        <TabPane tabId="2">
+        <TabPane tabId="two">
           <Row>
             <Col sm="6">
               <Card body>
@@ -75,17 +86,20 @@ const Example = ({initialActive}) => {
           </Row>
         </TabPane>
       </TabContent>
-      <button type='button' id='sibling-below' tabIndex={0}>Other Stuff</button>
+      <Button type="button" id="sibling-below" tabIndex={0}>
+        Other Stuff
+      </Button>
     </>
   );
-}
+};
+
 ```
 
 ## Props
 
 ### `tab: Tab`
 
-The tab component to attach the onKeyDown listener to. This should be an element of a list of Tabs (i.e. if your list has objects this tab should be referentially equal to one element in the list). Tabs can be either strings, like in the example, or can be objects with a name property (and any other properties you need but they will be safely ignored by this hook, but name is required)
+The tab component to attach the onKeyDown listener to. This should be an element of a list of Tabs (i.e. if your list has objects this tab should be referentially equal to one element in the list). Tabs can be either strings, like in the example, or can be objects with a name property (and any other properties you need but they will be safely ignored by this hook, but name is required). Also note that the NavLinks must use the tab or tab.name as part of building their elementID so any tab name must make a valid id (i.e. tabs can't be ['1', '2', '3'] but instead ['one', 'two', 'three] because 1-tab is not a valid id)
 
 ### `tabs: Tab[]`
 

--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -2,7 +2,7 @@
 title: useTabsEventHandlers
 ---
 
-Hook that returns keydown event handler for a tab and a focus event handler for the nav element containing your tabs. Intended for use with Reactstrap nav and tab components (see example for full list) but should be configurable if you are using alternate tab components. Tested and compatible with proxy-based state management libraries(you may need to use the custom find function to ensure that you are return a referentially identical tab from your tab list) as well as apps using plain context for managing state. Note that this hook relies on users adding tabIndex = 0 for their NavLink Reactstrap component and a few other conventions related to the way the tab element Ids are created. 
+Hook that returns keydown event handler for a tab. Intended for use with Reactstrap tab components (see example for full list) but should be configurable if you are using alternate tab components. Tested and compatible with proxy-based state management libraries(you may need to use the custom find function to ensure that you are return a referentially identical tab from your tab list) as well as apps using plain context for managing state. Note that this hook relies on users adding tabIndex = 0 for active tab and tabIndex = -1 for inactive tabs and a few other conventions related to the way the tab element Ids are created. 
 
 ### Example
 
@@ -19,23 +19,23 @@ const Example = ({ initialActive }) => {
   };
   const tabs = ['one', 'two'];
 
-  const { handleKeys: firstHandler, handleFocus: navHandler } = useTabsEventHandlers(
+  const firstHandler = useTabsEventHandlers(
     'one',
     tabs,
     setActiveTab,
     activeTab
   );
-  const { handleKeys: secondHandler } = useTabsEventHandlers('two', tabs, setActiveTab, activeTab);
+  const secondHandler = useTabsEventHandlers('two', tabs, setActiveTab, activeTab);
   return (
     <>
       <Button type="button" id="sibling-above" tabIndex={0}>
         Some Stuff
       </Button>
-      <Nav onFocus={navHandler} id="tabListParentNav" tabs>
+      <Nav id="tabListParentNav" tabs>
         <NavItem>
           <NavLink
             id="one-tab"
-            tabIndex={0}
+            tabIndex={activeTab === 'one' ? 0 : -1}
             onKeyDown={firstHandler}
             className={classnames({ active: activeTab === 'one' })}
             onClick={() => {
@@ -48,7 +48,7 @@ const Example = ({ initialActive }) => {
         <NavItem>
           <NavLink
             onKeyDown={secondHandler}
-            tabIndex={0}
+            tabIndex={activeTab === 'two' ? 0 : -1}
             id="two-tab"
             className={classnames({ active: activeTab === 'two' })}
             onClick={() => {
@@ -59,7 +59,7 @@ const Example = ({ initialActive }) => {
           </NavLink>
         </NavItem>
       </Nav>
-      <TabContent tabIndex={0} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
+      <TabContent tabIndex={activeTab == 'one' ? 0 : undefined} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
         <TabPane tabId="one">
           <Row>
             <Col sm="12">
@@ -114,6 +114,12 @@ This is the function used to update your state management with any newly active 
 
 The currently active tab.
 
-### `options?: {customFindFn?: CustomFindFunction, customSelector?: string}`
+### `options?: {customFindFn?: CustomFindFunction}`
 
-Optional overrides for certain features, customFindFn if you have a tab list of objects you will need to use a function like Lodash's isEqual or your own custom find logic, see tests for examples. Or a custom selector to override the id's we are checking in some cases. If you need additional overrides PR's are welcome.
+Optional overrides for certain features, customFindFn if you have a tab list of objects you will need to use a function like Lodash's isEqual or your own custom find logic, see tests for examples. If you need additional overrides PR's are welcome.
+
+## Returns
+
+### handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>
+
+Used as a keydown event handler on a HTML anchor tag. Type signature for event handler is (event: React.KeyboardEvent<HTMLAnchorElement>) => void. 

--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -120,6 +120,6 @@ Optional overrides for certain features, customFindFn if you have a tab list of 
 
 ## Returns
 
-### handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>
+### `handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>`
 
-Used as a keydown event handler on a HTML anchor tag. Type signature for event handler is (event: React.KeyboardEvent<HTMLAnchorElement>) => void. 
+`Used as a keydown event handler on a HTML anchor tag. Type signature for event handler is (event: React.KeyboardEvent<HTMLAnchorElement>) => void`. 

--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -1,0 +1,105 @@
+---
+title: useTabsEventHandlers
+---
+
+Hook that returns keydown event handler for a tab and a focus event handler for the nav element containing your tabs. Intended for use with Reactstrap nav and tab components (see example for full list) but should be configurable if you are using alternate tab components. Tested and compatible with proxy-based state management libraries(you may need to use the custom find function to ensure that you are return a referentially identical tab from your tab list) as well as apps using plain context for managing state. Note that this hook relies on users adding tabIndex = 0 for their NavLink Reactstrap component and a few other conventions related to the way the tab element Ids are created. 
+
+### Example
+
+```jsx
+import * as React from 'react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+
+const Example = ({initialActive}) => {
+  const [activeTab, setActiveTab] = useState(initialActive);
+
+  const toggle = tab => {
+    if(activeTab !== tab) setActiveTab(tab);
+  }
+  const tabs = ['1', '2']
+
+  const {handleKeys: firstHandler, handleFocus: navHandler} = useTabsEventHandlers('1', tabs, setActiveTab, activeTab)
+  const {handleKeys: secondHandler} = useTabsEventHandlers('2', tabs, setActiveTab, activeTab)
+  return (
+    <>
+    <button type='button' id='sibling-above' tabIndex={0}>Some Stuff</button>
+      <Nav onFocus={navHandler} id='tabListParentNav' tabs>
+        <NavItem>
+          <NavLink
+            id='1-tab'
+            tabIndex={0}
+            onKeyDown = {firstHandler}
+            className={classnames({ active: activeTab === '1' })}
+            onClick={() => { toggle('1'); }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={0}
+            id='2-tab'
+            className={classnames({ active: activeTab === '2' })}
+            onClick={() => { toggle('2'); }}
+          >
+          More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
+        <TabPane tabId="1">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="2">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <button type='button' id='sibling-below' tabIndex={0}>Other Stuff</button>
+    </>
+  );
+}
+```
+
+## Props
+
+### `tab: Tab`
+
+The tab component to attach the onKeyDown listener to. This should be an element of a list of Tabs (i.e. if your list has objects this tab should be referentially equal to one element in the list). Tabs can be either strings, like in the example, or can be objects with a name property (and any other properties you need but they will be safely ignored by this hook, but name is required)
+
+### `tabs: Tab[]`
+
+The complete list of your available tabs.
+
+
+### `updaterFn: UpdaterFn`
+
+This is the function used to update your state management with any newly active tab. In the example the updaterFn is simply the function returned by useState. In other solutions with a centralized state management library this may be the updating function for that centralized state (like with Mobx or Redux).
+
+### `active: Tab`
+
+The currently active tab.
+
+### `options?: {customFindFn?: CustomFindFunction, customSelector?: string}`
+
+Optional overrides for certain features, customFindFn if you have a tab list of objects you may need to use a function like Lodash's isEqual. Or a custom selector to override the id's we are checking in some cases. If you need additional overrides PR's are welcome.

--- a/packages/hooks/index.d.ts
+++ b/packages/hooks/index.d.ts
@@ -8,3 +8,4 @@ export { default as useProviders } from './types/useProviders';
 export { default as usePermissions } from './types/usePermissions';
 export { default as useOrganizations } from './types/useOrganizations';
 export { default as useWindowDimensions } from './types/useWindowDimensions';
+export { Tab, CustomFindFunction, default as useTabsEventHandlers } from './types/useTabsEventHandlers';

--- a/packages/hooks/index.js
+++ b/packages/hooks/index.js
@@ -8,3 +8,4 @@ export { default as useProviders } from './src/useProviders';
 export { default as usePermissions } from './src/usePermissions';
 export { default as useOrganizations } from './src/useOrganizations';
 export { default as useWindowDimensions } from './src/useWindowDimensions';
+export { default as useTabsEventHandlers} from './src/useTabsEventHandlers'

--- a/packages/hooks/src/useTabsEventHandlers.js
+++ b/packages/hooks/src/useTabsEventHandlers.js
@@ -9,8 +9,12 @@ function isObject(value) {
 
 export default function useTabsEventHandlers(tab, tabs, updaterFn, active, options = {}) {
   const { customFindFn, customSelector } = options;
-  if (typeof tab !== 'string' && !isObject(tab) && isObject(tab) && !('name' in tab)) {
-    throw new Error('useTabsEventHandler requires tabs to be strings or objects with a name propery');
+  if ((typeof tab !== 'string' && !isObject(tab)) || (isObject(tab) && !('name' in tab))) {
+    throw new Error('useTabsEventHandler requires tabs to be strings or objects with a name property');
+  }
+
+  if ((isObject(tab) || isObject(active)) && typeof customFindFn !== 'function') {
+    throw new Error('when using tab objects a custom find function is required');
   }
   const handleKeys = React.useCallback(
     (event) => {

--- a/packages/hooks/src/useTabsEventHandlers.js
+++ b/packages/hooks/src/useTabsEventHandlers.js
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+function mathMod(a, b) {
+  return ((a % b) + b) % b;
+}
+function isObject(value) {
+  return !!value && typeof value === 'object';
+}
+
+export default function useTabsEventHandlers(tab, tabs, updaterFn, active, options = {}) {
+  const { customFindFn, customSelector } = options;
+  if (typeof tab !== 'string' && !isObject(tab) && isObject(tab) && !('name' in tab)) {
+    throw new Error('useTabsEventHandler requires tabs to be strings or objects with a name propery');
+  }
+  const handleKeys = React.useCallback(
+    (event) => {
+      switch (event.key) {
+        case 'Tab': {
+          if (event.shiftKey) return false;
+          const selector = customSelector ?? '#tabPanel';
+          let el = document.querySelector(selector);
+          if (!el) {
+            el = document.querySelector('#tabListParentNav')?.nextElementSibling;
+          }
+          // if we cant find something either way fall back to default to avoid trap
+          if (el) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+          return el?.focus();
+        }
+        case ' ':
+        case 'Enter':
+          event.preventDefault();
+          event.stopPropagation();
+          return updaterFn(tab);
+        case 'ArrowLeft': {
+          const indexLeft =
+            isObject(tab) && typeof customFindFn === 'function'
+              ? mathMod(tabs.indexOf(customFindFn(tabs, active)) - 1, tabs.length)
+              : mathMod(tabs.indexOf(active) - 1, tabs.length);
+          const tabToUse = tabs[indexLeft];
+          updaterFn(tabToUse);
+          const id = typeof tabToUse === 'string' ? `${tabToUse}-tab` : `${tabToUse.name}-tab`;
+          return document.querySelector(`#${id}`)?.focus();
+        }
+        case 'ArrowRight': {
+          const indexRight =
+            isObject(tab) && typeof customFindFn === 'function'
+              ? mathMod(tabs.indexOf(customFindFn(tabs, active)) + 1, tabs.length)
+              : mathMod(tabs.indexOf(active) + 1, tabs.length);
+          const tabToUse = tabs[indexRight];
+          updaterFn(tabToUse);
+          const id = typeof tabToUse === 'string' ? `${tabToUse}-tab` : `${tabToUse.name}-tab`;
+          return document.querySelector(`#${id}`)?.focus();
+        }
+        default:
+          return false;
+      }
+    },
+    [tabs, tab, updaterFn, active, customFindFn, customSelector]
+  );
+  const handleFocus = React.useCallback(
+    (event) => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        // Not triggered when swapping focus between children
+        const id = typeof active === 'string' ? `${active}-tab` : `${active.name}-tab`;
+        const activeTab = document.querySelector(`#${id}`);
+        activeTab?.focus();
+      }
+    },
+    [active]
+  );
+  return { handleKeys, handleFocus };
+}

--- a/packages/hooks/src/useTabsEventHandlers.js
+++ b/packages/hooks/src/useTabsEventHandlers.js
@@ -8,7 +8,7 @@ function isObject(value) {
 }
 
 export default function useTabsEventHandlers(tab, tabs, updaterFn, active, options = {}) {
-  const { customFindFn, customSelector } = options;
+  const { customFindFn } = options;
   if ((typeof tab !== 'string' && !isObject(tab)) || (isObject(tab) && !('name' in tab))) {
     throw new Error('useTabsEventHandler requires tabs to be strings or objects with a name property');
   }
@@ -19,20 +19,6 @@ export default function useTabsEventHandlers(tab, tabs, updaterFn, active, optio
   const handleKeys = React.useCallback(
     (event) => {
       switch (event.key) {
-        case 'Tab': {
-          if (event.shiftKey) return false;
-          const selector = customSelector ?? '#tabPanel';
-          let el = document.querySelector(selector);
-          if (!el) {
-            el = document.querySelector('#tabListParentNav')?.nextElementSibling;
-          }
-          // if we cant find something either way fall back to default to avoid trap
-          if (el) {
-            event.preventDefault();
-            event.stopPropagation();
-          }
-          return el?.focus();
-        }
         case ' ':
         case 'Enter':
           event.preventDefault();
@@ -62,18 +48,7 @@ export default function useTabsEventHandlers(tab, tabs, updaterFn, active, optio
           return false;
       }
     },
-    [tabs, tab, updaterFn, active, customFindFn, customSelector]
+    [tabs, tab, updaterFn, active, customFindFn]
   );
-  const handleFocus = React.useCallback(
-    (event) => {
-      if (!event.currentTarget.contains(event.relatedTarget)) {
-        // Not triggered when swapping focus between children
-        const id = typeof active === 'string' ? `${active}-tab` : `${active.name}-tab`;
-        const activeTab = document.querySelector(`#${id}`);
-        activeTab?.focus();
-      }
-    },
-    [active]
-  );
-  return { handleKeys, handleFocus };
+  return handleKeys;
 }

--- a/packages/hooks/stories/useTabsEventHandlers.stories.tsx
+++ b/packages/hooks/stories/useTabsEventHandlers.stories.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+import {Tab} from '../types/useTabsEventHandlers'
+import { useTabsEventHandlers } from '..';
+
+
+const Example = ({initialActive}: {initialActive: string}) => {
+  const [activeTab, setActiveTab] = React.useState(initialActive);
+
+  const toggle = (tab: Tab) => {
+    if(activeTab !== tab) setActiveTab(tab);
+  }
+  const tabs = ['one', 'two']
+
+  const {handleKeys: firstHandler, handleFocus: navHandler} = useTabsEventHandlers('one', tabs, setActiveTab, activeTab)
+  const {handleKeys: secondHandler} = useTabsEventHandlers('two', tabs, setActiveTab, activeTab)
+  return (
+    <>
+      <button type='button' id='sibling-above' tabIndex={0}>Some Stuff</button>
+      <Nav onFocus={navHandler} id='tabListParentNav' tabs>
+        <NavItem>
+          <NavLink
+            id='one-tab'
+            tabIndex={0}
+            onKeyDown = {firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => { toggle('one'); }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={0}
+            id='two-tab'
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => { toggle('two'); }}
+          >
+          More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent tabIndex={0} data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
+        <TabPane tabId="one">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="two">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <button type='button' id='sibling-below' tabIndex={0}>Other Stuff</button>
+    </>
+  );
+}
+
+  export default {
+    title: 'Hooks/useTabsEventHandlers',
+    parameters: {
+      docs: {},
+    },
+  } as Meta;
+  
+  export const Default: Story = () => <Example initialActive='one' />;
+  Default.storyName = 'default';
+  

--- a/packages/hooks/stories/useTabsEventHandlers.stories.tsx
+++ b/packages/hooks/stories/useTabsEventHandlers.stories.tsx
@@ -14,16 +14,16 @@ const Example = ({initialActive}: {initialActive: string}) => {
   }
   const tabs = ['one', 'two']
 
-  const {handleKeys: firstHandler, handleFocus: navHandler} = useTabsEventHandlers('one', tabs, setActiveTab, activeTab)
-  const {handleKeys: secondHandler} = useTabsEventHandlers('two', tabs, setActiveTab, activeTab)
+  const firstHandler = useTabsEventHandlers('one', tabs, setActiveTab, activeTab)
+  const secondHandler = useTabsEventHandlers('two', tabs, setActiveTab, activeTab)
   return (
     <>
       <button type='button' id='sibling-above' tabIndex={0}>Some Stuff</button>
-      <Nav onFocus={navHandler} id='tabListParentNav' tabs>
+      <Nav  id='tabListParentNav' tabs>
         <NavItem>
           <NavLink
             id='one-tab'
-            tabIndex={0}
+            tabIndex={activeTab === 'one' ? 0 : -1}
             onKeyDown = {firstHandler}
             className={classnames({ active: activeTab === 'one' })}
             onClick={() => { toggle('one'); }}
@@ -34,7 +34,7 @@ const Example = ({initialActive}: {initialActive: string}) => {
         <NavItem>
           <NavLink
             onKeyDown={secondHandler}
-            tabIndex={0}
+            tabIndex={activeTab === 'two' ? 0 : -1}
             id='two-tab'
             className={classnames({ active: activeTab === 'two' })}
             onClick={() => { toggle('two'); }}
@@ -43,7 +43,7 @@ const Example = ({initialActive}: {initialActive: string}) => {
           </NavLink>
         </NavItem>
       </Nav>
-      <TabContent tabIndex={0} data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
+      <TabContent tabIndex={activeTab === 'one' ? 0 : undefined} data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
         <TabPane tabId="one">
           <Row>
             <Col sm="12">

--- a/packages/hooks/tests/useTabsEventHandlers.test.js
+++ b/packages/hooks/tests/useTabsEventHandlers.test.js
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PropTypes from 'prop-types';
+import useTabsEventHandlers from '../src/useTabsEventHandlers';
+
+const Example = ({ initialActive }) => {
+  const [activeTab, setActiveTab] = useState(initialActive);
+
+  const toggle = (tab) => {
+    if (activeTab !== tab) setActiveTab(tab);
+  };
+  const tabs = ['one', 'two'];
+
+  const { handleKeys: firstHandler, handleFocus: navHandler } = useTabsEventHandlers(
+    'one',
+    tabs,
+    setActiveTab,
+    activeTab
+  );
+  const { handleKeys: secondHandler } = useTabsEventHandlers('two', tabs, setActiveTab, activeTab);
+  return (
+    <>
+      <button type="button" id="sibling-above" tabIndex={0}>
+        Some Stuff
+      </button>
+      <Nav onFocus={navHandler} id="tabListParentNav" tabs>
+        <NavItem>
+          <NavLink
+            id="one-tab"
+            tabIndex={0}
+            onKeyDown={firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => {
+              toggle('one');
+            }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={0}
+            id="two-tab"
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => {
+              toggle('two');
+            }}
+          >
+            More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent tabIndex={0} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
+        <TabPane tabId="one">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="two">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <button type="button" id="sibling-below" tabIndex={0}>
+        Other Stuff
+      </button>
+    </>
+  );
+};
+Example.propTypes = {
+  initialActive: PropTypes.string,
+};
+
+// taken from https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#:~:text=.-,Keyboard%20Interaction,-For%20the%20tab
+// Tab:
+// When focus moves into the tab list, places focus on the active tab element.
+// When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel unless the first element containing meaningful content inside the tabpanel is focusable.
+// When focus is on a tab element in a horizontal tab list:
+// Left Arrow: moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Optionally, activates the newly focused tab (See note below).
+// Right Arrow: Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Optionally, activates the newly focused tab (See note below).
+// When focus is on a tab in a tablist with either horizontal or vertical orientation:
+// Space or Enter: Activates the tab if it was not activated automatically on focus.
+
+describe('useTabsEventHandlers', () => {
+  test('focus moving into tabList focuses on active tab', () => {
+    render(<Example initialActive="two" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    expect(tab2).toHaveFocus();
+  });
+  test('pressing tab key while focus in tab list goes to tab panel', () => {
+    render(<Example initialActive="one" />);
+    const tab1 = screen.getByText('Tab1');
+    tab1.focus();
+    userEvent.tab();
+    const tabPanel = screen.getByTestId('tabPanel');
+    expect(tabPanel).toHaveFocus();
+  });
+
+  test('left arrow moves focus to previous tab and will wrap around', () => {
+    render(<Example initialActive="two" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    expect(tab2).toHaveClass('active');
+    expect(tab2).toHaveFocus();
+    userEvent.keyboard('[ArrowLeft]');
+    const tab1 = screen.getByText('Tab1');
+    expect(tab1).toHaveFocus();
+    expect(tab1).toHaveClass('active');
+    expect(tab2).not.toHaveClass('active');
+    userEvent.keyboard('[ArrowLeft]');
+    expect(tab2).toHaveFocus();
+    expect(tab2).toHaveClass('active');
+    expect(tab1).not.toHaveClass('active');
+  });
+  test('right arrow moves focus to next tab and will wrap around', () => {
+    render(<Example initialActive="one" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    const tab1 = screen.getByText('Tab1');
+    expect(tab1).toHaveClass('active');
+    userEvent.keyboard('[ArrowRight]');
+    expect(tab2).toHaveFocus();
+    expect(tab2).toHaveClass('active');
+    expect(tab1).not.toHaveClass('active');
+    userEvent.keyboard('[ArrowRight]');
+    expect(tab1).toHaveFocus();
+    expect(tab1).toHaveClass('active');
+    expect(tab2).not.toHaveClass('active');
+  });
+
+  test('space or enter while focused on inactive tab will make it active', () => {
+    render(<Example initialActive="two" />);
+    const tab1 = screen.getByText('Tab1');
+    tab1.focus();
+    expect(tab1).not.toHaveClass('active');
+    userEvent.type(tab1, '[Space]');
+    expect(tab1).toHaveClass('active');
+  });
+});

--- a/packages/hooks/types/useTabsEventHandlers.d.ts
+++ b/packages/hooks/types/useTabsEventHandlers.d.ts
@@ -8,6 +8,6 @@ export const CustomFindFunction: (tabs: Tab[], active: Tab) => {tab: Tab};
 
 declare type options = {customFindFn?: CustomFindFunction, customSelector?: string}
 
-declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): {handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>}
+declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): React.KeyboardEventHandler<HTMLAnchorElement>
 
 export default useTabsEventHandlers

--- a/packages/hooks/types/useTabsEventHandlers.d.ts
+++ b/packages/hooks/types/useTabsEventHandlers.d.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+export type Tab = string | {name: string} & Record<string, unknown>
+
+export const UpdaterFn: (tab: Tab) => void;
+
+export const CustomFindFunction: (tabs: Tab[], active: Tab) => {tab: Tab};
+
+declare type options = {customFindFn?: CustomFindFunction, customSelector?: string}
+
+declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): {handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>, handleFocus: React.FocusEventHandler<HTMLUListElement>};
+
+export default useTabsEventHandlers

--- a/packages/hooks/types/useTabsEventHandlers.d.ts
+++ b/packages/hooks/types/useTabsEventHandlers.d.ts
@@ -8,6 +8,6 @@ export const CustomFindFunction: (tabs: Tab[], active: Tab) => {tab: Tab};
 
 declare type options = {customFindFn?: CustomFindFunction, customSelector?: string}
 
-declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): {handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>, handleFocus: React.FocusEventHandler<HTMLUListElement>};
+declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): {handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>}
 
 export default useTabsEventHandlers


### PR DESCRIPTION
based on https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#:~:text=.-,Keyboard%20Interaction,-For%20the%20tab we have several internal components that need to add 508 compliant keyboard and focus handlers for tab lists, commonly found using Reactstrap's nav and tab components. Because of the multiple uses of these components it is difficult to build a generalized solution in component form that meets all user needs.

Thus, this hook which should be compatible with any horizontal tab list, and multiple state management solutions. 

Also certainly open to feedback on whether you think this is even the right approach.
