### PR TITLE
fix(pagination): update div to li to fix 508 compliance issues

### DIFF
--- a/packages/pagination/CHANGELOG.md
+++ b/packages/pagination/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [2.15.3-alpha.0](https://github.com/Availity/availity-react/compare/@availity/pagination@2.15.2...@availity/pagination@2.15.3-alpha.0) (2022-08-18)
+
+
+### Bug Fixes
+
+* **pagination:** update div to li to fix 508 compliance issues ([8a34a7f](https://github.com/Availity/availity-react/commit/8a34a7f3aa9eff579ec984c0bbfc107af0a7af60))
+
+
+
 ## [2.15.2](https://github.com/Availity/availity-react/compare/@availity/pagination@2.15.1...@availity/pagination@2.15.2) (2022-07-28)
 
 

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/pagination",
-  "version": "2.15.2",
+  "version": "2.15.3-alpha.0",
   "description": "component for displaying paginated data",
   "keywords": [
     "availity",

--- a/packages/pagination/src/PaginationControls.tsx
+++ b/packages/pagination/src/PaginationControls.tsx
@@ -153,9 +153,9 @@ const PaginationControls = ({
         ''
       )}
       {showPaginationText && (
-        <div data-testid="pagination-text" className="pagination-text pt-1 pl-2 pr-2">
+        <li data-testid="pagination-text" className="pagination-text pt-1 pl-2 pr-2">
           {populatePaginationText ? populatePaginationText(lower, upper, total) : `${lower}-${upper} of ${total}`}
-        </div>
+        </li>
       )}
     </Pagination>
   ) : null;


### PR DESCRIPTION
We are focusing on fixing 508 compliance issues, and ran into the following violation with the pagination component, specifically involving the pagination text.

 **This UL should only contain li elements (without an ARIA-assigned role), script elements (without an ARIA-assigned role) or template elements (without an ARIA-assigned role); or elements with a role=listitem attribute; as direct child elements**
 
 This is because the text was in a `<div>` rather than an `<li>`.