### PR TITLE
feat(spaces): hide link for ghosted configs PF-3282

### DIFF
--- a/packages/spaces/src/SpacesLink.js
+++ b/packages/spaces/src/SpacesLink.js
@@ -99,6 +99,8 @@ const Link = ({
     linkAttributes,
   });
 
+  const showUrl = link?.url && (!metadata?.ghosted || metadata.ghosted === 'false');
+
   const getIconTitle = useCallback(() => {
     if (shortName) return shortName;
 
@@ -197,7 +199,7 @@ const Link = ({
       : cloneElement(children, {
           role: 'link',
           tabIndex: 0,
-          style: { cursor: link?.url ? 'pointer' : 'not-allowed' },
+          style: { cursor: showUrl ? 'pointer' : 'not-allowed' },
           'aria-label': name,
           ...analytics,
           ...props,
@@ -237,11 +239,11 @@ const Link = ({
                   )}
                   tabIndex={0}
                   style={{
-                    cursor: link?.url ? 'pointer' : 'not-allowed',
+                    cursor: showUrl ? 'pointer' : 'not-allowed',
                   }}
                   {...analytics}
                   {...props}
-                  role={link?.url ? 'link' : role}
+                  role={showUrl ? 'link' : role}
                   aria-label={name}
                   aria-describedby={`app-new-badge-${configurationId}`}
                 >

--- a/packages/spaces/tests/SpacesLink.test.js
+++ b/packages/spaces/tests/SpacesLink.test.js
@@ -462,4 +462,72 @@ describe('SpacesLink', () => {
 
     expect(link12_title.getAttribute('role')).toBe('listitem');
   });
+
+  it('renders title without link role when ghosted', async () => {
+    const space = {
+      id: 'encoded13',
+      configurationId: '13',
+      type: 'APPLICATION',
+      name: 'no link application',
+      description: 'This is a application',
+      link: {
+        url: '/path/to/url',
+        text: 'title',
+        target: '_self',
+      },
+      metadata: {
+        ghosted: true,
+      },
+    };
+    const { container } = render(
+      <SpacesLink
+        id="application-link-13"
+        space={space}
+        linkAttributes={{
+          spaceId: '13',
+        }}
+        role="listitem"
+        clientId="my-client-id"
+        title={space.link.text}
+      />
+    );
+
+    const link13_title = await waitFor(() => container.querySelector('#app-title-13'));
+
+    expect(link13_title.getAttribute('role')).toBe('listitem');
+  });
+
+  it("renders title with link role when url is provided and ghosted = 'false'", async () => {
+    const space = {
+      id: 'encoded14',
+      configurationId: '14',
+      type: 'APPLICATION',
+      name: 'application with link',
+      description: 'This is a application',
+      link: {
+        url: '/path/to/url',
+        text: 'title',
+        target: '_self',
+      },
+      metadata: {
+        ghosted: 'false',
+      },
+    };
+    const { container } = render(
+      <SpacesLink
+        id="application-link-14"
+        space={space}
+        linkAttributes={{
+          spaceId: '14',
+        }}
+        role="listitem"
+        clientId="my-client-id"
+        title={space.link.text}
+      />
+    );
+
+    const link14_title = await waitFor(() => container.querySelector('#app-title-14'));
+
+    expect(link14_title.getAttribute('role')).toBe('link');
+  });
 });


### PR DESCRIPTION
treats ghosted as if there is no url