### PR TITLE
@availity/tree - Select All Link Should only display on the first Root Node.

### DIFF
--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.2.1-alpha.1](https://github.com/Availity/availity-react/compare/@availity/tree@0.2.1-alpha.0...@availity/tree@0.2.1-alpha.1) (2022-12-06)
+
+
+
 ## [0.2.1-alpha.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.2.0...@availity/tree@0.2.1-alpha.0) (2022-12-05)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.2.1-alpha.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.2.0...@availity/tree@0.2.1-alpha.0) (2022-12-05)
+
+
+### Bug Fixes
+
+* **tree:** only show select all link on first root object ([3afdfe1](https://github.com/Availity/availity-react/commit/3afdfe17b7634a86bc9393d97e5faef5f700642c))
+
+
+
 # [0.2.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.1.1...@availity/tree@0.2.0) (2022-10-27)
 
 

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-alpha.1",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/src/Tree.stories.tsx
+++ b/packages/tree/src/Tree.stories.tsx
@@ -56,6 +56,15 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
       name: 'Child Test 5',
       parentId: '7',
     },
+    {
+      id: '9',
+      name: '2nd Root',
+    },
+    {
+      id: '10',
+      name: '2nd Root Child',
+      parentId: '9',
+    },
   ];
 
   const tree = buildTree(flatTreeItems, [flatTreeItems.find((o) => !o.parentId)?.id || '']);
@@ -91,7 +100,6 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
             onItemsSelected={onItemsSelected}
             selectedItems={selectedItems}
             selectable={selectable}
-            onDismount={resetTree}
           />
         )}
       </div>

--- a/packages/tree/src/Tree.test.tsx
+++ b/packages/tree/src/Tree.test.tsx
@@ -50,6 +50,18 @@ const items: TreeItem[] = [
       },
     ],
   },
+  {
+    id: '8',
+    name: '2nd Root',
+    children: [
+      {
+        id: '9',
+        name: '2nd Root Child',
+        parentId: '8',
+        children: [],
+      },
+    ],
+  },
 ];
 
 const flatTreeItems: TreeItem[] = [
@@ -87,6 +99,15 @@ const flatTreeItems: TreeItem[] = [
     id: '6',
     name: 'Validation Office',
     parentId: '7',
+  },
+  {
+    id: '8',
+    name: '2nd Root',
+  },
+  {
+    id: '9',
+    name: '2nd Root Child',
+    parentId: '8',
   },
 ];
 
@@ -269,7 +290,7 @@ describe('Tree', () => {
     await waitFor(async () => {
       expect(screen.getByTestId('btn-select-all').textContent).toBe('Deselect All');
       const response = onItemsSelected.mock.lastCall[0];
-      expect(response.length).toEqual(7);
+      expect(response.length).toEqual(9);
     });
 
     fireEvent.click(screen.getByTestId('btn-select-all'));
@@ -277,6 +298,13 @@ describe('Tree', () => {
       expect(screen.getByTestId('btn-select-all').textContent).toBe('Select All');
       const response = onItemsSelected.mock.lastCall[0];
       expect(response.length).toEqual(0);
+    });
+  });
+
+  test('should only show Select All Link on first item on root level', async () => {
+    render(<Tree items={[...items]} expandAll={false} selectable />);
+    await waitFor(async () => {
+      expect(screen.getAllByTestId('btn-select-all').length).toBe(1);
     });
   });
 

--- a/packages/tree/src/Tree.tsx
+++ b/packages/tree/src/Tree.tsx
@@ -341,7 +341,7 @@ const Tree = ({
         )}
 
         <ul>
-          {treeItems.map((item) => (
+          {treeItems.map((item, index) => (
             <li data-testid={`tree-view-item-${item.id}`} key={`tree-view-item-${item.id}`}>
               {!item.isHidden && (
                 <div>
@@ -372,7 +372,7 @@ const Tree = ({
                     {item.children && item.children.length > 0 && (
                       <Col sm="5">
                         <div className="form-inline d-flex justify-content-end ml-auto align-items-center">
-                          {isRoot && selectable && (
+                          {isRoot && index === 0 && selectable && (
                             <Button
                               data-testid="btn-select-all"
                               color="link"


### PR DESCRIPTION
This is a simple bug fix for the tree component. In RCM, the top root level tree has a 'Select All' link that selects all tree items.

In the React implementation of this, there was a check missing in the case where there are multiple top level root elements and the Select All Link was appearing twice.

This PR fixes that. 