### PR TITLE
fix(form): Fix Currency Input: Don't allow negatives by default & fix issue when decimal is entered as first character

### DIFF
--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [1.5.3-alpha.0](https://github.com/Availity/availity-react/compare/@availity/form@1.5.2...@availity/form@1.5.3-alpha.0) (2022-08-30)
+
+
+### Bug Fixes
+
+* **form:** prevent negative values in currency input, issues with decimals first ([bbf5389](https://github.com/Availity/availity-react/commit/bbf53897b811771979fae367c902d4dcaed2e4d3))
+
+
+
 ## [1.5.2](https://github.com/Availity/availity-react/compare/@availity/form@1.5.1...@availity/form@1.5.2) (2022-08-29)
 
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/form",
-  "version": "1.5.2",
+  "version": "1.5.3-alpha.0",
   "description": "Form Wrapper around formik using reactstrap components",
   "keywords": [
     "react",

--- a/packages/form/src/CurrencyInput.tsx
+++ b/packages/form/src/CurrencyInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactCurrencyInput from 'react-currency-input-field';
+import ReactCurrencyInput, { CurrencyInputProps } from 'react-currency-input-field';
 import classnames from 'classnames';
 import { useField, useFormikContext } from 'formik';
 import Feedback from './Feedback';
@@ -11,9 +11,9 @@ type Props = {
   placeholder?: string;
   disabled?: boolean;
   onValueChanged: (value: string | undefined) => void;
-};
+} & CurrencyInputProps;
 
-const CurrencyInput = ({ id, name, value, placeholder, disabled, onValueChanged }: Props) => {
+const CurrencyInput = ({ id, name, value, placeholder, disabled, onValueChanged, ...attributes }: Props) => {
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const [, metadata] = useField({
     name,
@@ -71,6 +71,15 @@ const CurrencyInput = ({ id, name, value, placeholder, disabled, onValueChanged 
           formatDecimals(event.target.value.replace('$', ''));
         }}
         onValueChange={onValueChanged}
+        allowNegativeValue={false}
+        transformRawValue={(rawValue: string) => {
+          // This resolves an issue where entering decimals first will not format properly: https://github.com/cchanxzy/react-currency-input-field/issues/249
+          if (rawValue && rawValue.startsWith('.')) {
+            return `0${rawValue}`;
+          }
+          return rawValue;
+        }}
+        {...attributes}
       />
       <Feedback name={name} />
     </>

--- a/packages/form/tests/CurrencyInput.test.js
+++ b/packages/form/tests/CurrencyInput.test.js
@@ -121,4 +121,27 @@ describe('CurrencyInput', () => {
 
     expect(container.querySelector('input').getAttribute('id')).toEqual('paidAmountId');
   });
+
+  test('should transform raw value when decimal is entered first', () => {
+    const { container } = render(
+      <Form
+        onSubmit={() => {}}
+        initialValues={{
+          paidAmount: '',
+        }}
+      >
+        <CurrencyInput name="paidAmount" id="paidAmountId" />
+      </Form>
+    );
+
+    const currencyInput = container.querySelector('input');
+
+    fireEvent.focus(currencyInput);
+    fireEvent.change(currencyInput, { target: { value: '.1' } });
+    fireEvent.blur(currencyInput);
+
+    setTimeout(() => {
+      expect(currencyInput.value).toEqual('$0.10');
+    });
+  });
 });


### PR DESCRIPTION
**This PR will handle the following:**
- Update props for the CurrencyInput to extend CurrencyInputProps from react-currency-input-field to be able to override or set additional properties on the field.
- By default, don't allow negative values.
- Fix issue where entering '.10' will format to $1.00 instead of $0.10 as expected (error that is reported as an issue for the component and a suggested fix here: https://github.com/cchanxzy/react-currency-input-field/issues/249) 