### PR TITLE
feat(authorize): cache region

### DIFF
--- a/packages/authorize/src/Authorize.stories.tsx
+++ b/packages/authorize/src/Authorize.stories.tsx
@@ -26,10 +26,11 @@ export default {
     organizationId: '1111',
     unauthorized: 'You are not authorized to see this content.',
     authorized: 'You are authorized to see this content.',
+    region: true,
   },
 } as Meta;
 
-export const Default: Story = ({ permissions, organizationId, negate, loader, authorized, unauthorized }) => (
+export const Default: Story = ({ authorized, loader, negate, organizationId, permissions, region, unauthorized }) => (
   <div>
     <p>
       For this demo, the following permissions are granted: 1234, 2345, 3456, 4567, 5678, 6789. You can use the knobs to
@@ -42,6 +43,7 @@ export const Default: Story = ({ permissions, organizationId, negate, loader, au
       negate={negate}
       loader={loader}
       unauthorized={<Alert color="danger">{unauthorized}</Alert>}
+      region={region}
     >
       <Alert color="success">{authorized}</Alert>
     </Authorize>
@@ -53,8 +55,8 @@ Default.args = {
 };
 Default.storyName = 'default';
 
-export const UseAuthorize: Story = ({ permissions, organizationId, unauthorized, authorized }) => {
-  const { authorized: isAuthorized, isLoading } = useAuthorize(permissions, { organizationId });
+export const UseAuthorize: Story = ({ authorized, organizationId, permissions, region, unauthorized }) => {
+  const { authorized: isAuthorized, isLoading } = useAuthorize(permissions, { organizationId, region });
 
   return (
     <div>

--- a/packages/authorize/src/api.ts
+++ b/packages/authorize/src/api.ts
@@ -2,6 +2,11 @@ import { avUserPermissionsApi, avRegionsApi } from '@availity/api-axios';
 
 import type { Permission, RequestedPermissions, RequestedResources } from './types';
 
+/**
+ * Fetch the current region for the logged in user.
+ *
+ * If the region is a string then it will be returned without fetching.
+ */
 export const getRegion = async (region?: boolean | string): Promise<string | undefined> => {
   if (region === true) {
     const resp = await avRegionsApi.getCurrentRegion();
@@ -12,14 +17,17 @@ export const getRegion = async (region?: boolean | string): Promise<string | und
   return region || undefined;
 };
 
+/**
+ * Fetch the permissions for the logged in user
+ */
 export const getPermissions = async (
   permissions: RequestedPermissions,
-  region?: boolean | string
+  region?: string
 ): Promise<Record<string, Permission>> => {
   if (!permissions) return {};
 
   // TODO: fix these types
-  const response = await avUserPermissionsApi.getPermissions(permissions as string[], await getRegion(region));
+  const response = await avUserPermissionsApi.getPermissions(permissions as string[], region);
 
   return response.reduce<Record<string, Permission>>((prev, cur) => {
     prev[cur.id] = cur;
@@ -27,6 +35,9 @@ export const getPermissions = async (
   }, {});
 };
 
+/**
+ * Validate whether the user has the permission
+ */
 export const checkPermission = (
   permission?: Permission,
   resources?: RequestedResources,
@@ -75,9 +86,12 @@ export const checkPermission = (
   return isAuthorizedForCustomerId && isAuthorizedForOrganizationId && isAuthorizedForResources;
 };
 
+/**
+ * Validate multiple permissions
+ */
 export const checkPermissions = async (
   permissions: RequestedPermissions,
-  region: boolean | string = true,
+  region?: string,
   resources?: RequestedResources,
   organizationId?: string,
   customerId?: string


### PR DESCRIPTION
The `getRegion` call now uses `react-query` in order to cache the response