### PR TITLE
feat(form-upload): add prop btnColor to Upload component

### DIFF
--- a/packages/form-upload/src/Upload.d.ts
+++ b/packages/form-upload/src/Upload.d.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import type { FileError } from 'react-dropzone/typings/react-dropzone';
 
 export interface UploadProps {
+  btnColor?: string;
   btnText?: React.ReactNode;
   bucketId: string;
   customerId: string;

--- a/packages/form-upload/src/Upload.js
+++ b/packages/form-upload/src/Upload.js
@@ -20,6 +20,7 @@ const dropzoneFallback = <div data-testid="dropzone-fallback">Loading...</div>;
 const Upload = ({
   allowedFileNameCharacters,
   allowedFileTypes,
+  btnColor = 'light',
   btnText,
   bucketId,
   children,
@@ -254,7 +255,7 @@ const Upload = ({
       <FilePickerBtn
         data-testid="file-picker"
         onChange={handleFileInputChange}
-        color={fieldValue.length === 0 ? 'light' : 'link'}
+        color={fieldValue.length === 0 ? btnColor : 'link'}
         multiple={multiple}
         allowedFileTypes={allowedFileTypes}
         maxSize={maxSize}
@@ -283,6 +284,7 @@ Upload.propTypes = {
   name: PropTypes.string.isRequired,
   allowedFileNameCharacters: PropTypes.string,
   allowedFileTypes: PropTypes.arrayOf(PropTypes.string),
+  btnColor: PropTypes.string,
   btnText: PropTypes.node,
   children: PropTypes.func,
   className: PropTypes.string,


### PR DESCRIPTION
So... that last PR I made may have been to `upload` instead of `form-upload`. This is where I actually wanted it.