### PR TITLE
fix(select): display selected option when raw is false

### DIFF
--- a/packages/select/src/AvOrganizationSelect.js
+++ b/packages/select/src/AvOrganizationSelect.js
@@ -7,6 +7,7 @@ import ResourceSelect from './ResourceSelect';
 const OrganizationSelect = ResourceSelect.create({
   resource: avOrganizationsApi,
   labelKey: 'name',
+  valueKey: 'id',
 });
 
 const AvOrganizationSelect = ({ name, resourceIds, permissionIds, ...props }) => (

--- a/packages/select/src/AvPayerSelect.js
+++ b/packages/select/src/AvPayerSelect.js
@@ -16,6 +16,7 @@ const AvPayerSelect = ({ name, customerId, ...props }) => (
   <ResourceSelect
     name={name}
     labelKey="payerName"
+    valueKey="payerId"
     resource={extendedPayersApi}
     pageAll
     customerId={customerId}

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -108,6 +108,7 @@ const Select = ({
     _cacheUniq = [_cacheUniq];
   }
 
+  // Enhance placeholder for accessibility
   placeholder = (
     <>
       {placeholder || 'Select...'}
@@ -117,6 +118,10 @@ const Select = ({
     </>
   );
 
+  /**
+   * Get the path to the label from the option. Uses the `labelKey` prop.
+   * Default to the `label` property on the option
+   */
   const getOptionLabel = (option) => {
     if (option.__isNew__) {
       return option.label;
@@ -125,8 +130,15 @@ const Select = ({
     return option[get(attributes, 'labelKey', 'label')];
   };
 
+  /**
+   * Get the path to the value from the option. Uses the `valueKey` prop.
+   * Default to the `value` property on the option
+   */
   const getValueKey = (attrs = attributes) => get(attrs, 'valueKey', 'value');
 
+  /**
+   * Get the actual value for the option.
+   */
   const getOptionValue = (option) =>
     attributes.raw && !attributes.valueKey ? option : get(option, getValueKey(attributes), option);
 
@@ -142,7 +154,13 @@ const Select = ({
     return get(value, valueKey, value);
   };
 
+  /**
+   * Find the actual option in the list when the set value
+   * is a string or number
+   */
   const findOptionFromValue = (value, options) => {
+    // selectRef.current.commonProps has the options returned by loadOptions function
+    options = options || selectRef?.current?.commonProps.options;
     if (Array.isArray(options)) {
       const flattened = [...options, ...newOptions].reduce((prev, current) => {
         if (current.type === 'group') {
@@ -156,8 +174,21 @@ const Select = ({
     return null;
   };
 
+  /**
+   * Get the value that will be used by the dropdown.
+   */
   const getViewValue = () => {
-    if (attributes.raw || attributes.loadOptions || !options) return fieldValue;
+    // Return entire object when:
+    // 1) raw prop is set
+    // 2) loadOptions is set and labelKey and getOptionLabel are not given
+    // 3) loadOptions is not set and no options are available
+    if (
+      attributes.raw ||
+      (attributes.loadOptions && !attributes.labelKey && !attributes.getOptionLabel) ||
+      (!attributes.loadOptions && !options)
+    ) {
+      return fieldValue;
+    }
     if (attributes.isMulti && Array.isArray(fieldValue)) {
       return fieldValue.map((value) => findOptionFromValue(value, options) || value);
     }

--- a/packages/select/src/resources.js
+++ b/packages/select/src/resources.js
@@ -28,6 +28,7 @@ const AvPermissionSelect = ResourceSelect.create({
 const AvProviderSelect = ResourceSelect.create({
   resource: avProvidersApi,
   labelKey: 'uiDisplayName',
+  valueKey: 'npi',
   requiredParams: ['customerId'],
   watchParams: ['customerId'],
 });
@@ -35,6 +36,7 @@ const AvProviderSelect = ResourceSelect.create({
 const AvUserSelect = ResourceSelect.create({
   resource: avUserApi,
   getOptionLabel: (option) => `${option.firstName} ${option.lastName} (${option.id}) - ${option.userId}`,
+  valueKey: 'userId',
 });
 
 export {

--- a/packages/select/stories/ResourceSelect.stories.tsx
+++ b/packages/select/stories/ResourceSelect.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = ({ creatable, disabled, helpMessage, isMulti, labe
           isMulti={isMulti}
           label={label}
           labelKey="name"
+          valueKey="value"
           maxLength={max}
           raw={raw}
           required={required}

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -291,9 +291,48 @@ describe('ResourceSelect', () => {
     });
   });
 
-  describe('defaultToOnlyOption', () => {
-    it('defaults to only option', async () => {
-      avRegionsApi.postGet.mockResolvedValue({
+  it('defaults to only option', async () => {
+    avRegionsApi.postGet.mockResolvedValue({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+        ],
+      },
+    });
+
+    const { getByText } = renderSelect({
+      resource: avRegionsApi,
+      labelKey: 'value',
+      valueKey: 'id',
+      classNamePrefix: 'test__regions',
+      getResult: 'regions',
+      defaultToOnlyOption: true,
+    });
+
+    await waitFor(() => {
+      expect(avRegionsApi.postGet).toHaveBeenCalled();
+    });
+
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'test-form-input': {
+            id: 'FL',
+            value: 'Florida',
+          },
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it('defaults to only option when cacheUniq changes', async () => {
+    avRegionsApi.postGet
+      .mockResolvedValueOnce({
         data: {
           regions: [
             {
@@ -302,106 +341,10 @@ describe('ResourceSelect', () => {
             },
           ],
         },
-      });
-
-      const { getByText } = renderSelect({
-        resource: avRegionsApi,
-        labelKey: 'value',
-        valueKey: 'id',
-        classNamePrefix: 'test__regions',
-        getResult: 'regions',
-        defaultToOnlyOption: true,
-      });
-
-      await waitFor(() => {
-        expect(avRegionsApi.postGet).toHaveBeenCalled();
-      });
-
-      fireEvent.click(getByText('Submit'));
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith(
-          expect.objectContaining({
-            'test-form-input': {
-              id: 'FL',
-              value: 'Florida',
-            },
-          }),
-          expect.anything()
-        );
-      });
-    });
-
-    it('defaults to only option when cacheUniq changes', async () => {
-      avRegionsApi.postGet
-        .mockResolvedValueOnce({
-          data: {
-            regions: [
-              {
-                id: 'FL',
-                value: 'Florida',
-              },
-            ],
-          },
-        })
-        .mockResolvedValue({
-          data: {
-            regions: [
-              {
-                id: 'AL',
-                value: 'Alabama',
-              },
-            ],
-          },
-        });
-
-      const { getByTestId, getByText } = renderSelect({
-        resource: avRegionsApi,
-        labelKey: 'value',
-        valueKey: 'id',
-        classNamePrefix: 'test__regions',
-        getResult: 'regions',
-        defaultToOnlyOption: true,
-      });
-
-      await waitFor(() => {
-        expect(avRegionsApi.postGet).toHaveBeenCalledTimes(1);
-      });
-
-      fireEvent.click(getByText('Submit'));
-      await waitFor(() => {
-        const testFormInput = onSubmit.mock.calls[0][0]['test-form-input'];
-        expect(testFormInput).toEqual({
-          id: 'FL',
-          value: 'Florida',
-        });
-      });
-
-      // Change what cache uniq is
-      fireEvent.click(getByTestId('btn-toggle-cacheUniq'));
-
-      await waitFor(() => {
-        expect(avRegionsApi.postGet).toHaveBeenCalledTimes(2);
-      });
-
-      fireEvent.click(getByText('Submit'));
-
-      await waitFor(() => {
-        const testFormInput = onSubmit.mock.calls[1][0]['test-form-input'];
-        expect(testFormInput).toEqual({
-          id: 'AL',
-          value: 'Alabama',
-        });
-      });
-    });
-
-    it('does not default to only option when more than one option', async () => {
-      avRegionsApi.postGet.mockResolvedValue({
+      })
+      .mockResolvedValue({
         data: {
           regions: [
-            {
-              id: 'FL',
-              value: 'Florida',
-            },
             {
               id: 'AL',
               value: 'Alabama',
@@ -410,73 +353,126 @@ describe('ResourceSelect', () => {
         },
       });
 
-      const { getByText } = renderSelect({
-        resource: avRegionsApi,
-        labelKey: 'value',
-        valueKey: 'id',
-        classNamePrefix: 'test__regions',
-        getResult: 'regions',
-        defaultToOnlyOption: true,
-      });
+    const { getByTestId, getByText } = renderSelect({
+      resource: avRegionsApi,
+      labelKey: 'value',
+      valueKey: 'id',
+      classNamePrefix: 'test__regions',
+      getResult: 'regions',
+      defaultToOnlyOption: true,
+    });
 
-      await waitFor(() => {
-        expect(avRegionsApi.postGet).toHaveBeenCalled();
-      });
+    await waitFor(() => {
+      expect(avRegionsApi.postGet).toHaveBeenCalledTimes(1);
+    });
 
-      fireEvent.click(getByText('Submit'));
-      await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith(
-          expect.objectContaining({
-            'test-form-input': undefined,
-          }),
-          expect.anything()
-        );
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      const testFormInput = onSubmit.mock.calls[0][0]['test-form-input'];
+      expect(testFormInput).toEqual({
+        id: 'FL',
+        value: 'Florida',
       });
     });
 
-    describe('defaultToFirstOption', () => {
-      it('defaults to first option', async () => {
-        avRegionsApi.postGet.mockResolvedValue({
-          data: {
-            regions: [
-              {
-                id: 'FL',
-                value: 'Florida',
-              },
-              {
-                id: 'TX',
-                value: 'Texas',
-              },
-            ],
-          },
-        });
+    // Change what cache uniq is
+    fireEvent.click(getByTestId('btn-toggle-cacheUniq'));
 
-        const { getByText } = renderSelect({
-          resource: avRegionsApi,
-          labelKey: 'value',
-          valueKey: 'id',
-          classNamePrefix: 'test__regions',
-          getResult: 'regions',
-          defaultToFirstOption: true,
-        });
+    await waitFor(() => {
+      expect(avRegionsApi.postGet).toHaveBeenCalledTimes(2);
+    });
 
-        await waitFor(() => {
-          expect(avRegionsApi.postGet).toHaveBeenCalled();
-        });
+    fireEvent.click(getByText('Submit'));
 
-        fireEvent.click(getByText('Submit'));
-        await waitFor(() => {
-          expect(onSubmit).toHaveBeenCalledWith(
-            expect.objectContaining({
-              'test-form-input': {
-                id: 'FL',
-                value: 'Florida',
-              },
-            }),
-            expect.anything()
-          );
-        });
+    await waitFor(() => {
+      const testFormInput = onSubmit.mock.calls[1][0]['test-form-input'];
+      expect(testFormInput).toEqual({
+        id: 'AL',
+        value: 'Alabama',
       });
+    });
+  });
+
+  it('defaults to first option', async () => {
+    avRegionsApi.postGet.mockResolvedValue({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'TX',
+            value: 'Texas',
+          },
+        ],
+      },
+    });
+
+    const { getByText } = renderSelect({
+      resource: avRegionsApi,
+      labelKey: 'value',
+      valueKey: 'id',
+      classNamePrefix: 'test__regions',
+      getResult: 'regions',
+      defaultToFirstOption: true,
+    });
+
+    await waitFor(() => {
+      expect(avRegionsApi.postGet).toHaveBeenCalled();
+    });
+
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'test-form-input': {
+            id: 'FL',
+            value: 'Florida',
+          },
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it('does not default to only option when more than one option', async () => {
+    avRegionsApi.postGet.mockResolvedValue({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'AL',
+            value: 'Alabama',
+          },
+        ],
+      },
+    });
+
+    const { getByText } = renderSelect({
+      resource: avRegionsApi,
+      labelKey: 'value',
+      valueKey: 'id',
+      classNamePrefix: 'test__regions',
+      getResult: 'regions',
+      defaultToOnlyOption: true,
+    });
+
+    await waitFor(() => {
+      expect(avRegionsApi.postGet).toHaveBeenCalled();
+    });
+
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'test-form-input': undefined,
+        }),
+        expect.anything()
+      );
     });
   });
 
@@ -694,11 +690,9 @@ describe('ResourceSelect', () => {
       </Form>
     );
 
-    const regionsSelect = container.querySelector('.test__regions__control');
-
-    fireEvent.focus(regionsSelect);
-    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
-    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+    // Click on select component and wait for options to be available
+    const select = container.querySelector('.test__regions__control');
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
 
     await waitFor(() => expect(getByText('Florida')).toBeDefined());
 
@@ -748,11 +742,9 @@ describe('ResourceSelect', () => {
       </Form>
     );
 
-    const regionsSelect = container.querySelector('.test__regions__control');
-
-    fireEvent.focus(regionsSelect);
-    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
-    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+    // Click on select component and wait for options to be available
+    const select = container.querySelector('.test__regions__control');
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
 
     await waitFor(() => expect(getByText('Florida')).toBeDefined());
 
@@ -769,18 +761,76 @@ describe('ResourceSelect', () => {
       classNamePrefix: 'test__value__key',
     });
 
-    // query
+    // Click on the select component
     const select = container.querySelector('.test__value__key__control');
     fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
 
+    // Click the option
     const option = await waitFor(() => getByText('test'));
     fireEvent.click(option);
 
+    // Submit the form
     fireEvent.click(getByText('Submit'));
 
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ 'test-form-input': 'value' }), expect.anything())
     );
+  });
+
+  it('applies labelKey when raw is false', async () => {
+    const { container, getByText } = renderSelect({
+      resource: { all: async () => [{ name: 'test', test: 'value' }] },
+      pageAll: true,
+      labelKey: 'name',
+      valueKey: 'test',
+      raw: false,
+      classNamePrefix: 'test__value__key',
+    });
+
+    // Click on the select component
+    const select = container.querySelector('.test__value__key__control');
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
+
+    // Click on the option
+    const option = await waitFor(() => getByText('test'));
+    fireEvent.click(option);
+
+    await waitFor(() => expect(getByText('test')).toBeDefined());
+
+    // Submit the form
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ 'test-form-input': 'value' }), expect.anything());
+    });
+  });
+
+  it('applies getOptionLabel when raw is false', async () => {
+    const { container, getByText } = renderSelect({
+      resource: { all: async () => [{ name: 'test', test: 'value' }] },
+      pageAll: true,
+      getOptionLabel: (option) => `${option.name}-${option.test}`,
+      valueKey: 'test',
+      raw: false,
+      classNamePrefix: 'test__value__key',
+    });
+
+    // Click on the select component
+    const select = container.querySelector('.test__value__key__control');
+    fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
+
+    // Click on the option
+    const option = await waitFor(() => getByText('test-value'));
+    fireEvent.click(option);
+
+    await waitFor(() => expect(getByText('test-value')).toBeDefined());
+
+    // Submit the form
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ 'test-form-input': 'value' }), expect.anything());
+    });
   });
 });
 
@@ -1072,7 +1122,9 @@ describe('Custom Resources', () => {
 
       render(<RegionComponent regionProps={regionProps} />);
 
-      expect(avRegionsApi.all).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(avRegionsApi.all).toHaveBeenCalled();
+      });
     });
 
     it('filters when a search value is typed', async () => {
@@ -1244,7 +1296,6 @@ describe('Custom Resources', () => {
         name: 'test-form-input',
         classNamePrefix: 'test__region',
         defaultToCurrentRegion: true,
-        pageAllSearchBy: 'not a method',
       };
 
       const { container, getByText, queryByText } = render(<RegionComponent regionProps={regionProps} />);
@@ -1269,7 +1320,6 @@ describe('Custom Resources', () => {
         expect(queryByText('Florida')).toBeNull();
 
         fireEvent.click(getByText('Submit'));
-
         await waitFor(() => {
           expect(onSubmit).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -1299,7 +1349,6 @@ describe('Custom Resources', () => {
         expect(queryByText('Florida')).toBeNull();
 
         fireEvent.click(getByText('Submit'));
-
         await waitFor(() => {
           expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({}), expect.anything());
         });
@@ -1405,10 +1454,14 @@ describe('AvPayerSelect', () => {
       name: 'test-form-input',
       classNamePrefix: 'test__payer',
       customerId: '12345',
+      parameters: { region: 'FL', tranTypeCode: '1' },
+      resource: extendedPayersApi,
     };
 
     render(<PayerComponent payerProps={payerProps} />);
 
-    expect(extendedPayersApi.all).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(extendedPayersApi.all).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -853,6 +853,8 @@ describe('Select', () => {
     fireEvent.keyDown(select, { key: 'ArrowDown', keyCode: 40 });
     fireEvent.keyDown(select, { key: 'Enter', keyCode: 13 });
 
-    expect(getByText('Foo')).toBeDefined();
+    await waitFor(() => {
+      expect(getByText('Foo')).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue where the selected option would not be displayed in the dropdown when the `raw` prop was set to false. 

I also added defaults to each of the custom resource selects for when someone sets the `raw` prop to false
