### PR TITLE
fix(date): remove css from bundle as it was only producing an error

### DIFF
--- a/docusaurus/docs/form/date/index.mdx
+++ b/docusaurus/docs/form/date/index.mdx
@@ -25,7 +25,7 @@ yarn add @availity/date @availity/form formik reactstrap@^8.0.0
 You must import the `styles.scss` file `@availity/date` provides in order to have the field styled correctly
 
 ```js
-import Date from '@availity/date/styles.scss';
+import Date from '@availity/date';
 import '@availity/date/styles.scss';
 ```
 

--- a/packages/date/src/Date.js
+++ b/packages/date/src/Date.js
@@ -8,7 +8,6 @@ import { InputGroup, Input, Row, Col } from 'reactstrap';
 import moment from 'moment';
 
 import '../polyfills';
-import '../styles.scss';
 
 import { isOutsideRange, limitPropType, buildYearPickerOptions } from './utils';
 
@@ -26,11 +25,11 @@ const AvDate = ({
   onPickerFocusChange,
   min,
   max,
-  format,
+  format = 'MM/DD/YYYY',
   validate,
   datePickerProps,
   'data-testid': dataTestId,
-  openDirection,
+  openDirection = 'down',
   ...attributes
 }) => {
   const { setFieldValue, setFieldTouched, validateField } = useFormikContext();
@@ -201,11 +200,6 @@ AvDate.propTypes = {
   validate: PropTypes.func,
   datePickerProps: PropTypes.object,
   openDirection: PropTypes.string,
-};
-
-AvDate.defaultProps = {
-  format: 'MM/DD/YYYY',
-  openDirection: 'down',
 };
 
 export default AvDate;

--- a/packages/date/src/DateRange.js
+++ b/packages/date/src/DateRange.js
@@ -58,15 +58,15 @@ const DateRange = ({
   onPickerFocusChange,
   innerRef,
   className,
-  format,
+  format = isoDateFormat,
   ariaDescribedBy,
   datepickerProps,
   'data-testid': dataTestId,
   autoSync,
   ranges: propsRanges,
   customArrowIcon,
-  openDirection,
-  allowInvalidDates,
+  openDirection = 'down',
+  allowInvalidDates = false,
   ...attributes
 }) => {
   const { setFieldValue, setFieldTouched, validateField } = useFormikContext();
@@ -337,12 +337,6 @@ DateRange.propTypes = {
   customArrowIcon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   openDirection: PropTypes.string,
   allowInvalidDates: PropTypes.bool,
-};
-
-DateRange.defaultProps = {
-  format: isoDateFormat,
-  openDirection: 'down',
-  allowInvalidDates: false,
 };
 
 export default DateRange;


### PR DESCRIPTION
This fixes the warning that shows up about not being able to import a css file due to mime type. 
