### PR TITLE
feat(select): ResourceSelect - Add support to leverage a regular GET rather than defaulting to POST GET. 

### DIFF
--- a/docusaurus/docs/form/select/components/resource-select.md
+++ b/docusaurus/docs/form/select/components/resource-select.md
@@ -59,9 +59,9 @@ Configuration object used in the query method on the resource. Useful for defini
 
 Object used to create querystring parameters in the request. If function, will return new object with params for request.
 
-#### `method?: string`
+#### `method?: POST | GET`
 
-Override method to use `post` request on REST calls with `graphqlConfig`.
+Override method to use `POST` request on REST calls with `graphqlConfig`. When method = 'GET', on populating the options it will call the `query` function on the API Resource rather then default to a POST GET for cases when not using graphql.
 
 #### `customerId?: string`
 

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.3.3-alpha.0](https://github.com/Availity/availity-react/compare/@availity/select@3.3.2...@availity/select@3.3.3-alpha.0) (2023-01-09)
+
+
+### Features
+
+* **select:** add support for the resource select to call regular (get) query instead of forcing it to be a postget to fix significant performance issues ([21b9312](https://github.com/Availity/availity-react/commit/21b9312672f82db696a01e6f499cda082eb55e11))
+
+
+
 ## [3.3.2](https://github.com/Availity/availity-react/compare/@availity/select@3.3.1...@availity/select@3.3.2) (2022-08-03)
 
 

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/select",
-  "version": "3.3.2",
+  "version": "3.3.3-alpha.0",
   "description": "Wrapper for react-select to work with formik",
   "keywords": [
     "availity",

--- a/packages/select/src/ResourceSelect.d.ts
+++ b/packages/select/src/ResourceSelect.d.ts
@@ -24,7 +24,7 @@ export type ResourceSelectProps<
     | ((data: any) => boolean)
     | ((data: { totalCount: number; limit: number; offset: number }) => boolean);
   itemsPerPage?: number;
-  method?: 'POST';
+  method?: 'POST' | 'GET';
   minCharsToSearch?: number;
   onError?: (error: unknown) => void;
   onPageChange?: (inputValue: any, page: any) => void;

--- a/packages/select/src/ResourceSelect.js
+++ b/packages/select/src/ResourceSelect.js
@@ -192,6 +192,8 @@ const ResourceSelect = ({
           },
           ...rest.requestConfig,
         });
+    } else if (method === 'GET') {
+      fetch = () => resource.query({ params });
     } else {
       fetch = () =>
         resource.postGet(
@@ -220,7 +222,8 @@ const ResourceSelect = ({
         let items = [];
         if (pageAll) {
           items = resp.data ? resp.data : resp;
-          if (getResult) items = typeof getResult === 'function' ? await getResult.call(resource, items) : items[getResult];
+          if (getResult)
+            items = typeof getResult === 'function' ? await getResult.call(resource, items) : items[getResult];
         } else {
           items = typeof getResult === 'function' ? await getResult.call(resource, resp.data) : resp.data[getResult];
         }
@@ -311,6 +314,8 @@ ResourceSelect.propTypes = {
     post: PropTypes.func,
     getResult: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     all: PropTypes.func,
+    // Avoid any type of backwards compatibility issues with resources not have query defined. Allow function or any.
+    query: PropTypes.oneOfType([PropTypes.func, PropTypes.any]),
   }).isRequired,
   getResult: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   hasMore: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),

--- a/packages/select/tests/ResourceSelect.test.js
+++ b/packages/select/tests/ResourceSelect.test.js
@@ -832,6 +832,70 @@ describe('ResourceSelect', () => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ 'test-form-input': 'value' }), expect.anything());
     });
   });
+
+  it('call query function when method=GET', async () => {
+    avRegionsApi.query.mockResolvedValueOnce({
+      data: {
+        regions: [
+          {
+            id: 'FL',
+            value: 'Florida',
+          },
+          {
+            id: 'TX',
+            value: 'Texas',
+          },
+          {
+            id: 'WA',
+            value: 'Washington',
+          },
+        ],
+      },
+    });
+
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          'test-form-input': undefined,
+        }}
+        onSubmit={onSubmit}
+      >
+        <ResourceSelect
+          name="test-form-input"
+          resource={avRegionsApi}
+          classNamePrefix="test__regions"
+          labelKey="value"
+          valueKey="id"
+          getResult="regions"
+          method="GET"
+          searchTerm="myCustomSearchParam"
+          minCharsToSearch={3}
+        />
+      </Form>
+    );
+
+    const regionsSelect = container.querySelector('.test__regions__control');
+
+    fireEvent.keyDown(regionsSelect, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.keyDown(regionsSelect, { key: 'Enter', keyCode: 13 });
+
+    fireEvent.keyDown(regionsSelect, {
+      key: 'w',
+      keyCode: 87,
+    });
+
+    await waitFor(() => expect(getByText('Florida')).toBeDefined());
+
+    waitFor(async () => {
+      expect(avRegionsApi.get).toHaveBeenCalledTimes(1);
+      expect(avRegionsApi.get.mock.calls[0][0]).toStrictEqual({
+        myCustomSearchParam: '',
+        limit: 50,
+        customerId: undefined,
+        offset: 0,
+      });
+    });
+  });
 });
 
 // -----


### PR DESCRIPTION
Traditionally for Remote Dropdowns we utilize a GET call (or `query` on the API Resource). We do not utilize graphQL so by default this will do a POST GET utilizing the ResourceSelect in @availity/select. 

With a POST GET, even when APIs are pagination on the server side, we are seeing it doubles the load time. After doing some research, this is common for POST GET to be slower due to sending the Request in the body rather than through query parameters. We thought we would be okay with the POST GET because it still returns the same results but the performance degradation has proven to be a show stopper. 

To get around this without impacting others, I updated the method prop to be able to conditionally take in 'GET' rather than 'POST' and when method = 'GET' call `query` on the API Resource. 