### PR TITLE
refactor(spaces): separate link handling from bootstrap dependent code

### DIFF
--- a/packages/spaces/src/linkHandlers.js
+++ b/packages/spaces/src/linkHandlers.js
@@ -25,7 +25,7 @@ export const openLink = async (space, { akaname, linkAttributes }) => {
   window.open(url, target);
 };
 
-export const linkSso = async (space, { akaname, clientId, linkAttributes, event }) => {
+export const openSsoLink = async (space, { akaname, clientId, linkAttributes, event }) => {
   if (space.metadata && space.metadata.ssoId) {
     event.preventDefault();
 
@@ -36,7 +36,6 @@ export const linkSso = async (space, { akaname, clientId, linkAttributes, event 
       X_XSRF_TOKEN: document.cookie.replace(/(?:(?:^|.*;\s*)XSRF-TOKEN\s*=\s*([^;]*).*$)|^.*$/, '$1'),
       // TODO: this attribute gets set on the html form, does it ever make it to magneto? what is it used for?
       // seems to have logging implications
-      // spaceId: parents && parents[0] ? parents[0].id : linkAttributes.spaceId,
       spaceId: linkAttributes.spaceId,
       ...linkAttributes,
     };

--- a/packages/spaces/src/useLink.js
+++ b/packages/spaces/src/useLink.js
@@ -1,7 +1,7 @@
 import { useCurrentUser } from '@availity/hooks';
 import { useSpaces, useSpacesContext } from './Spaces';
 import { useModal } from './modals/ModalProvider';
-import { openLink, linkSso } from './linkHandlers';
+import { openLink, openSsoLink } from './linkHandlers';
 
 export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} } = {}) => {
   const { clientId = propsClientId } = useSpacesContext() || {};
@@ -51,9 +51,9 @@ export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} }
   };
 
   if (metadata?.ssoId) {
-    mediaProps.onClick = (event) => linkSso(space, { event, akaname: user.akaname, clientId, linkAttributes });
+    mediaProps.onClick = (event) => openSsoLink(space, { event, akaname: user.akaname, clientId, linkAttributes });
     mediaProps.onKeyPress = (event) =>
-      event.charCode === 13 && linkSso(space, { event, akaname: user.akaname, clientId, linkAttributes });
+      event.charCode === 13 && openSsoLink(space, { event, akaname: user.akaname, clientId, linkAttributes });
   } else if (metadata?.disclaimerId) {
     mediaProps.onClick = legacySso;
     mediaProps.onKeyPress = (e) => e.charCode === 13 && legacySso(e);

--- a/packages/spaces/src/useLink.js
+++ b/packages/spaces/src/useLink.js
@@ -1,10 +1,7 @@
-import nativeForm from '@availity/native-form';
-import { getUrl, getTarget } from '@availity/link';
-import { isAbsoluteUrl } from '@availity/resolve-url';
 import { useCurrentUser } from '@availity/hooks';
 import { useSpaces, useSpacesContext } from './Spaces';
-import { updateTopApps, updateUrl } from './helpers';
 import { useModal } from './modals/ModalProvider';
+import { openLink, linkSso } from './linkHandlers';
 
 export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} } = {}) => {
   const { clientId = propsClientId } = useSpacesContext() || {};
@@ -15,16 +12,9 @@ export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} }
 
   const openModal = useModal();
 
-  const {
-    metadata = {},
-    parents = [],
-    name,
-    type,
-    configurationId,
-    description,
-    link = {},
-    ...space
-  } = spaceFromSpacesProvider || (typeof spaceOrSpaceId === 'object' ? spaceOrSpaceId : {});
+  const space = spaceFromSpacesProvider || (typeof spaceOrSpaceId === 'object' ? spaceOrSpaceId : {});
+
+  const { metadata = {}, parents = [], name, type, configurationId, description, link = {} } = space;
 
   const parentPayerSpaces = parents.filter(
     (p) => p.type && (p.type.toLowerCase() === 'space' || p.type.toLowerCase() === 'payerspace') // no world stuff
@@ -41,57 +31,6 @@ export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} }
       link,
       user: user.akaname,
     });
-  };
-
-  const linkSso = async (event) => {
-    if (metadata && metadata.ssoId) {
-      event.preventDefault();
-
-      const options = link.target ? { target: getTarget(link.target) } : undefined;
-
-      const attributes = {
-        X_Client_ID: clientId,
-        X_XSRF_TOKEN: document.cookie.replace(/(?:(?:^|.*;\s*)XSRF-TOKEN\s*=\s*([^;]*).*$)|^.*$/, '$1'),
-        // TODO: this attribute gets set on the html form, does it ever make it to magneto? what is it used for?
-        // seems to have logging implications
-        // spaceId: parents && parents[0] ? parents[0].id : linkAttributes.spaceId,
-        spaceId: linkAttributes.spaceId,
-        ...linkAttributes,
-      };
-
-      try {
-        await updateTopApps(configurationId, type, user.akaname);
-        await nativeForm(metadata.ssoId, attributes, options, type);
-      } catch {
-        // eslint-disable-next-line no-console
-        console.warn('Something went wrong');
-      }
-
-      return false;
-    }
-    return false;
-  };
-
-  const openLink = async () => {
-    if (!link.url) {
-      return;
-    }
-
-    await updateTopApps(configurationId, type, user.akaname);
-
-    const target = getTarget(link.target);
-    const url = !isAbsoluteUrl(link.url)
-      ? getUrl(
-          updateUrl(
-            link.url,
-            'spaceId',
-            space.parents && space.parents[0] ? space.parents[0].id : linkAttributes.spaceId
-          ),
-          false,
-          false
-        )
-      : link.url;
-    window.open(url, target);
   };
 
   const openMultiPayerModal = () =>
@@ -112,8 +51,9 @@ export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} }
   };
 
   if (metadata?.ssoId) {
-    mediaProps.onClick = linkSso;
-    mediaProps.onKeyPress = (e) => e.charCode === 13 && linkSso(e);
+    mediaProps.onClick = (event) => linkSso(space, { event, akaname: user.akaname, clientId, linkAttributes });
+    mediaProps.onKeyPress = (event) =>
+      event.charCode === 13 && linkSso(space, { event, akaname: user.akaname, clientId, linkAttributes });
   } else if (metadata?.disclaimerId) {
     mediaProps.onClick = legacySso;
     mediaProps.onKeyPress = (e) => e.charCode === 13 && legacySso(e);
@@ -121,8 +61,8 @@ export default (spaceOrSpaceId, { clientId: propsClientId, linkAttributes = {} }
     mediaProps.onClick = openMultiPayerModal;
     mediaProps.onKeyPress = (e) => e.charCode === 13 && openMultiPayerModal(e);
   } else {
-    mediaProps.onClick = openLink;
-    mediaProps.onKeyPress = (e) => e.charCode === 13 && openLink(e);
+    mediaProps.onClick = () => openLink(space, { akaname: user.akaname, linkAttributes });
+    mediaProps.onKeyPress = (e) => e.charCode === 13 && openLink(space, { akaname: user.akaname, linkAttributes });
   }
 
   return [

--- a/packages/spaces/types/linkHandlers.d.ts
+++ b/packages/spaces/types/linkHandlers.d.ts
@@ -1,0 +1,19 @@
+import { Space } from './Spaces';
+
+export function openLink(
+  space: Space,
+  {
+    akaname: string,
+    linkAttributes: { spaceId: string },
+  }
+): Promise<void>;
+
+export function openLink(
+  space: Space,
+  {
+    akaname: string,
+    clientId: string,
+    linkAttributes: { spaceId: string },
+    event: Event,
+  }
+): Promise<boolean>;


### PR DESCRIPTION
I'd like to use some of the functionality from useLink, but I need it usable in an app without bootstrap. So I'm separating the code into separate modules based on whether or not it depends on bootstrap.
