### PR TITLE
Fix/favorites/add favorites update subscription

### DIFF
--- a/packages/favorites/package.json
+++ b/packages/favorites/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@availity/analytics-core": "^4.0.1",
     "@availity/hooks": "workspace:*",
-    "@availity/message-core": "^6.0.1",
+    "@availity/message-core": "^6.1.0",
     "@radix-ui/react-tooltip": "0.1.6",
     "lodash": "^4.17.21"
   },

--- a/packages/favorites/src/context/FavoritesProvider.tsx
+++ b/packages/favorites/src/context/FavoritesProvider.tsx
@@ -36,11 +36,30 @@ export const FavoritesProvider = ({
   });
 
   useEffect(() => {
-    avMessages.subscribe(AV_INTERNAL_GLOBALS.FAVORITES_CHANGED, (messagesData) => {
-      queryClient.setQueryData('favorites', messagesData?.favorites || []);
-    });
+    const unsubscribeFavoritesChanged = avMessages.subscribe(
+      AV_INTERNAL_GLOBALS.FAVORITES_CHANGED,
+      (data) => {
+        if (data?.favorites) {
+          queryClient.setQueryData('favorites', data?.favorites);
+        }
+      },
+      { ignoreSameWindow: false }
+    );
 
-    return () => avMessages.unsubscribe(AV_INTERNAL_GLOBALS.FAVORITES_CHANGED);
+    const unsubscribeFavoritesUpdate = avMessages.subscribe(
+      AV_INTERNAL_GLOBALS.FAVORITES_UPDATE,
+      (data) => {
+        if (data?.favorites) {
+          queryClient.setQueryData('favorites', data?.favorites);
+        }
+      },
+      { ignoreSameWindow: false }
+    );
+
+    return () => {
+      unsubscribeFavoritesChanged();
+      unsubscribeFavoritesUpdate();
+    };
   }, [queryClient]);
 
   const deleteFavorite = async (id: string) => {

--- a/packages/favorites/src/tests/FavoriteHeart.test.js
+++ b/packages/favorites/src/tests/FavoriteHeart.test.js
@@ -360,7 +360,7 @@ describe('FavoriteHeart', () => {
 
     avMessages.send({
       event: 'av:favorites:changed',
-      message: { favorites: [] },
+      favorites: [],
     });
 
     await waitFor(() => expect(heart).not.toBeChecked());
@@ -383,9 +383,9 @@ describe('FavoriteHeart', () => {
 
     avMessages.send({
       event: 'av:favorites:update',
-      message: { favorites: [] },
+      favorites: [],
     });
-
+    console.log('yoooooohooooooo');
     await waitFor(() => expect(heart).not.toBeChecked());
   });
 

--- a/packages/favorites/src/tests/FavoriteHeart.test.js
+++ b/packages/favorites/src/tests/FavoriteHeart.test.js
@@ -385,7 +385,6 @@ describe('FavoriteHeart', () => {
       event: 'av:favorites:update',
       favorites: [],
     });
-    console.log('yoooooohooooooo');
     await waitFor(() => expect(heart).not.toBeChecked());
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -545,7 +545,7 @@ __metadata:
   resolution: "@availity/help@workspace:packages/help"
   dependencies:
     "@availity/icon": "workspace:*"
-    "@availity/message-core": ^6.1.0
+    "@availity/message-core": ^6.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
     tsup: ^5.12.7
@@ -643,7 +643,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@availity/message-core@npm:^6.1.0":
+"@availity/message-core@npm:^6.0.1, @availity/message-core@npm:^6.1.0":
   version: 6.1.0
   resolution: "@availity/message-core@npm:6.1.0"
   checksum: c6ef958a5c90b1fdeae119990530aeb10e9a017d27bd556cd1b9331b55913be53acf4c4bbfda5d0201d762970b23ea46e317944ef2933bca0158db00119e5df1
@@ -906,7 +906,7 @@ __metadata:
     "@availity/icon": "workspace:*"
     "@availity/link": "workspace:*"
     "@availity/list-group-item": "workspace:*"
-    "@availity/message-core": ^6.1.0
+    "@availity/message-core": ^6.0.1
     "@availity/native-form": ^5.0.1
     "@availity/typography": "workspace:*"
     axios: ^0.21.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,7 +420,7 @@ __metadata:
     "@availity/analytics-core": ^4.0.1
     "@availity/api-axios": ^7.0.1
     "@availity/hooks": "workspace:*"
-    "@availity/message-core": ^6.0.1
+    "@availity/message-core": ^6.1.0
     "@radix-ui/react-tooltip": 0.1.6
     axios: ^0.21.4
     esbuild-sass-plugin: ^2.2.6
@@ -545,7 +545,7 @@ __metadata:
   resolution: "@availity/help@workspace:packages/help"
   dependencies:
     "@availity/icon": "workspace:*"
-    "@availity/message-core": ^6.0.1
+    "@availity/message-core": ^6.1.0
     react: ^17.0.2
     react-dom: ^17.0.2
     tsup: ^5.12.7
@@ -643,10 +643,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@availity/message-core@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@availity/message-core@npm:6.0.1"
-  checksum: 523f675c20495c7f2873ba52529d6b2ece59978ce6fe436f4f687b724bdfd1e1953b3f53598a218def09b7420e642bd5d31fe85ec0c97057c5b204bd2daa123a
+"@availity/message-core@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@availity/message-core@npm:6.1.0"
+  checksum: c6ef958a5c90b1fdeae119990530aeb10e9a017d27bd556cd1b9331b55913be53acf4c4bbfda5d0201d762970b23ea46e317944ef2933bca0158db00119e5df1
   languageName: node
   linkType: hard
 
@@ -906,7 +906,7 @@ __metadata:
     "@availity/icon": "workspace:*"
     "@availity/link": "workspace:*"
     "@availity/list-group-item": "workspace:*"
-    "@availity/message-core": ^6.0.1
+    "@availity/message-core": ^6.1.0
     "@availity/native-form": ^5.0.1
     "@availity/typography": "workspace:*"
     axios: ^0.21.4


### PR DESCRIPTION
In my previous refactor around early March, the handling of `av:favorites:updated` was accidentally removed. This causes a bug observable in QA as of today, where deleting all favorites using the Manage My Favorites functionality does NOT update favorites hearts in payer spaces.

This PR also updates @availity/message-core and includes functionality for responding to messages from the same window.