### PR TITLE
feat(hooks): add new hook for 508 compliant event handlers for tabs

### DIFF
--- a/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
+++ b/docusaurus/docs/components/hooks/use-tabs-event-handlers.md
@@ -1,0 +1,125 @@
+---
+title: useTabsEventHandlers
+---
+
+Hook that returns keydown event handler for a tab. Intended for use with Reactstrap tab components (see example for full list) but should be configurable if you are using alternate tab components. Tested and compatible with proxy-based state management libraries(you may need to use the custom find function to ensure that you are return a referentially identical tab from your tab list) as well as apps using plain context for managing state. Note that this hook relies on users adding tabIndex = 0 for active tab and tabIndex = -1 for inactive tabs and a few other conventions related to the way the tab element Ids are created. 
+
+### Example
+
+```jsx
+import * as React from 'react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+
+const Example = ({ initialActive }) => {
+  const [activeTab, setActiveTab] = useState(initialActive);
+
+  const toggle = (tab) => {
+    if (activeTab !== tab) setActiveTab(tab);
+  };
+  const tabs = ['one', 'two'];
+
+  const firstHandler = useTabsEventHandlers(
+    'one',
+    tabs,
+    setActiveTab,
+    activeTab
+  );
+  const secondHandler = useTabsEventHandlers('two', tabs, setActiveTab, activeTab);
+  return (
+    <>
+      <Button type="button" id="sibling-above" tabIndex={0}>
+        Some Stuff
+      </Button>
+      <Nav id="tabListParentNav" tabs>
+        <NavItem>
+          <NavLink
+            id="one-tab"
+            tabIndex={activeTab === 'one' ? 0 : -1}
+            onKeyDown={firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => {
+              toggle('one');
+            }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={activeTab === 'two' ? 0 : -1}
+            id="two-tab"
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => {
+              toggle('two');
+            }}
+          >
+            More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent tabIndex={activeTab == 'one' ? 0 : undefined} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
+        <TabPane tabId="one">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="two">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <Button type="button" id="sibling-below" tabIndex={0}>
+        Other Stuff
+      </Button>
+    </>
+  );
+};
+
+```
+
+## Props
+
+### `tab: Tab`
+
+The tab component to attach the onKeyDown listener to. This should be an element of a list of Tabs (i.e. if your list has objects this tab should be referentially equal to one element in the list). Tabs can be either strings, like in the example, or can be objects with a name property (and any other properties you need but they will be safely ignored by this hook, but name is required). Also note that the NavLinks must use the tab or tab.name as part of building their elementID so any tab name must make a valid id (i.e. tabs can't be ['1', '2', '3'] but instead ['one', 'two', 'three] because 1-tab is not a valid id)
+
+### `tabs: Tab[]`
+
+The complete list of your available tabs.
+
+
+### `updaterFn: UpdaterFn`
+
+This is the function used to update your state management with any newly active tab. In the example the updaterFn is simply the function returned by useState. In other solutions with a centralized state management library this may be the updating function for that centralized state (like with Mobx or Redux).
+
+### `active: Tab`
+
+The currently active tab.
+
+### `options?: {customFindFn?: CustomFindFunction}`
+
+Optional overrides for certain features, customFindFn if you have a tab list of objects you will need to use a function like Lodash's isEqual or your own custom find logic, see tests for examples. If you need additional overrides PR's are welcome.
+
+## Returns
+
+### `handleKeys: React.KeyboardEventHandler<HTMLAnchorElement>`
+
+`Used as a keydown event handler on a HTML anchor tag. Type signature for event handler is (event: React.KeyboardEvent<HTMLAnchorElement>) => void`. 

--- a/packages/hooks/index.d.ts
+++ b/packages/hooks/index.d.ts
@@ -8,3 +8,4 @@ export { default as useProviders } from './types/useProviders';
 export { default as usePermissions } from './types/usePermissions';
 export { default as useOrganizations } from './types/useOrganizations';
 export { default as useWindowDimensions } from './types/useWindowDimensions';
+export { Tab, CustomFindFunction, default as useTabsEventHandlers } from './types/useTabsEventHandlers';

--- a/packages/hooks/index.js
+++ b/packages/hooks/index.js
@@ -8,3 +8,4 @@ export { default as useProviders } from './src/useProviders';
 export { default as usePermissions } from './src/usePermissions';
 export { default as useOrganizations } from './src/useOrganizations';
 export { default as useWindowDimensions } from './src/useWindowDimensions';
+export { default as useTabsEventHandlers} from './src/useTabsEventHandlers'

--- a/packages/hooks/src/useTabsEventHandlers.js
+++ b/packages/hooks/src/useTabsEventHandlers.js
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+function mathMod(a, b) {
+  return ((a % b) + b) % b;
+}
+function isObject(value) {
+  return !!value && typeof value === 'object';
+}
+
+export default function useTabsEventHandlers(tab, tabs, updaterFn, active, options = {}) {
+  const { customFindFn } = options;
+  if ((typeof tab !== 'string' && !isObject(tab)) || (isObject(tab) && !('name' in tab))) {
+    throw new Error('useTabsEventHandler requires tabs to be strings or objects with a name property');
+  }
+
+  if ((isObject(tab) || isObject(active)) && typeof customFindFn !== 'function') {
+    throw new Error('when using tab objects a custom find function is required');
+  }
+  const handleKeys = React.useCallback(
+    (event) => {
+      switch (event.key) {
+        case ' ':
+        case 'Enter':
+          event.preventDefault();
+          event.stopPropagation();
+          return updaterFn(tab);
+        case 'ArrowLeft': {
+          const indexLeft =
+            isObject(tab) && typeof customFindFn === 'function'
+              ? mathMod(tabs.indexOf(customFindFn(tabs, active)) - 1, tabs.length)
+              : mathMod(tabs.indexOf(active) - 1, tabs.length);
+          const tabToUse = tabs[indexLeft];
+          updaterFn(tabToUse);
+          const id = typeof tabToUse === 'string' ? `${tabToUse}-tab` : `${tabToUse.name}-tab`;
+          return document.querySelector(`#${id}`)?.focus();
+        }
+        case 'ArrowRight': {
+          const indexRight =
+            isObject(tab) && typeof customFindFn === 'function'
+              ? mathMod(tabs.indexOf(customFindFn(tabs, active)) + 1, tabs.length)
+              : mathMod(tabs.indexOf(active) + 1, tabs.length);
+          const tabToUse = tabs[indexRight];
+          updaterFn(tabToUse);
+          const id = typeof tabToUse === 'string' ? `${tabToUse}-tab` : `${tabToUse.name}-tab`;
+          return document.querySelector(`#${id}`)?.focus();
+        }
+        default:
+          return false;
+      }
+    },
+    [tabs, tab, updaterFn, active, customFindFn]
+  );
+  return handleKeys;
+}

--- a/packages/hooks/stories/useTabsEventHandlers.stories.tsx
+++ b/packages/hooks/stories/useTabsEventHandlers.stories.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+import {Tab} from '../types/useTabsEventHandlers'
+import { useTabsEventHandlers } from '..';
+
+
+const Example = ({initialActive}: {initialActive: string}) => {
+  const [activeTab, setActiveTab] = React.useState(initialActive);
+
+  const toggle = (tab: Tab) => {
+    if(activeTab !== tab) setActiveTab(tab);
+  }
+  const tabs = ['one', 'two']
+
+  const firstHandler = useTabsEventHandlers('one', tabs, setActiveTab, activeTab)
+  const secondHandler = useTabsEventHandlers('two', tabs, setActiveTab, activeTab)
+  return (
+    <>
+      <button type='button' id='sibling-above' tabIndex={0}>Some Stuff</button>
+      <Nav  id='tabListParentNav' tabs>
+        <NavItem>
+          <NavLink
+            id='one-tab'
+            tabIndex={activeTab === 'one' ? 0 : -1}
+            onKeyDown = {firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => { toggle('one'); }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={activeTab === 'two' ? 0 : -1}
+            id='two-tab'
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => { toggle('two'); }}
+          >
+          More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent tabIndex={activeTab === 'one' ? 0 : undefined} data-testid='tabPanel' id='tabPanel' activeTab={activeTab}>
+        <TabPane tabId="one">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="two">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <button type='button' id='sibling-below' tabIndex={0}>Other Stuff</button>
+    </>
+  );
+}
+
+  export default {
+    title: 'Hooks/useTabsEventHandlers',
+    parameters: {
+      docs: {},
+    },
+  } as Meta;
+  
+  export const Default: Story = () => <Example initialActive='one' />;
+  Default.storyName = 'default';
+  

--- a/packages/hooks/tests/useTabsEventHandlers.test.js
+++ b/packages/hooks/tests/useTabsEventHandlers.test.js
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col } from 'reactstrap';
+import classnames from 'classnames';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PropTypes from 'prop-types';
+import useTabsEventHandlers from '../src/useTabsEventHandlers';
+
+function setup(...args) {
+  const returnVal = {};
+  function TestComponent() {
+    Object.assign(returnVal, useTabsEventHandlers(...args));
+    return null;
+  }
+  render(<TestComponent />);
+  return returnVal;
+}
+
+const Example = ({ initialActive, useObjects, customFindFn }) => {
+  const [activeTab, setActiveTab] = useState(initialActive);
+
+  const toggle = (tab) => {
+    if (activeTab !== tab) setActiveTab(tab);
+  };
+  const tabs = useObjects ? [{ name: 'one' }, { name: 'two' }] : ['one', 'two'];
+
+  const firstHandler = useTabsEventHandlers('one', tabs, setActiveTab, activeTab, { customFindFn });
+  const secondHandler = useTabsEventHandlers('two', tabs, setActiveTab, activeTab, {
+    customFindFn,
+  });
+  return (
+    <div>
+      <button type="button" id="sibling-above" tabIndex={0}>
+        Some Stuff
+      </button>
+      <Nav id="tabListParentNav" tabs>
+        <NavItem>
+          <NavLink
+            id="one-tab"
+            tabIndex={activeTab === 'one' ? 0 : -1}
+            onKeyDown={firstHandler}
+            className={classnames({ active: activeTab === 'one' })}
+            onClick={() => {
+              toggle('one');
+            }}
+          >
+            Tab1
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            onKeyDown={secondHandler}
+            tabIndex={activeTab === 'two' ? 0 : -1}
+            id="two-tab"
+            className={classnames({ active: activeTab === 'two' })}
+            onClick={() => {
+              toggle('two');
+            }}
+          >
+            More Tabs
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent tabIndex={0} data-testid="tabPanel" id="tabPanel" activeTab={activeTab}>
+        <TabPane tabId="one">
+          <Row>
+            <Col sm="12">
+              <h4>Tab 1 Contents</h4>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane tabId="two">
+          <Row>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+            <Col sm="6">
+              <Card body>
+                <CardTitle>Special Title Treatment</CardTitle>
+                <CardText>With supporting text below as a natural lead-in to additional content.</CardText>
+                <Button>Go somewhere</Button>
+              </Card>
+            </Col>
+          </Row>
+        </TabPane>
+      </TabContent>
+      <button type="button" id="sibling-below" tabIndex={0}>
+        Other Stuff
+      </button>
+    </div>
+  );
+};
+
+Example.propTypes = {
+  initialActive: PropTypes.string,
+  useObjects: PropTypes.bool,
+  customFindFn: PropTypes.func,
+};
+
+// taken from https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#:~:text=.-,Keyboard%20Interaction,-For%20the%20tab
+// Tab:
+// When focus moves into the tab list, places focus on the active tab element.
+// When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel unless the first element containing meaningful content inside the tabpanel is focusable.
+// When focus is on a tab element in a horizontal tab list:
+// Left Arrow: moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Optionally, activates the newly focused tab (See note below).
+// Right Arrow: Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Optionally, activates the newly focused tab (See note below).
+// When focus is on a tab in a tablist with either horizontal or vertical orientation:
+// Space or Enter: Activates the tab if it was not activated automatically on focus.
+
+describe('useTabsEventHandlers', () => {
+  test('focus moving into tabList focuses on active tab', () => {
+    render(<Example initialActive="two" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    expect(tab2).toHaveFocus();
+  });
+  test('pressing tab key while focus in tab list goes to tab panel', () => {
+    render(<Example initialActive="one" />);
+    const tab1 = screen.getByText('Tab1');
+    tab1.focus();
+    userEvent.tab();
+    const tabPanel = screen.getByTestId('tabPanel');
+    expect(tabPanel).toHaveFocus();
+  });
+
+  test('left arrow moves focus to previous tab and will wrap around', () => {
+    render(<Example initialActive="two" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    expect(tab2).toHaveClass('active');
+    expect(tab2).toHaveFocus();
+    userEvent.keyboard('[ArrowLeft]');
+    const tab1 = screen.getByText('Tab1');
+    expect(tab1).toHaveFocus();
+    expect(tab1).toHaveClass('active');
+    expect(tab2).not.toHaveClass('active');
+    userEvent.keyboard('[ArrowLeft]');
+    expect(tab2).toHaveFocus();
+    expect(tab2).toHaveClass('active');
+    expect(tab1).not.toHaveClass('active');
+  });
+  test('right arrow moves focus to next tab and will wrap around', () => {
+    render(<Example initialActive="one" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    const tab1 = screen.getByText('Tab1');
+    expect(tab1).toHaveClass('active');
+    userEvent.keyboard('[ArrowRight]');
+    expect(tab2).toHaveFocus();
+    expect(tab2).toHaveClass('active');
+    expect(tab1).not.toHaveClass('active');
+    userEvent.keyboard('[ArrowRight]');
+    expect(tab1).toHaveFocus();
+    expect(tab1).toHaveClass('active');
+    expect(tab2).not.toHaveClass('active');
+  });
+
+  test('space or enter while focused on inactive tab will make it active', () => {
+    render(<Example initialActive="two" />);
+    const tab1 = screen.getByText('Tab1');
+    tab1.focus();
+    expect(tab1).not.toHaveClass('active');
+    userEvent.type(tab1, '[Space]');
+    expect(tab1).toHaveClass('active');
+  });
+  test('it throws if tabs are objects without a name property', () => {
+    const firstTab = { id: 'firsttab' };
+    const secondTab = { id: 'secondtab' };
+    const tabs = [firstTab, secondTab];
+    expect(() => setup(firstTab, tabs, () => tabs[1], firstTab)).toThrow(
+      'useTabsEventHandler requires tabs to be strings or objects with a name property'
+    );
+  });
+
+  test('using tab objects without a custom find function wont work and so will throw', () => {
+    const firstTab = { name: 'firsttab' };
+    const secondTab = { name: 'secondtab' };
+    const tabs = [firstTab, secondTab];
+    expect(() => setup(firstTab, tabs, () => tabs[1], firstTab)).toThrow(
+      'when using tab objects a custom find function is required'
+    );
+  });
+
+  test('use tab objects and provide a custom find function', () => {
+    render(
+      <Example
+        useObjects
+        initialActive="two"
+        customFindFn={(tabs, active) => {
+          tabs.find((tab) => tab.name === active.name);
+        }}
+      />
+    );
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    const tab1 = screen.getByText('Tab1');
+    expect(tab2).toHaveClass('active');
+    expect(tab2).toHaveFocus();
+    userEvent.keyboard('[ArrowLeft]');
+    expect(tab1).toHaveFocus();
+  });
+
+  test('arrow up and arrow down have no effect on tab active or focus state', () => {
+    render(<Example useObjects initialActive="two" />);
+    const buttonAbove = screen.getByText('Some Stuff');
+    buttonAbove.focus();
+    userEvent.tab();
+    const tab2 = screen.getByText('More Tabs');
+    expect(tab2).toHaveClass('active');
+    expect(tab2).toHaveFocus();
+    userEvent.keyboard('[ArrowDown]');
+    expect(tab2).toHaveFocus();
+    userEvent.keyboard('[ArrowUp]');
+    expect(tab2).toHaveFocus();
+    expect(tab2).toHaveClass('active');
+  });
+});

--- a/packages/hooks/types/useTabsEventHandlers.d.ts
+++ b/packages/hooks/types/useTabsEventHandlers.d.ts
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+export type Tab = string | {name: string} & Record<string, unknown>
+
+export const UpdaterFn: (tab: Tab) => void;
+
+export const CustomFindFunction: (tabs: Tab[], active: Tab) => {tab: Tab};
+
+declare type options = {customFindFn?: CustomFindFunction, customSelector?: string}
+
+declare function useTabsEventHandlers(tab: Tab, tabs: Tab[], updaterFn: UpdaterFn, active: Tab, options?): React.KeyboardEventHandler<HTMLAnchorElement>
+
+export default useTabsEventHandlers


### PR DESCRIPTION
reopened this after previous PR https://github.com/Availity/availity-react/pull/1094 closed to rebase and squash multiple commits that were growing unwieldy. 
From original: Based on https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#:~:text=.-,Keyboard%20Interaction,-For%20the%20tab we have several internal components that need to add 508 compliant keyboard and focus handlers for tab lists, commonly found using Reactstrap's nav tab components. Because of the multiple uses of these components it is difficult to build a generalized solution in component form that meets all user needs. But we will likely be able to build a limited use compatible wrapper tab component utilizing this hook.

Another design goal for this hook was to make it compatible with multiple horizontal tab list components, and multiple state management solutions.

Also certainly open to feedback on whether you think this is even the right approach.

Note that as opposed to the original PR - this one relies more on users to manage their own tabIndices to control the focus order but in return greatly simplifies the logic and eliminates multiple difficult edge cases from manually managing focus.