### PR TITLE
docs(breadcrumbs): sample docs format for new design system

### DIFF
--- a/.storybook/config.scss
+++ b/.storybook/config.scss
@@ -5,7 +5,8 @@ pre.prismjs {
   color: inherit;
 }
 
-[id*='hidden'][id*='components'] {
+// Doesn't work for sidebar items, must place sidebar styling in manager-head.html
+[id*='--hidden'] {
   display: none !important;
 }
 

--- a/.storybook/config.scss
+++ b/.storybook/config.scss
@@ -4,3 +4,12 @@ $availity-font-path: '~availity-uikit/fonts';
 pre.prismjs {
   color: inherit;
 }
+
+[id*='hidden'][id*='components'] {
+  display: none !important;
+}
+
+.argstable-remove-default th:last-child,
+.argstable-remove-default td:last-child {
+  display: none !important;
+}

--- a/.storybook/index.stories.mdx
+++ b/.storybook/index.stories.mdx
@@ -22,6 +22,7 @@ Component stories are grouped similarly to how they are in the documentation
 + Form Components
 + Legacy Form Components
 + Deprecated
++ 3rd Party Recommended Components
 
 Each tab presents slightly different information for the component.
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,13 @@
 module.exports = {
-  stories: ['./*.stories.mdx', '../packages/**/*.stories.tsx'],
+  stories: ['./*.stories.mdx', './stories/*.stories.mdx', './stories/*.stories.tsx', '../packages/**/*.stories.tsx'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-docs'],
   staticDirs: ['../static', './static'],
+  typescript: {
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: (prop) => (prop.parent ? !/node_modules\/(?!reactstrap).*/.test(prop.parent.fileName) : true),
+    },
+  },
   webpackFinal: async (config) => {
     config.module.rules.push(
       {

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,1 +1,4 @@
+<style>
+  [id*=hidden][id*=components] {display: none !important}
+</style>
 <link rel="icon" href="/avfavicon.ico">

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,4 +1,4 @@
 <style>
-  [id*=hidden][id*=components] {display: none !important}
+  [id*=hidden] {display: none !important}
 </style>
 <link rel="icon" href="/avfavicon.ico">

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -17,7 +17,7 @@ addons.setConfig({
   panelPosition: 'bottom',
   theme,
   sidebar: {
-    collapsedRoots: ['components', 'form-components', 'hooks', 'legacy-form-components', 'deprecated'],
+    collapsedRoots: ['components', 'form-components', 'hooks', 'legacy-form-components', 'deprecated', '3rd-party'],
   },
 });
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,6 +17,7 @@ export const parameters = {
         ['Form', 'Date', 'Phone', 'Select', 'Upload'],
         'Legacy Form Components',
         'Deprecated',
+        '3rd Party',
       ],
     },
   },

--- a/.storybook/stories/button.stories.tsx
+++ b/.storybook/stories/button.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { ArgsTable } from '@storybook/addon-docs';
+import { Button, ButtonProps } from 'reactstrap';
+
+import { colors } from './options';
+
+export default {
+  title: '3rd Party/Reactstrap/Button',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Custom Buttons for actions in forms, dialogs, and more with support for multiple sizes, states, and more.',
+      },
+      // page: README,
+    },
+    controls: {
+      expanded: true,
+    },
+  },
+};
+
+export const ButtonStory = (args) => <Button {...args} />;
+ButtonStory.storyName = 'Button';
+ButtonStory.args = {
+  children: 'Click Me',
+  color: 'primary',
+  outline: false,
+  size: undefined,
+  block: false,
+  active: false,
+  close: false,
+};
+ButtonStory.argTypes = {
+  color: {
+    control: { type: 'select' },
+    options: colors,
+  },
+  size: {
+    control: { type: 'select' },
+    options: ['', 'sm', 'lg'],
+  },
+};
+
+export const hidden_RSButton = ({ children, ...buttonProps }: ButtonProps): Button => (
+  <Button {...buttonProps}>{children}</Button>
+);
+
+export const Props = () => (
+  <>
+    <h4>Reactstrap Props</h4>
+    <h5>Button</h5>
+    <div className="argstable-remove-default">
+      <ArgsTable of={hidden_RSButton} />
+    </div>
+  </>
+);

--- a/.storybook/stories/options.js
+++ b/.storybook/stories/options.js
@@ -1,0 +1,4 @@
+export const colors = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'];
+export const buttonColors = [...colors, 'link'];
+export const bgColors = [...colors, 'transparent'];
+export const textColors = [...colors, 'body', 'muted', 'white', 'black-50', 'white-50'];

--- a/.storybook/stories/reactstrap-installation.stories.mdx
+++ b/.storybook/stories/reactstrap-installation.stories.mdx
@@ -1,0 +1,104 @@
+<!-- reactstrap-installation.stories.mdx -->
+
+import { Meta } from '@storybook/addon-docs';
+import { Button } from 'reactstrap';
+
+<Meta title="3rd Party/Reactstrap/Installation" />
+
+### Reactstrap is a [React](https://reactjs.org) component library for [Bootstrap](https://getbootstrap.com)
+
+The Availity UI Kit utilizes Bootstrap 4, which caps the Reactstrap version to [Reactstrap v8](https://deploy-preview-2356--reactstrap.netlify.app/)
+
+## Getting Started
+
+### Install Reactstrap:
+
+```sh
+npm install reactstrap react react-dom
+```
+
+Reactstrap currently requires React 16.8 or higher.
+
+### Import components:
+
+```jsx
+import React from 'react';
+import { Button } from 'reactstrap';
+
+export default (props) => {
+  return <Button color="danger">Danger!</Button>;
+};
+```
+
+## About
+
+Unlike some component libraries, Reactstrap does not embed its own styles, and instead depends on the Bootstrap CSS framework for its styles and theme.
+This allows you to have consistent styles across your React-based components and static parts of your site, and allows you to include your own custom Bootstrap theme when needed.
+
+Unlike using Bootstrap in HTML, Reactstrap exports all the correct Bootstrap classes automatically, and don't need to use or include Bootstrap's JavaScript files or add data attributes to trigger functionality. Instead, components are defined in React-friendly components with appropriate props for you to control.
+
+So instead of:
+
+```html
+<!-- HTML -->
+<div class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Modal title</h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p>Modal body text goes here.</p>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+You can use:
+
+```jsx
+// React
+import { Modal, ModalBody, ModalHeader } from 'reactstrap';
+...
+<Modal isOpen={open} toggle={() => setOpen(false)}>
+  <ModalHeader>
+    Modal title
+  </ModalHeader>
+  <ModalBody>
+    Modal body text goes here.
+  </ModalBody>
+</Modal>
+
+```
+
+#### CSSModule
+
+You can use `cssModule` to change the underlying component's default CSS className. This is an escape hatch
+if you do not want to use the default bootstrap class.
+
+For example Button renders with a default class `.btn`. You can use
+
+```jsx
+<Button color="primary" cssModule={{ btn: 'hyperspeed-btn' }}>
+  primary
+</Button>
+```
+
+so that Button renders with `.hyperspeed-btn` instead of `.btn`.
+
+You can use `setGlobalCssModule` function to set custom classes globally.
+
+```jsx
+import { Util } from 'reactstrap';
+
+Util.setGlobalCssModule({
+  btn: 'hyperspeed-btn',
+});
+```

--- a/.storybook/stories/reactstrap-installation.stories.mdx
+++ b/.storybook/stories/reactstrap-installation.stories.mdx
@@ -14,10 +14,10 @@ The Availity UI Kit utilizes Bootstrap 4, which caps the Reactstrap version to [
 ### Install Reactstrap:
 
 ```sh
-npm install reactstrap react react-dom
+npm install reactstrap@^8.0.0 react react-dom
 ```
 
-Reactstrap currently requires React 16.8 or higher.
+Reactstrap currently requires React 16.3 or higher.
 
 ### Import components:
 

--- a/.storybook/stories/utils.js
+++ b/.storybook/stories/utils.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ArgsTable } from '@storybook/addon-docs';
+
+const OutsideArgsTable = (...props) => (
+  <div className="outside-args-table">
+    <ArgsTable {...props} />
+  </div>
+);
+
+export default OutsideArgsTable;

--- a/packages/breadcrumbs/src/Breadcrumbs.js
+++ b/packages/breadcrumbs/src/Breadcrumbs.js
@@ -32,16 +32,22 @@ const Breadcrumbs = ({ crumbs, active, emptyState, children, linkTag: LinkTag, h
 };
 
 Breadcrumbs.propTypes = {
+  /** The currently active page */
+  active: PropTypes.string.isRequired,
+  /** Additional parent breadcrumbs */
   crumbs: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
       url: PropTypes.string,
     })
   ),
+  /** Tag for link */
   linkTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  active: PropTypes.string.isRequired,
+  /** Breadcrumb value when state is empty */
   emptyState: PropTypes.string,
+  /** Node to go between parent and active breadcrumb */
   children: PropTypes.node,
+  /** URL for home breadcrumb */
   homeUrl: PropTypes.string,
 };
 

--- a/packages/breadcrumbs/src/Breadcrumbs.js
+++ b/packages/breadcrumbs/src/Breadcrumbs.js
@@ -32,22 +32,22 @@ const Breadcrumbs = ({ crumbs, active, emptyState, children, linkTag: LinkTag, h
 };
 
 Breadcrumbs.propTypes = {
-  /** The currently active page */
+  /** The name of the active page (the page the user is currently on). */
   active: PropTypes.string.isRequired,
-  /** Additional parent breadcrumbs */
+  /** The ancestor pages. Objects in array contain `name` (String) and `url` (String) properties. */
   crumbs: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
       url: PropTypes.string,
     })
   ),
-  /** Tag for link */
+  /** Custom link tag for the links. */
   linkTag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** Breadcrumb value when state is empty */
+  /** The value to display when the active page or an ancestor does not have a value. */
   emptyState: PropTypes.string,
-  /** Node to go between parent and active breadcrumb */
+  /** The children must be a reactstrap `BreadcrumbItem` components. */
   children: PropTypes.node,
-  /** URL for home breadcrumb */
+  /** Url for the Home route. */
   homeUrl: PropTypes.string,
 };
 

--- a/packages/breadcrumbs/stories/breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/stories/breadcrumbs.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { ArgsTable } from '@storybook/addon-docs';
 import { MemoryRouter as Router, Route, Routes, Link } from 'react-router-dom';
-import { BreadcrumbItem, BreadcrumbItemProps } from 'reactstrap';
+import { Breadcrumb, BreadcrumbProps, BreadcrumbItem, BreadcrumbItemProps } from 'reactstrap';
 
 import Breadcrumbs from '../src/Breadcrumbs';
 // import README from '../README.md';
@@ -87,6 +87,7 @@ export const WithCustomContent: Story = ({ activePage, emptyState, homeUrl }) =>
 );
 WithCustomContent.storyName = 'with custom content';
 
+export const hidden_RSBreadcrumb = (props: BreadcrumbProps) => <Breadcrumb {...props} />;
 export const hidden_RSBreadcrumbItem = (props: BreadcrumbItemProps) => <BreadcrumbItem {...props} />;
 export const Props: Story = () => (
   <>
@@ -95,8 +96,14 @@ export const Props: Story = () => (
     <ArgsTable of={Breadcrumbs} />
 
     <h4>Reactstrap Props</h4>
-    <h5>BreadcrumbItem</h5>
+    <h5>Breadcrumb</h5>
     <div>Additional props on Breadcrumbs spread to this component</div>
+    <div className="argstable-remove-default">
+      <ArgsTable of={hidden_RSBreadcrumb} />
+    </div>
+
+    <h5>BreadcrumbItem</h5>
+    <div>Child components</div>
     <div className="argstable-remove-default">
       <ArgsTable of={hidden_RSBreadcrumbItem} />
     </div>

--- a/packages/breadcrumbs/stories/breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/stories/breadcrumbs.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
+import { ArgsTable } from '@storybook/addon-docs';
 import { MemoryRouter as Router, Route, Routes, Link } from 'react-router-dom';
-import { BreadcrumbItem } from 'reactstrap';
+import { BreadcrumbItem, BreadcrumbItemProps } from 'reactstrap';
 
 import Breadcrumbs from '../src/Breadcrumbs';
 // import README from '../README.md';
@@ -18,6 +19,9 @@ export default {
   parameters: {
     docs: {
       // page: README,
+      // description: {
+      //   component: ''
+      // }
     },
   },
   args: {
@@ -82,3 +86,19 @@ export const WithCustomContent: Story = ({ activePage, emptyState, homeUrl }) =>
   </Routes>
 );
 WithCustomContent.storyName = 'with custom content';
+
+export const hidden_RSBreadcrumbItem = (props: BreadcrumbItemProps) => <BreadcrumbItem {...props} />;
+export const Props: Story = () => (
+  <>
+    <h4>Availity Props</h4>
+    <h5>Breadcrumbs</h5>
+    <ArgsTable of={Breadcrumbs} />
+
+    <h4>Reactstrap Props</h4>
+    <h5>BreadcrumbItem</h5>
+    <div>Additional props on Breadcrumbs spread to this component</div>
+    <div className="argstable-remove-default">
+      <ArgsTable of={hidden_RSBreadcrumbItem} />
+    </div>
+  </>
+);


### PR DESCRIPTION
Storybook changes to help prepare for new design system (to be embedded within zeroheight)

1. Breadcrumbs argstable - automatically generate props data for our components
2. Breadcrumbs argstable - generate a basic list of props for 3rd party dependency components
3. 3rd party - have 3rd party components with ui kit styling (directly copy/pasted reactstrap story and installation guide)
4. 3rd party argstable - generate a basic list of props (cannot have description or default value for 3rd party components, only prop name and type)
![Screen Shot of argstable data for availity & reactstrap components ](https://user-images.githubusercontent.com/39015049/196437044-5868cfd8-d49e-4b42-b7d7-65bf525bd302.png)

