### PR TITLE
feat(form-upload): add prop btnColor to Upload component

### DIFF
--- a/docusaurus/docs/form/upload/upload.md
+++ b/docusaurus/docs/form/upload/upload.md
@@ -106,6 +106,10 @@ const Example = () => (
 
 Identifies the field and matches the validation schema.
 
+#### `btnColor?: string`
+
+The color of the button. Refer to the Reactstrap documentation to determine which colors are available. **Default:** `light`.
+
 #### `btnText?: ReactNode`
 
 `+ Add File` for initial file or `+ Add Another File Attachment` if an attachment already have been selected. | The text that appears on the button.

--- a/packages/upload/src/Upload.js
+++ b/packages/upload/src/Upload.js
@@ -136,6 +136,7 @@ class Upload extends Component {
 
   render() {
     const {
+      btnColor,
       btnText,
       max,
       multiple,
@@ -184,7 +185,7 @@ class Upload extends Component {
         <FilePickerBtn
           data-testid="file-picker"
           onChange={this.handleFileInputChange}
-          color={files.length === 0 ? 'light' : 'link'}
+          color={files.length === 0 ? btnColor : 'link'}
           multiple={multiple}
           allowedFileTypes={allowedFileTypes}
           maxSize={maxSize}
@@ -212,6 +213,7 @@ class Upload extends Component {
 }
 
 Upload.propTypes = {
+  btnColor: PropTypes.string,
   btnText: PropTypes.node,
   bucketId: PropTypes.string.isRequired,
   customerId: PropTypes.string.isRequired,
@@ -234,6 +236,7 @@ Upload.propTypes = {
 };
 
 Upload.defaultProps = {
+  btnColor: 'light',
   multiple: true,
   showFileDrop: false,
   disabled: false,

--- a/packages/upload/types/Upload.d.ts
+++ b/packages/upload/types/Upload.d.ts
@@ -3,6 +3,7 @@ import { FileError } from 'react-dropzone/typings/react-dropzone';
 export interface UploadProps {
   allowedFileNameCharacters?: string;
   allowedFileTypes?: string[];
+  btnColor?: string;
   btnText?: React.ReactNode;
   bucketId: string;
   children?: Function;


### PR DESCRIPTION
We use the Upload component in one of our apps and we wanted to change the color to better match with everything else. There isn't currently a way to change this, so I thought we could add a prop to handle it while still leaving the current default.