### PR TITLE
feat(select): move clear field button, allow aria-required, export styling fix #933

### DIFF
--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -4,6 +4,16 @@ title: <Select />
 
 Select dropdown without a Label or Feedback
 
+### Additional Resources
+
+- `SelectStyles(showError, styles, isInline)`
+  - Extract styling of this component for cases when react-select is used directly.
+  - Returns style and theme object to be spread on Select
+  - Props
+    - `showError?: boolean` if error styling should be applied
+    - `styles?: css object` same as react-select styles prop
+    - `isInline?: boolean` if inline styling should be applied, must be within a flexbox.
+
 ### Example
 
 ```jsx
@@ -91,6 +101,10 @@ Adds hidden help message to placeholder so it is read with `aria-describedby` (s
 
 Will add default `<Feedback />` id to `aria-errormessage`.
 
+#### `required?: boolean`
+
+Will add `aria-required` to input.
+
 #### `maxLength?: number`
 
 The maximum number of options that can be selected ( when `isMulti` is `true`)
@@ -106,6 +120,10 @@ Allow new items to be created if not found. **Default:** `false`.
 #### `allowSelectAll?: boolean`
 
 Adds a `Select all` option ( when `isMulti` is `true`). Note: `allowSelectAll` is ignored when `loadOptions` is defined.
+
+#### `clearButtonClassName?: string`
+
+Class names to add to clear button (only available when `isMulti` or `isClearable`). **Default:** `btn btn-link link`
 
 ### `waitUntilFocused?: boolean`
 

--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -6,13 +6,13 @@ Select dropdown without a Label or Feedback
 
 ### Additional Resources
 
-- `SelectStyles(showError, styles, isInline)`
+- `selectStyles(showError, styles, isInline)`
   - Extract styling of this component for cases when react-select is used directly.
   - Returns style and theme object to be spread on Select
-  - Props
+  - Args
     - `showError?: boolean` if error styling should be applied
-    - `styles?: css object` same as react-select styles prop
-    - `isInline?: boolean` if inline styling should be applied, must be within a flexbox.
+    - `styles?: StylesConfig object` refer to react-select docs for info on styles
+    - `isInline?: boolean` if inline styling should be applied, must be within a flexbox
 
 ### Example
 

--- a/packages/select/src/Select.d.ts
+++ b/packages/select/src/Select.d.ts
@@ -1,13 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ReactNode } from 'react';
-import type { Props as RSelectProps, GroupBase } from 'react-select';
+import type { Props as RSelectProps, GroupBase, StylesConfig, ThemeConfig } from 'react-select';
 import type { AsyncPaginateProps } from 'react-select-async-paginate';
 import type { FieldValidator } from 'formik';
+import React from 'react';
+
+export interface SelectStyleProps {
+  showError?: boolean;
+  styles?: React.CSSProperties;
+  isInline?: boolean;
+}
+
+export declare const SelectStyles: (props: SelectStyleProps) => {
+  styles: StylesConfig;
+  theme: ThemeConfig;
+};
 
 export type SelectProps<Option, IsMulti extends boolean, Group extends GroupBase<Option> = GroupBase<Option>> = {
   allowSelectAll?: boolean;
   autofill?: boolean | Record<string, string | ((value: any) => any)>;
   cacheUniq?: any | any[];
+  clearButtonClassName?: string = 'btn btn-link link';
   creatable?: boolean;
   feedback?: boolean;
   helpMessage?: ReactNode;
@@ -18,6 +31,7 @@ export type SelectProps<Option, IsMulti extends boolean, Group extends GroupBase
   name: string;
   onChange?: (value: Option) => void;
   raw?: boolean;
+  required?: boolean;
   selectRef?: AsyncPaginateProps<Option, Group, any, IsMulti>['selectRef'];
   validate?: FieldValidator;
   waitUntilFocused?: boolean;

--- a/packages/select/src/Select.d.ts
+++ b/packages/select/src/Select.d.ts
@@ -3,15 +3,14 @@ import type { ReactNode } from 'react';
 import type { Props as RSelectProps, GroupBase, StylesConfig, ThemeConfig } from 'react-select';
 import type { AsyncPaginateProps } from 'react-select-async-paginate';
 import type { FieldValidator } from 'formik';
-import React from 'react';
 
-export interface SelectStyleProps {
+export interface SelectStyleArgs {
   showError?: boolean;
-  styles?: React.CSSProperties;
+  styles?: StylesConfig;
   isInline?: boolean;
 }
 
-export declare const SelectStyles: (props: SelectStyleProps) => {
+export declare const selectStyles: (props: SelectStyleArgs) => {
   styles: StylesConfig;
   theme: ThemeConfig;
 };
@@ -20,7 +19,7 @@ export type SelectProps<Option, IsMulti extends boolean, Group extends GroupBase
   allowSelectAll?: boolean;
   autofill?: boolean | Record<string, string | ((value: any) => any)>;
   cacheUniq?: any | any[];
-  clearButtonClassName?: string = 'btn btn-link link';
+  clearButtonClassName?: string;
   creatable?: boolean;
   feedback?: boolean;
   helpMessage?: ReactNode;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useField, useFormikContext } from 'formik';
-import RSelect, { components as reactSelectComponents } from 'react-select';
+import RSelect, { components as reactSelectComponents, selectProps } from 'react-select';
 import Creatable from 'react-select/creatable';
 import { AsyncPaginate as Async, withAsyncPaginate } from 'react-select-async-paginate';
 import get from 'lodash/get';
@@ -11,7 +11,7 @@ import has from 'lodash/has';
 import isFunction from 'lodash/isFunction';
 import isEqual from 'lodash/isEqual';
 
-const { DownChevron, CrossIcon, DropdownIndicator, ClearIndicator, Option, MultiValueRemove } = reactSelectComponents;
+const { DownChevron, DropdownIndicator, Input, Option, MultiValueRemove } = reactSelectComponents;
 
 const CreatableAsyncPaginate = withAsyncPaginate(Creatable);
 
@@ -22,18 +22,10 @@ const components = {
       <span className="sr-only">Toggle Select Options</span>
     </DropdownIndicator>
   ),
-  ClearIndicator: (props) => {
-    const innerProps = {
-      ...props.innerProps,
-      role: 'button',
-      'aria-hidden': false,
-    };
-    return (
-      <ClearIndicator {...props} innerProps={innerProps}>
-        <CrossIcon />
-        <span className="sr-only">Clear all selections</span>
-      </ClearIndicator>
-    );
+  ClearIndicator: () => null,
+  Input: (props) => {
+    const { 'aria-required': required } = props.selectProps;
+    return <Input {...props} aria-required={required} />;
   },
   Option: (props) => {
     const innerProps = {
@@ -75,6 +67,107 @@ const validateSelectAllOptions = (options) => {
   }
 };
 
+// needed for inline styling of clear button
+const wrapperStyle = { display: 'flex' };
+
+export const SelectStyles = (showError, styles, isInline) => ({
+  styles: {
+    ...styles,
+    container: (provided) => ({
+      ...provided,
+      display: isInline ? 'inline-flex' : 'inherit',
+      flexGrow: '1',
+    }),
+    placeholder: (provided, state) => {
+      if (state.isDisabled) {
+        return {
+          ...provided,
+          borderColor: '#ced4da',
+          color: '#495057',
+        };
+      }
+      const showErrors = showError && !state.focused;
+
+      return {
+        ...provided,
+        color: showErrors ? '#3D3D3D' : '#666',
+        maxWidth: '99%',
+      };
+    },
+    valueContainer: (provided) => ({
+      ...provided,
+      width: '90%',
+    }),
+    singleValue: (provided) => ({
+      ...provided,
+      color: '#495057',
+    }),
+    control: (provided, state) => {
+      if (state.isDisabled) {
+        return {
+          ...provided,
+          flexGrow: '1',
+          borderRadius: '0.25em',
+          borderColor: 'inherit',
+          backgroundColor: '#e9ecef',
+        };
+      }
+
+      return {
+        ...provided,
+        flexGrow: '1',
+        borderRadius: '0.25em',
+        backgroundColor: 'white',
+        borderColor: showError ? '#dc3545' : '#555',
+        ':hover': {
+          borderColor: showError ? '#dc3545' : '#555',
+          cursor: 'text',
+        },
+        ':focus-within': {
+          borderColor: showError ? '#dc3545' : '#2261b5',
+          boxShadow: showError ? '0 0 0 0.2rem rgba(220 53 69 / 25%)' : '0 0 0 0.2rem #2261b5',
+        },
+        zIndex: state.focused && '3',
+      };
+    },
+    menu: (provided) => ({ ...provided, borderRadius: '.25em' }),
+    multiValue: (provided) => ({
+      ...provided,
+      borderRadius: '0.25em',
+      width: 'auto',
+    }),
+    input: (provided) => ({
+      ...provided,
+      maxWidth: '99%',
+    }),
+    dropdownIndicator: (provided, state) => {
+      if (state.isDisabled) {
+        return provided;
+      }
+      const showErrors = showError && !state.focused;
+
+      return {
+        ...provided,
+        pointerEvents: 'none',
+        color: showErrors ? '#dc3545' : '#555',
+      };
+    },
+    option: (provided) => ({
+      ...provided,
+    }),
+  },
+  theme: (theme) => ({
+    ...theme,
+    borderRadius: 0,
+    boxShadow: 0,
+    colors: {
+      ...theme.colors,
+      primary25: '#b8d4fb',
+      primary: '#3262af',
+    },
+  }),
+});
+
 const Select = ({
   name,
   validate,
@@ -92,6 +185,8 @@ const Select = ({
   feedback,
   placeholder,
   components: componentOverrides,
+  required,
+  clearButtonClassName,
   ...attributes
 }) => {
   const [{ onChange, value: fieldValue, ...field }, { touched, error: fieldError }] = useField({
@@ -101,6 +196,8 @@ const Select = ({
   const { values, setFieldValue, initialValues } = useFormikContext();
 
   const [newOptions, setNewOptions] = useState([]);
+
+  const errorShown = touched && fieldError;
 
   let _cacheUniq = attributes.cacheUniq;
 
@@ -113,7 +210,7 @@ const Select = ({
     <>
       {placeholder || 'Select...'}
       <span className="sr-only">
-        {(touched && fieldError) || null} {helpMessage || null}
+        {errorShown || null} {helpMessage || null}
       </span>
     </>
   );
@@ -306,128 +403,55 @@ const Select = ({
   }
 
   return (
-    <Tag
-      {...field}
-      onChange={onChangeHandler}
-      ref={attributes.loadOptions ? undefined : selectRef}
-      selectRef={attributes.loadOptions ? selectRef : undefined}
-      name={name}
-      classNamePrefix="av"
-      role="listbox"
-      onCreateOption={handleCreate}
-      className={classNames(
-        className,
-        'av-select',
-        touched ? 'is-touched' : 'is-untouched',
-        fieldError ? 'av-invalid' : 'av-valid',
-        touched && fieldError && 'is-invalid'
-      )}
-      getOptionLabel={getOptionLabel}
-      getOptionValue={getOptionValue}
-      closeMenuOnSelect={!attributes.isMulti}
-      aria-invalid={fieldError && touched}
-      aria-errormessage={feedback && fieldValue && fieldError && touched ? `${name}-feedback`.toLowerCase() : ''}
-      placeholder={placeholder}
-      components={{ ...components, ...componentOverrides }}
-      options={selectOptions}
-      defaultOptions={waitUntilFocused ? [] : true}
-      cacheUniqs={_cacheUniq}
-      styles={{
-        ...styles,
-        placeholder: (provided, state) => {
-          if (state.isDisabled) {
-            return {
-              ...provided,
-              borderColor: '#ced4da',
-            };
-          }
-          const showError = touched && fieldError && !state.focused;
-
-          return {
-            ...provided,
-            color: showError ? '#3D3D3D' : '#666',
-            maxWidth: '99%',
-          };
-        },
-        valueContainer: (provided) => ({
-          ...provided,
-          width: '90%',
-        }),
-        singleValue: (provided) => ({
-          ...provided,
-          color: '#495057',
-        }),
-        control: (provided, state) => {
-          if (state.isDisabled) {
-            return {
-              ...provided,
-              borderRadius: '0.25em',
-              borderColor: 'inherit',
-              backgroundColor: '#e9ecef',
-            };
-          }
-          const showError = touched && fieldError;
-
-          return {
-            ...provided,
-            borderRadius: '0.25em',
-            backgroundColor: 'white',
-            borderColor: showError ? '#dc3545' : '#555',
-            ':hover': {
-              borderColor: showError ? '#dc3545' : '#555',
-              cursor: 'text',
-            },
-            ':focus-within': {
-              borderColor: showError ? '#dc3545' : '#2261b5',
-              boxShadow: showError ? '0 0 0 0.2rem rgba(220 53 69 / 25%)' : '0 0 0 0.2rem #2261b5',
-            },
-            zIndex: state.focused && '3',
-          };
-        },
-        menu: (provided) => ({ ...provided, borderRadius: '.25em' }),
-        multiValue: (provided) => ({
-          ...provided,
-          borderRadius: '0.25em',
-          width: 'auto',
-        }),
-        input: (provided) => ({
-          ...provided,
-          maxWidth: '99%',
-        }),
-        dropdownIndicator: (provided, state) => {
-          if (state.isDisabled) {
-            return provided;
-          }
-          const showError = touched && fieldError && !state.focused;
-
-          return {
-            ...provided,
-            pointerEvents: 'none',
-            color: showError ? '#dc3545' : '#555',
-          };
-        },
-        option: (provided) => ({
-          ...provided,
-        }),
-      }}
-      theme={(theme) => ({
-        ...theme,
-        borderRadius: 0,
-        boxShadow: 0,
-        colors: {
-          ...theme.colors,
-          primary25: '#b8d4fb',
-          primary: '#3262af',
-        },
-      })}
-      {...attributes}
-      value={getViewValue()}
-    />
+    <div style={wrapperStyle}>
+      <Tag
+        {...field}
+        onChange={onChangeHandler}
+        ref={attributes.loadOptions ? undefined : selectRef}
+        selectRef={attributes.loadOptions ? selectRef : undefined}
+        name={name}
+        classNamePrefix="av"
+        role="listbox"
+        onCreateOption={handleCreate}
+        className={classNames(
+          className,
+          'av-select',
+          touched ? 'is-touched' : 'is-untouched',
+          fieldError ? 'av-invalid' : 'av-valid',
+          touched && fieldError && 'is-invalid'
+        )}
+        getOptionLabel={getOptionLabel}
+        getOptionValue={getOptionValue}
+        closeMenuOnSelect={!attributes.isMulti}
+        aria-invalid={!!errorShown || undefined}
+        aria-errormessage={feedback && fieldValue && errorShown ? `${name}-feedback`.toLowerCase() : ''}
+        aria-required={required}
+        placeholder={placeholder}
+        components={{ ...components, ...componentOverrides }}
+        options={selectOptions}
+        defaultOptions={waitUntilFocused ? [] : true}
+        cacheUniqs={_cacheUniq}
+        {...SelectStyles(!!errorShown, styles, attributes.isClearable || attributes.isMulti)}
+        {...attributes}
+        value={getViewValue()}
+      />
+      {attributes.isClearable || attributes.isMulti ? (
+        <button
+          type="button"
+          className={clearButtonClassName}
+          onClick={() => onChangeHandler(attributes.isMulti ? [] : null)}
+        >{`clear${attributes.isMulti ? ' all' : ''}`}</button>
+      ) : null}
+    </div>
   );
 };
 
 Select.defaultTypes = {
   waitUntilFocused: false,
+};
+
+Select.defaultProps = {
+  clearButtonClassName: 'btn btn-link link',
 };
 
 Select.propTypes = {
@@ -449,6 +473,8 @@ Select.propTypes = {
   feedback: PropTypes.bool,
   placeholder: PropTypes.string,
   components: PropTypes.object,
+  required: PropTypes.bool,
+  clearButtonClassName: PropTypes.string,
 };
 
 components.Option.propTypes = {
@@ -456,12 +482,18 @@ components.Option.propTypes = {
   isSelected: PropTypes.bool,
 };
 
-components.ClearIndicator.propTypes = {
-  innerProps: PropTypes.object,
+components.Input.propTypes = {
+  selectProps,
 };
 
 components.MultiValueRemove.propTypes = {
   innerProps: PropTypes.object,
+};
+
+SelectStyles.propTypes = {
+  showError: PropTypes.bool,
+  isInline: PropTypes.bool,
+  styles: PropTypes.object,
 };
 
 export default Select;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -70,7 +70,7 @@ const validateSelectAllOptions = (options) => {
 // needed for inline styling of clear button
 const wrapperStyle = { display: 'flex' };
 
-export const SelectStyles = (showError, styles, isInline) => ({
+export const selectStyles = (showError, styles, isInline) => ({
   styles: {
     ...styles,
     container: (provided) => ({
@@ -418,7 +418,7 @@ const Select = ({
           'av-select',
           touched ? 'is-touched' : 'is-untouched',
           fieldError ? 'av-invalid' : 'av-valid',
-          touched && fieldError && 'is-invalid'
+          errorShown && 'is-invalid'
         )}
         getOptionLabel={getOptionLabel}
         getOptionValue={getOptionValue}
@@ -431,7 +431,7 @@ const Select = ({
         options={selectOptions}
         defaultOptions={waitUntilFocused ? [] : true}
         cacheUniqs={_cacheUniq}
-        {...SelectStyles(!!errorShown, styles, attributes.isClearable || attributes.isMulti)}
+        {...selectStyles(!!errorShown, styles, attributes.isClearable || attributes.isMulti)}
         {...attributes}
         value={getViewValue()}
       />
@@ -488,12 +488,6 @@ components.Input.propTypes = {
 
 components.MultiValueRemove.propTypes = {
   innerProps: PropTypes.object,
-};
-
-SelectStyles.propTypes = {
-  showError: PropTypes.bool,
-  isInline: PropTypes.bool,
-  styles: PropTypes.object,
 };
 
 export default Select;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useField, useFormikContext } from 'formik';
-import RSelect, { components as reactSelectComponents, selectProps } from 'react-select';
+import RSelect, { components as reactSelectComponents } from 'react-select';
 import Creatable from 'react-select/creatable';
 import { AsyncPaginate as Async, withAsyncPaginate } from 'react-select-async-paginate';
 import get from 'lodash/get';
@@ -483,7 +483,7 @@ components.Option.propTypes = {
 };
 
 components.Input.propTypes = {
-  selectProps,
+  selectProps: PropTypes.object,
 };
 
 components.MultiValueRemove.propTypes = {

--- a/packages/select/src/index.d.ts
+++ b/packages/select/src/index.d.ts
@@ -1,4 +1,4 @@
-export { default, SelectProps } from './Select';
+export { default, SelectProps, SelectStyleProps } from './Select';
 export { default as SelectField, SelectFieldProps } from './SelectField';
 export { default as ResourceSelect, ResourceSelectProps } from './ResourceSelect';
 export * from './resources';

--- a/packages/select/src/index.d.ts
+++ b/packages/select/src/index.d.ts
@@ -1,4 +1,4 @@
-export { default, SelectProps, SelectStyleProps } from './Select';
+export { default, SelectProps, selectStyles, SelectStyleArgs } from './Select';
 export { default as SelectField, SelectFieldProps } from './SelectField';
 export { default as ResourceSelect, ResourceSelectProps } from './ResourceSelect';
 export * from './resources';

--- a/packages/select/src/index.js
+++ b/packages/select/src/index.js
@@ -1,4 +1,4 @@
-export { default, SelectStyles } from './Select';
+export { default, selectStyles } from './Select';
 export { default as SelectField } from './SelectField';
 export { default as ResourceSelect } from './ResourceSelect';
 export * from './resources';

--- a/packages/select/src/index.js
+++ b/packages/select/src/index.js
@@ -1,4 +1,4 @@
-export { default } from './Select';
+export { default, SelectStyles } from './Select';
 export { default as SelectField } from './SelectField';
 export { default as ResourceSelect } from './ResourceSelect';
 export * from './resources';

--- a/packages/select/stories/SelectField.stories.tsx
+++ b/packages/select/stories/SelectField.stories.tsx
@@ -7,7 +7,7 @@ import { Field } from '@availity/form';
 import { SelectField } from '../src';
 // import README from '../README.md';
 
-import { singleValueSchema, multiValueSchema, options, SelectedOption } from './utils';
+import { singleValueSchema, multiValueSchema, options, autofillOptions, SelectedOption } from './utils';
 import FormikResults from '../../../story-utils/FormikResults';
 
 export default {
@@ -24,7 +24,8 @@ export default {
     helpId: '',
     helpMessage: 'This is a message to provide guidance',
     isMulti: false,
-    label: 'Select Field Label',
+    isClearable: false,
+    label: 'Select Field',
     min: 2,
     max: 3,
     raw: false,
@@ -39,6 +40,7 @@ export const SelectFieldStory: Story = ({
   helpId,
   helpMessage,
   isMulti,
+  isClearable,
   label,
   max,
   min,
@@ -54,7 +56,11 @@ export const SelectFieldStory: Story = ({
       autoFill1: '',
       autoFill2: '',
     }}
-    validationSchema={isMulti ? multiValueSchema('select', required, min, max) : singleValueSchema('select', required)}
+    validationSchema={
+      isMulti
+        ? multiValueSchema('select', required, min, max, !autofill)
+        : singleValueSchema('select', required, !autofill)
+    }
   >
     <Row>
       <Col>
@@ -66,9 +72,10 @@ export const SelectFieldStory: Story = ({
           helpMessage={helpMessage}
           isDisabled={disabled}
           isMulti={isMulti}
+          isClearable={isClearable}
           label={label}
           maxLength={max}
-          options={options}
+          options={!autofill ? options : autofillOptions}
           raw={raw}
           required={required}
         />

--- a/packages/select/stories/SelectField.stories.tsx
+++ b/packages/select/stories/SelectField.stories.tsx
@@ -58,33 +58,48 @@ export const SelectFieldStory: Story = ({
     }}
     validationSchema={
       isMulti
-        ? multiValueSchema('select', required, min, max, !autofill)
-        : singleValueSchema('select', required, !autofill)
+        ? multiValueSchema('select', required, min, max, !autofill && !raw)
+        : singleValueSchema('select', required, !autofill && !raw)
     }
   >
     <Row>
       <Col>
-        <SelectField
-          name="select"
-          autofill={autofill}
-          creatable={creatable}
-          helpId={helpId}
-          helpMessage={helpMessage}
-          isDisabled={disabled}
-          isMulti={isMulti}
-          isClearable={isClearable}
-          label={label}
-          maxLength={max}
-          options={!autofill ? options : autofillOptions}
-          raw={raw}
-          required={required}
-        />
         {autofill ? (
           <>
+            <SelectField
+              name="select"
+              label={label}
+              autofill
+              creatable={creatable}
+              helpId={helpId}
+              helpMessage={helpMessage}
+              isDisabled={disabled}
+              isMulti={isMulti}
+              isClearable={isClearable}
+              maxLength={max}
+              options={autofillOptions}
+              raw={raw}
+              required={required}
+            />
             <Field name="autoFill1" type="text" label="Autofill Value 1" />
             <Field name="autoFill2" type="text" label="Autofill Value 2" />
           </>
-        ) : null}
+        ) : (
+          <SelectField
+            name="select"
+            label={label}
+            creatable={creatable}
+            helpId={helpId}
+            helpMessage={helpMessage}
+            isDisabled={disabled}
+            isMulti={isMulti}
+            isClearable={isClearable}
+            maxLength={max}
+            options={options}
+            raw={raw}
+            required={required}
+          />
+        )}
         <Button color="primary" type="submit">
           Submit
         </Button>

--- a/packages/select/stories/select.stories.tsx
+++ b/packages/select/stories/select.stories.tsx
@@ -8,7 +8,7 @@ import Select from '../src';
 // import README from '../README.md';
 
 import FormikResults from '../../../story-utils/FormikResults';
-import { singleValueSchema, multiValueSchema, options, SelectedOption } from './utils';
+import { singleValueSchema, multiValueSchema, options, SelectedOption, autofillOptions } from './utils';
 
 export default {
   title: 'Form Components/Select',
@@ -23,6 +23,7 @@ export default {
     disabled: false,
     helpMessage: 'This is a message to provide guidance',
     isMulti: false,
+    isClearable: false,
     min: 2,
     max: 3,
     raw: false,
@@ -30,7 +31,18 @@ export default {
   },
 } as Meta;
 
-export const Default: Story = ({ autofill, creatable, disabled, helpMessage, isMulti, max, min, raw, required }) => (
+export const Default: Story = ({
+  autofill,
+  creatable,
+  disabled,
+  helpMessage,
+  isMulti,
+  isClearable,
+  max,
+  min,
+  raw,
+  required,
+}) => (
   <FormikResults
     onSubmit={() => {
       console.log('submitted');
@@ -40,28 +52,48 @@ export const Default: Story = ({ autofill, creatable, disabled, helpMessage, isM
       autoFill1: '',
       autoFill2: '',
     }}
-    validationSchema={isMulti ? multiValueSchema('select', required, min, max) : singleValueSchema('select', required)}
+    validationSchema={
+      isMulti
+        ? multiValueSchema('select', required, min, max, !autofill)
+        : singleValueSchema('select', required, !autofill)
+    }
   >
     <Row>
       <Col>
-        <Select
-          name="select"
-          aria-label="stand-alone"
-          autofill={autofill}
-          creatable={creatable}
-          helpMessage={helpMessage}
-          isDisabled={disabled}
-          isMulti={isMulti}
-          maxLength={max}
-          options={options}
-          raw={raw}
-        />
         {autofill ? (
           <>
+            <Select
+              name="select"
+              aria-label="stand-alone"
+              autofill
+              creatable={creatable}
+              helpMessage={helpMessage}
+              isDisabled={disabled}
+              isMulti={isMulti}
+              isClearable={isClearable}
+              maxLength={max}
+              options={autofillOptions}
+              raw={raw}
+              required={required}
+            />
             <Field name="autoFill1" type="text" label="Autofill Value 1" />
             <Field name="autoFill2" type="text" label="Autofill Value 2" />
           </>
-        ) : null}
+        ) : (
+          <Select
+            name="select"
+            aria-label="stand-alone"
+            creatable={creatable}
+            helpMessage={helpMessage}
+            isDisabled={disabled}
+            isMulti={isMulti}
+            isClearable={isClearable}
+            maxLength={max}
+            options={options}
+            raw={raw}
+            required={required}
+          />
+        )}
         <Button className="mt-3" color="primary" type="submit">
           Submit
         </Button>

--- a/packages/select/stories/select.stories.tsx
+++ b/packages/select/stories/select.stories.tsx
@@ -54,8 +54,8 @@ export const Default: Story = ({
     }}
     validationSchema={
       isMulti
-        ? multiValueSchema('select', required, min, max, !autofill)
-        : singleValueSchema('select', required, !autofill)
+        ? multiValueSchema('select', required, min, max, !autofill && !raw)
+        : singleValueSchema('select', required, !autofill && !raw)
     }
   >
     <Row>

--- a/packages/select/stories/utils.tsx
+++ b/packages/select/stories/utils.tsx
@@ -4,22 +4,33 @@ import { useField } from 'formik';
 import * as yup from 'yup';
 import '@availity/yup';
 
-export const singleValueSchema = (name: string, required = false) =>
-  yup.object().shape({
-    [name]: yup.string().nullable().isRequired(required, 'This field is required.'),
-  });
+export const singleValueSchema = (name: string, required = false, stringValue = false) =>
+  stringValue
+    ? yup.object().shape({
+        [name]: yup.string().nullable().isRequired(required, 'This field is required.'),
+      })
+    : yup.object().shape({
+        [name]: yup.object().nullable().isRequired(required, 'This field is required.'),
+      });
 
-export const multiValueSchema = (name: string, required: boolean, min: number, max: number) =>
+export const multiValueSchema = (name: string, required: boolean, min: number, max: number, stringValue?: boolean) =>
   yup.object().shape({
     [name]: yup
       .array()
-      .of(yup.string())
+      .of(stringValue ? yup.string() : yup.object())
       .min(min, `Must select at least ${min} option${min !== 1 && 's'}.`)
       .max(max, `Cannot select more than ${max} option${max !== 1 && 's'}.`)
       .isRequired(required, 'This field is required.'),
   });
 
 export const options = [
+  { label: 'Option 1', value: 'value for option 1' },
+  { label: 'Option 2', value: 'value for option 2' },
+  { label: 'Option 3', value: 'value for option 3' },
+  { label: 'Option 4', value: 'value for option 4' },
+];
+
+export const autofillOptions = [
   {
     label: 'Option 1',
     value: {


### PR DESCRIPTION
- removed built-in clear field link/indicator, added clear field button outside of field
- pulled style and theme objects out of component and added as single export (issue #933 )
- required prop puts aria-required on input
