### PR TITLE
feat/table: Miscellaneous Styling, Enhancements + Bug Fixes, Add support for a table ref to access tableInstance in a parent component, default support for useExpanded plugin.

### DIFF
--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -259,6 +259,28 @@ The `instance` property is tied directly to the [react-table Table Instance](htt
 
 This is used to display an action menu in a cell.
 
+#### `actions?: RecordAction<T>[]`
+
+The actions that are present in the dropdown.
+
+#### `primaryTableAction?:PrimaryRecordAction<T>`
+
+This is the primary action of record. It displays as an clickable icon underneath the Action Menu on the table row.
+
+#### `isSticky?: boolean`
+
+When the action menu is open, setting this to true means that the action menu will maintain the same position even on scroll or resize. This default to default to match the default Popper beahvior of automatically calculating the correct position of the Dropdown Menu.
+
+#### `tableActionMenuProps?: TableActionMenuProps`
+
+Any additional properties that should be passed to the `TableActionMenu` component.
+
+#### `tooltipProps?: UncontrolledTooltipProps`
+
+This is only utilized when there is a primary action on the table. This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+
+### Action Definitions
+
 #### `isVisible?`: (record?: T) => boolean
 
 This is an optional function that can be used to conditionally display an action. The record will be passed into the function so that, if needed, the properties on the record can determine if the action is visible or not. If this properties are not populated, the action will always display.
@@ -327,6 +349,20 @@ const columns = [
 ];
 ```
 
+#### Props
+
+`color: string`
+
+The color of the badge. Refer to the Reactstrap documentation linked above for available stylings.
+
+`displayText: string`
+
+The text that should be displayed inside the badge
+
+`defaultValue: string`
+
+An optional default value text or component that can be displayed whenever the value of the cell is not defined.
+
 ### Currency Cell
 
 This is used to format currency in a cell. You can optionally pass it a default value to display if the value is null.
@@ -373,6 +409,24 @@ const columns = [
 ];
 ```
 
+#### Props
+
+`dateFormat: string`
+
+The format of the date string that you want to be displayed.
+
+`defaultValue?: string`
+
+An optional default value text or component that can be displayed whenever the value of the cell is not defined.
+
+`displayTooltip?: boolean`
+
+Boolean that determines if a tooltip should be displayed on hovering over the cell. Defaults to true.
+
+`tooltipProps?: UncontrolledTooltipProps`
+
+This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+
 ### Icon Cell
 
 This is used to have an cell display an icon. This will only show the icon if the value for the cell is populated (or `true`).
@@ -395,7 +449,7 @@ In the body of the table, the icon is displayed if the hasNotes property is set 
     ]
 ```
 
-If the title (tooltip) of the icon is dependent on the data of the record, it is possible to pass a function to the IconCell (as `getTitle`) to populate the record.
+If the title of the icon is dependent on the data of the record, it is possible to pass a function to the IconCell (as `getTitle`) to populate the record.
 
 ```jsx
 const columns = [
@@ -436,6 +490,28 @@ See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for av
     ]
 ```
 
+#### Props
+
+`name: string`
+
+The name of the icon that is displayed.See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for available icons.
+
+`defaultValue?: string`
+
+An optional default value text or component that can be displayed whenever the value of the cell is not defined.
+
+`tooltipText?: string | ((value: T) => string)`
+
+The text that should display inside the tooltip. This can take in either a hard coded string or a function that refers to the cell value to populate the tooltip.
+
+`getId? (row: Row<T>) => string`
+
+Use this to formulate an id that is unique for the table. This is required for the tooltip to be able to correctly set target.
+
+`tooltipProps?: UncontrolledTooltipProps`
+
+This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+
 ### Default Value Cell
 
 This cell will display default text whenever the cell value is not defined.
@@ -449,6 +525,12 @@ This cell will display default text whenever the cell value is not defined.
       Cell: DefaultValueCell('Not Available'),
     ]
 ```
+
+#### Props
+
+`defaultValue?: string`
+
+An optional default value text or component that can be displayed whenever the value of the cell is not defined.
 
 ## Column Configuration Properties
 
@@ -478,6 +560,29 @@ Display a formatted header, such as an Icon.
   const columns = [
         {
             Header: <Icon name="phone" title="phone/>,
+            ...
+        }
+    ]
+```
+
+The same applies for adding a `Footer` for a column cell (make sure to also add the `footer` prop to the table to ensure that it displays).
+
+```jsx
+
+  const columns = [
+        {
+            Footer: 'My Column',
+            ...
+        }
+    ]
+```
+
+Display a formatted header, such as an Icon.
+
+```jsx
+  const columns = [
+        {
+            Footer: <Icon name="phone" title="phone/>,
             ...
         }
     ]
@@ -607,7 +712,7 @@ const columns = [
 
 Note that this is not supported in IE 11.
 
-## Accessing the Table Ref in a parent component
+## Accessing the Table Ref in a Parent Component
 
 It is common that a parent component will need to have access to the the table instance. This can be done utilizing React Refs.
 

--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -195,6 +195,14 @@ This function determines if a row in a selectable table can be selected. By defa
 
 This function is called whenever a row on the table has been clicked.
 
+#### `useColumnWidths: boolean`
+
+When true, it will take the width as defined in the column configuration and apply it to the styles of each column. It is recommended that when this is true that you set a `defaultColumn` with a width of `auto` to ensure that the columns just take whatever width is necessary to fit the content.
+
+#### `footer: boolean`
+
+Determines whether a footer should be displayed. Footer configuration must be added the Column Definition for the Footer value for the column to display.
+
 ##### OnTableClickEvent Props
 
 `instance: Row` The react-table [Row](https://react-table.tanstack.com/docs/api/useTable#row-properties) instance that was clicked.
@@ -428,6 +436,20 @@ See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for av
     ]
 ```
 
+### Default Value Cell
+
+This cell will display default text whenever the cell value is not defined.
+
+#### Usages
+
+```jsx
+    const columns = [
+      Header: 'Has Middle Name',
+      accessor: 'middleName'
+      Cell: DefaultValueCell('Not Available'),
+    ]
+```
+
 ## Column Configuration Properties
 
 To see a comprehensive list of available properties for column configuration, view the [react-table documentation](https://react-table.tanstack.com/docs/api/useTable#column-options).
@@ -490,6 +512,22 @@ When there is an on OnRowClick event populated, this designates that the column 
 #### `hidden`
 
 When this is true, the column will be hidden in the table.
+
+#### `width?: number`
+
+The width of the column. Use this in combination with `useColumnWidths` boolean on the `<Table>` component.
+
+#### `minWidth?: number`
+
+The min-width of the column. Use this in combination with `useColumnWidths` boolean on the `<Table>` component.
+
+#### `maxWidth?: number`
+
+The max-width of the column. Use this in combination with `useColumnWidths` boolean on the `<Table>` component.
+
+#### `Footer`
+
+What should be displayed in the Footer for the column. `footer` must be added to the table for this to display.
 
 ## Styling the Table
 
@@ -568,6 +606,73 @@ const columns = [
 ```
 
 Note that this is not supported in IE 11.
+
+## Accessing the Table Ref in a parent component
+
+It is common that a parent component will need to have access to the the table instance. This can be done utilizing React Refs.
+
+There is now an exported `TableRef` that contains the react-table `tableInstance`.
+
+```jsx
+import React from 'react';
+import Table, { TableRef } from '@availity/table';
+
+import MyObject from '@types/MyObject';
+
+type Props = {
+  data: MyObject[];
+};
+
+const MyComponent = ({ data }: Props) : JSX.Element => {
+  const ref = useRef<TableRef<MyObject>>(null);
+  const [areAllSelected, setAreAllSelected] = useState(false);
+
+  const columns =  useMemo(
+    () =>
+    [
+      {
+        Header: 'Column 1',
+        accessor: 'column1',
+      },
+      {
+        Header: 'Column 2',
+        accessor: 'column2',
+      },
+      {
+        Header: 'Column 3',
+        accessor: 'column3',
+      },
+    ],
+    []
+  );
+
+
+  const toggleSelectAll = () => {
+    const selectAll = !areAllSelected;
+    setAreAllSelected(selectAll);
+    tableRef.current?.instance?.toggleAllRowsSelected(showAll);
+  };
+
+  return (
+    <>
+      <Input
+        id="checkSelectAll"
+        aria-labelledby="lblSelectAll"
+        type="checkbox"
+        checked={showAllDetails}
+        onChange={toggleSelectAll}
+      />
+      <Label id="lblSelectAll" className="ml-1 mr-2" check>
+      Select All
+      </Label>
+   <Table ref={ref} selectable columns={columns} data={data}/>
+  </>
+  )
+}
+
+export const MyComponent;
+
+```
 
 ## Migrating from version 0.3.x
 

--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -269,7 +269,7 @@ This is the primary action of record. It displays as an clickable icon underneat
 
 #### `isSticky?: boolean`
 
-When the action menu is open, setting this to true means that the action menu will maintain the same position even on scroll or resize. This default to default to match the default Popper beahvior of automatically calculating the correct position of the Dropdown Menu.
+When the action menu is open, setting this to true means that the action menu will maintain the same position even on scroll or resize. When false, the behavior matches the default Popper behavior of automatically calculating the correct position of the Dropdown Menu.
 
 #### `tableActionMenuProps?: TableActionMenuProps`
 
@@ -277,7 +277,7 @@ Any additional properties that should be passed to the `TableActionMenu` compone
 
 #### `tooltipProps?: UncontrolledTooltipProps`
 
-This is only utilized when there is a primary action on the table. This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+This is only utilized when there is a primary action on the table. This will override any of the default tooltip props for the `UncontrolledTooltip` that appear when hovering over the primary action icon.
 
 ### Action Definitions
 
@@ -357,7 +357,7 @@ The color of the badge. Refer to the Reactstrap documentation linked above for a
 
 `displayText: string`
 
-The text that should be displayed inside the badge
+The text that should be displayed inside the badge.
 
 `defaultValue: string`
 
@@ -425,7 +425,7 @@ Boolean that determines if a tooltip should be displayed on hovering over the ce
 
 `tooltipProps?: UncontrolledTooltipProps`
 
-This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+This will override any of the default tooltip props for the `UncontrolledTooltip` that appear when hovering over the primary action icon.
 
 ### Icon Cell
 
@@ -494,7 +494,7 @@ See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for av
 
 `name: string`
 
-The name of the icon that is displayed.See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for available icons.
+The name of the icon that is displayed. See [Availity UI Kit](https://availity.github.io/availity-uikit/v4/icons) for available icons.
 
 `defaultValue?: string`
 
@@ -502,15 +502,15 @@ An optional default value text or component that can be displayed whenever the v
 
 `tooltipText?: string | ((value: T) => string)`
 
-The text that should display inside the tooltip. This can take in either a hard coded string or a function that refers to the cell value to populate the tooltip.
+The text that should display inside the tooltip. This can be either a hard coded string or a function that refers to the cell value to populate the tooltip.
 
 `getId? (row: Row<T>) => string`
 
-Use this to formulate an id that is unique for the table. This is required for the tooltip to be able to correctly set target.
+Use this to formulate an id that is unique for the table. This is required for the tooltip to be able to correctly set the target and appear on hover over the correct element.
 
 `tooltipProps?: UncontrolledTooltipProps`
 
-This will override any of the default tooltip props for the `UncontrolledTooltip` that appears when hovering over the primary action icon.
+This will override any of the default tooltip props for the `UncontrolledTooltip` that appear when hovering over the primary action icon.
 
 ### Default Value Cell
 
@@ -719,7 +719,7 @@ It is common that a parent component will need to have access to the the table i
 There is now an exported `TableRef` that contains the react-table `tableInstance`.
 
 ```jsx
-import React from 'react';
+import React, { useRef } from 'react';
 import Table, { TableRef } from '@availity/table';
 
 import MyObject from '@types/MyObject';
@@ -764,7 +764,7 @@ const MyComponent = ({ data }: Props) : JSX.Element => {
         id="checkSelectAll"
         aria-labelledby="lblSelectAll"
         type="checkbox"
-        checked={showAllDetails}
+        checked={areAllSelected}
         onChange={toggleSelectAll}
       />
       <Label id="lblSelectAll" className="ml-1 mr-2" check>

--- a/docusaurus/docs/components/table/index.md
+++ b/docusaurus/docs/components/table/index.md
@@ -582,7 +582,7 @@ Display a formatted header, such as an Icon.
 ```jsx
   const columns = [
         {
-            Footer: <Icon name="phone" title="phone/>,
+            Footer: <Icon name="phone" title="phone"/>,
             ...
         }
     ]
@@ -770,8 +770,8 @@ const MyComponent = ({ data }: Props) : JSX.Element => {
       <Label id="lblSelectAll" className="ml-1 mr-2" check>
       Select All
       </Label>
-   <Table ref={ref} selectable columns={columns} data={data}/>
-  </>
+      <Table ref={ref} selectable columns={columns} data={data}/>
+    </>
   )
 }
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [0.6.0-alpha.8](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.7...@availity/table@0.6.0-alpha.8) (2023-02-21)
+
+
+### Features
+
+* **table:** add useexpanded tableinstance type ([59630e8](https://github.com/Availity/availity-react/commit/59630e8c9582f3ed70e10c8655b6fdab81cda721))
+
+
+
 # [0.6.0-alpha.7](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.6...@availity/table@0.6.0-alpha.7) (2023-02-21)
 
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [0.6.0-alpha.7](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.6...@availity/table@0.6.0-alpha.7) (2023-02-21)
+
+
+### Features
+
+* **table:** adding forwardref in order to access instance in a parent component and passing in row data to leverage hooks on rows ([f617bca](https://github.com/Availity/availity-react/commit/f617bcad393f2fca8944419e5a49d055cb36f191))
+
+
+
 # [0.6.0-alpha.6](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.5...@availity/table@0.6.0-alpha.6) (2023-02-14)
 
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [0.6.0-alpha.5](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.4...@availity/table@0.6.0-alpha.5) (2023-02-14)
+
+
+### Features
+
+* **table:** only add style widths if in fixed container ([7e18180](https://github.com/Availity/availity-react/commit/7e181808c35133dc07bd8c82c25aa5650c82b212))
+
+
+
 # [0.6.0-alpha.4](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.3...@availity/table@0.6.0-alpha.4) (2023-02-10)
 
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [0.6.0-alpha.6](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.5...@availity/table@0.6.0-alpha.6) (2023-02-14)
+
+
+### Features
+
+* **table:** pass in flag for use column widths ([a6d50e4](https://github.com/Availity/availity-react/commit/a6d50e41495a18a9f5dbd4166f1873d651766b99))
+
+
+
 # [0.6.0-alpha.5](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.4...@availity/table@0.6.0-alpha.5) (2023-02-14)
 
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+
+# [0.6.0-alpha.0](https://github.com/Availity/availity-react/compare/@availity/table@0.5.3...@availity/table@0.6.0-alpha.0) (2023-01-18)
+
+
+### Features
+
+* **table:** add support to display text function for all actions, add defaultvaluecell, add ability to pass in container for action menu to avoid it getting hidden in a scrollable container ([2fdb114](https://github.com/Availity/availity-react/commit/2fdb114938b3f4d049acc2f20cc577c1c41154cd))
+* **table:** update actioncell to take in more configurable props for dropdown including popper modifiers ([d013061](https://github.com/Availity/availity-react/commit/d0130618e7100872a3465e5956adb71ec2624f4e))
+
 ## [0.5.5](https://github.com/Availity/availity-react/compare/@availity/table@0.5.4...@availity/table@0.5.5) (2023-02-10)
 
 

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+# [0.6.0-alpha.4](https://github.com/Availity/availity-react/compare/@availity/table@0.6.0-alpha.3...@availity/table@0.6.0-alpha.4) (2023-02-10)
+
+
+### Features
+
+* **table:** enhancements with column widths and tooltip configuration, add footer suppport ([d254ad3](https://github.com/Availity/availity-react/commit/d254ad383746c94ebbf74b1e5d0f658a763db508))
+
+
 
 # [0.6.0-alpha.0](https://github.com/Availity/availity-react/compare/@availity/table@0.5.3...@availity/table@0.6.0-alpha.0) (2023-01-18)
 

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -29,6 +29,7 @@
     "publish:canary": "yarn npm publish --access public --tag canary"
   },
   "dependencies": {
+    "@availity/hooks": "workspace:*",
     "@availity/icon": "workspace:*",
     "@types/react-table": "^7.7.12",
     "classnames": "^2.3.1",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0-alpha.4",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.2",
+  "version": "0.6.0-alpha.3",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.5.5",
+  "version": "0.6.0-alpha.0",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.7",
+  "version": "0.6.0-alpha.8",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.6",
+  "version": "0.6.0-alpha.7",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.0",
+  "version": "0.6.0-alpha.1",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.4",
+  "version": "0.6.0-alpha.5",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/table",
-  "version": "0.6.0-alpha.5",
+  "version": "0.6.0-alpha.6",
   "description": "A generic table wrapper for react-table",
   "keywords": [
     "react",

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -1,26 +1,61 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import * as Popper from 'popper.js';
+import { useWindowDimensions } from '@availity/hooks';
+
 import Icon from '@availity/icon';
 import TableActionMenu, { TableActionMenuProps } from '../TableActionMenu';
 import TableActionMenuItem from '../TableActionMenuItem';
 import { Cell, IdType } from '../types/ReactTable';
 import { RecordAction } from '../types/RecordAction';
 import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
+import { useTableContext } from '../TableContext';
 
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
   primaryAction?: PrimaryRecordAction<T>;
-  tableActionMenuProps?: TableActionMenuProps;
-  isStatic?: boolean;
+  tableActionMenuProps?: Omit<TableActionMenuProps, 'children'>;
+  isSticky?: boolean;
 }
 
 const ActionCell = <T extends IdType>({
   actions,
   primaryAction,
   tableActionMenuProps,
-  isStatic,
+  isSticky,
 }: ActionCellConfig<T>): ((cell: Cell<T>) => JSX.Element) => {
   const ActionCellDef = ({ row: { original, id } }: Cell<T>): JSX.Element => {
+    const { height, width } = useWindowDimensions();
+    const { scrollable } = useTableContext();
+
     const [menuPositionTransform, setMenuPositionTransform] = useState<string | undefined>();
+
+    const stickyMenuModifiers = useMemo(
+      () => ({
+        eventListeners: {
+          scroll: !(isSticky && scrollable),
+        },
+        maintainInitialPosition: {
+          order: 849,
+          enabled: isSticky && scrollable,
+          fn: (data: Popper.Data) => {
+            if (!isSticky) {
+              return data;
+            }
+
+            if (!menuPositionTransform) {
+              setMenuPositionTransform(data.styles.transform);
+            } else {
+              data.styles.transform = menuPositionTransform;
+            }
+
+            return data;
+          },
+          phase: 'beforeWrite',
+          requires: ['computeStyles'],
+        },
+      }),
+      [isSticky, menuPositionTransform, scrollable]
+    );
 
     const isPrimaryActionVisible = primaryAction
       ? primaryAction.isVisible
@@ -28,33 +63,36 @@ const ActionCell = <T extends IdType>({
         : true
       : false;
 
+    const { dropdownMenuProps, ...tableActionMenuAttrs } = tableActionMenuProps || {};
+
+    useEffect(() => {
+      setMenuPositionTransform(undefined);
+    }, [height, width]);
+
+    let modifiers: Popper.Modifiers | undefined;
+    let dropDownMenuAttrs;
+    if (dropdownMenuProps) {
+      const { modifiers: modifierOverrides, ...dropdownMenuPropsOverride } = dropdownMenuProps;
+      modifiers = modifierOverrides;
+      dropDownMenuAttrs = dropdownMenuPropsOverride;
+    }
+
+    const onMenuToggled = (isOpen: boolean) => {
+      if (!isOpen) {
+        setMenuPositionTransform(undefined);
+      }
+    };
+
     return (
       <>
         <TableActionMenu
           id={`table_row_action_menu_${id}`}
+          onMenuToggled={isSticky && scrollable ? onMenuToggled : undefined}
           dropdownMenuProps={{
-            modifiers: {
-              maintainInitialPosition: {
-                order: 849,
-                fn: (data) => {
-                  if (!isStatic) {
-                    return data;
-                  }
-
-                  if (!menuPositionTransform) {
-                    setMenuPositionTransform(data.styles.transform);
-                  } else {
-                    data.styles.transform = menuPositionTransform;
-                  }
-
-                  return data;
-                },
-                phase: 'beforeWrite',
-                requires: ['computeStyles'],
-              },
-            },
+            modifiers: { ...stickyMenuModifiers, ...modifiers },
+            ...dropDownMenuAttrs,
           }}
-          {...tableActionMenuProps}
+          {...tableActionMenuAttrs}
         >
           {actions.map((action) => (
             <TableActionMenuItem

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Icon from '@availity/icon';
-import TableActionMenu from '../TableActionMenu';
+import TableActionMenu, { TableActionMenuProps } from '../TableActionMenu';
 import TableActionMenuItem from '../TableActionMenuItem';
 import { Cell, IdType } from '../types/ReactTable';
 import { RecordAction } from '../types/RecordAction';
@@ -9,15 +9,19 @@ import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
   primaryAction?: PrimaryRecordAction<T>;
-  container?: string;
+  tableActionMenuProps?: TableActionMenuProps;
+  isStatic?: boolean;
 }
 
 const ActionCell = <T extends IdType>({
   actions,
   primaryAction,
-  container = 'body',
+  tableActionMenuProps,
+  isStatic,
 }: ActionCellConfig<T>): ((cell: Cell<T>) => JSX.Element) => {
   const ActionCellDef = ({ row: { original, id } }: Cell<T>): JSX.Element => {
+    const [menuPositionTransform, setMenuPositionTransform] = useState<string | undefined>();
+
     const isPrimaryActionVisible = primaryAction
       ? primaryAction.isVisible
         ? primaryAction.isVisible(original)
@@ -26,7 +30,32 @@ const ActionCell = <T extends IdType>({
 
     return (
       <>
-        <TableActionMenu id={`table_row_action_menu_${id}`} container={container}>
+        <TableActionMenu
+          id={`table_row_action_menu_${id}`}
+          dropdownMenuProps={{
+            modifiers: {
+              maintainInitialPosition: {
+                order: 849,
+                fn: (data) => {
+                  if (!isStatic) {
+                    return data;
+                  }
+
+                  if (!menuPositionTransform) {
+                    setMenuPositionTransform(data.styles.transform);
+                  } else {
+                    data.styles.transform = menuPositionTransform;
+                  }
+
+                  return data;
+                },
+                phase: 'beforeWrite',
+                requires: ['computeStyles'],
+              },
+            },
+          }}
+          {...tableActionMenuProps}
+        >
           {actions.map((action) => (
             <TableActionMenuItem
               key={action.id}

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -8,11 +8,13 @@ import TableActionMenuItem from '../TableActionMenuItem';
 import { Cell, IdType } from '../types/ReactTable';
 import { RecordAction } from '../types/RecordAction';
 import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
+import { UncontrolledTooltip, UncontrolledTooltipProps } from 'reactstrap';
 
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
   primaryAction?: PrimaryRecordAction<T>;
   tableActionMenuProps?: Omit<TableActionMenuProps, 'children'>;
+  tooltipProps?: UncontrolledTooltipProps;
   isSticky?: boolean;
 }
 
@@ -20,6 +22,7 @@ const ActionCell = <T extends IdType>({
   actions,
   primaryAction,
   tableActionMenuProps,
+  tooltipProps,
   isSticky,
 }: ActionCellConfig<T>): ((cell: Cell<T>) => JSX.Element) => {
   const ActionCellDef = ({ row: { original, id } }: Cell<T>): JSX.Element => {
@@ -102,14 +105,24 @@ const ActionCell = <T extends IdType>({
           ))}
         </TableActionMenu>
         {primaryAction && isPrimaryActionVisible && (
-          <Icon
-            data-testid={`table_row_action_menu_item_${id}_primaryAction`}
-            name={
-              typeof primaryAction.iconName === 'function' ? primaryAction.iconName(original) : primaryAction.iconName
-            }
-            title={typeof primaryAction.title === 'function' ? primaryAction.title(original) : primaryAction.title}
-            onClick={() => primaryAction.onClick(original)}
-          />
+          <>
+            <Icon
+              id={`table_row_action_menu_item_${id}_primaryAction`}
+              data-testid={`table_row_action_menu_item_${id}_primaryAction`}
+              name={
+                typeof primaryAction.iconName === 'function' ? primaryAction.iconName(original) : primaryAction.iconName
+              }
+              onClick={() => primaryAction.onClick(original)}
+            />
+            <UncontrolledTooltip
+              placement="top"
+              target={`table_row_action_menu_item_${id}_primaryAction`}
+              boundary="window"
+              {...tooltipProps}
+            >
+              {typeof primaryAction.title === 'function' ? primaryAction.title(original) : primaryAction.title}
+            </UncontrolledTooltip>
+          </>
         )}
       </>
     );

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -115,6 +115,7 @@ const ActionCell = <T extends IdType>({
               onClick={() => primaryAction.onClick(original)}
             />
             <UncontrolledTooltip
+              role="tooltip"
               placement="top"
               target={`table_row_action_menu_item_${id}_primaryAction`}
               boundary="window"

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -9,11 +9,13 @@ import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
   primaryAction?: PrimaryRecordAction<T>;
+  container?: string;
 }
 
 const ActionCell = <T extends IdType>({
   actions,
   primaryAction,
+  container = 'body',
 }: ActionCellConfig<T>): ((cell: Cell<T>) => JSX.Element) => {
   const ActionCellDef = ({ row: { original, id } }: Cell<T>): JSX.Element => {
     const isPrimaryActionVisible = primaryAction
@@ -24,7 +26,7 @@ const ActionCell = <T extends IdType>({
 
     return (
       <>
-        <TableActionMenu id={`table_row_action_menu_${id}`}>
+        <TableActionMenu id={`table_row_action_menu_${id}`} container={container}>
           {actions.map((action) => (
             <TableActionMenuItem
               key={action.id}
@@ -37,8 +39,10 @@ const ActionCell = <T extends IdType>({
         {primaryAction && isPrimaryActionVisible && (
           <Icon
             data-testid={`table_row_action_menu_item_${id}_primaryAction`}
-            name={primaryAction.iconName}
-            title={primaryAction.title}
+            name={
+              typeof primaryAction.iconName === 'string' ? primaryAction.iconName : primaryAction.iconName(original)
+            }
+            title={typeof primaryAction.title === 'string' ? primaryAction.title : primaryAction.title(original)}
             onClick={() => primaryAction.onClick(original)}
           />
         )}

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -105,9 +105,9 @@ const ActionCell = <T extends IdType>({
           <Icon
             data-testid={`table_row_action_menu_item_${id}_primaryAction`}
             name={
-              typeof primaryAction.iconName === 'string' ? primaryAction.iconName : primaryAction.iconName(original)
+              typeof primaryAction.iconName === 'function' ? primaryAction.iconName(original) : primaryAction.iconName
             }
-            title={typeof primaryAction.title === 'string' ? primaryAction.title : primaryAction.title(original)}
+            title={typeof primaryAction.title === 'function' ? primaryAction.title(original) : primaryAction.title}
             onClick={() => primaryAction.onClick(original)}
           />
         )}

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { UncontrolledTooltip, UncontrolledTooltipProps } from 'reactstrap';
+
 import * as Popper from 'popper.js';
 import { useWindowDimensions } from '@availity/hooks';
 
@@ -8,7 +10,6 @@ import TableActionMenuItem from '../TableActionMenuItem';
 import { Cell, IdType } from '../types/ReactTable';
 import { RecordAction } from '../types/RecordAction';
 import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
-import { UncontrolledTooltip, UncontrolledTooltipProps } from 'reactstrap';
 
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
@@ -88,6 +89,7 @@ const ActionCell = <T extends IdType>({
       <>
         <TableActionMenu
           id={`table_row_action_menu_${id}`}
+          data-test-id={`table_row_action_menu_${id}`}
           onMenuToggled={isSticky ? onMenuToggled : undefined}
           dropdownMenuProps={{
             modifiers: { ...stickyMenuModifiers, ...modifiers },

--- a/packages/table/src/CellDefinitions/ActionCell.tsx
+++ b/packages/table/src/CellDefinitions/ActionCell.tsx
@@ -8,7 +8,6 @@ import TableActionMenuItem from '../TableActionMenuItem';
 import { Cell, IdType } from '../types/ReactTable';
 import { RecordAction } from '../types/RecordAction';
 import { PrimaryRecordAction } from '../types/PrimaryRecordAction';
-import { useTableContext } from '../TableContext';
 
 export interface ActionCellConfig<T> {
   actions: RecordAction<T>[];
@@ -25,18 +24,17 @@ const ActionCell = <T extends IdType>({
 }: ActionCellConfig<T>): ((cell: Cell<T>) => JSX.Element) => {
   const ActionCellDef = ({ row: { original, id } }: Cell<T>): JSX.Element => {
     const { height, width } = useWindowDimensions();
-    const { scrollable } = useTableContext();
 
     const [menuPositionTransform, setMenuPositionTransform] = useState<string | undefined>();
 
     const stickyMenuModifiers = useMemo(
       () => ({
         eventListeners: {
-          scroll: !(isSticky && scrollable),
+          scroll: !isSticky,
         },
         maintainInitialPosition: {
           order: 849,
-          enabled: isSticky && scrollable,
+          enabled: isSticky,
           fn: (data: Popper.Data) => {
             if (!isSticky) {
               return data;
@@ -54,7 +52,7 @@ const ActionCell = <T extends IdType>({
           requires: ['computeStyles'],
         },
       }),
-      [isSticky, menuPositionTransform, scrollable]
+      [isSticky, menuPositionTransform]
     );
 
     const isPrimaryActionVisible = primaryAction
@@ -87,7 +85,7 @@ const ActionCell = <T extends IdType>({
       <>
         <TableActionMenu
           id={`table_row_action_menu_${id}`}
-          onMenuToggled={isSticky && scrollable ? onMenuToggled : undefined}
+          onMenuToggled={isSticky ? onMenuToggled : undefined}
           dropdownMenuProps={{
             modifiers: { ...stickyMenuModifiers, ...modifiers },
             ...dropDownMenuAttrs,

--- a/packages/table/src/CellDefinitions/BadgeCell.tsx
+++ b/packages/table/src/CellDefinitions/BadgeCell.tsx
@@ -12,13 +12,7 @@ const BadgeCell = (
 ): JSX.Element | ((cell: CellProps) => JSX.Element | null) | null => {
   const BadgeCellDef = ({ value }: CellProps): JSX.Element | null => {
     const defaultVal = defaultValue || null;
-    return value ? (
-      <Badge color={color} title={value}>
-        {value}
-      </Badge>
-    ) : defaultValue ? (
-      <>{defaultVal}</>
-    ) : null;
+    return value ? <Badge color={color}>{value}</Badge> : defaultValue ? <>{defaultVal}</> : null;
   };
 
   if (displayText !== '') {

--- a/packages/table/src/CellDefinitions/CurrencyCell.tsx
+++ b/packages/table/src/CellDefinitions/CurrencyCell.tsx
@@ -8,7 +8,7 @@ type CellProps<T extends IdType> = {
   column: Column<T>;
 };
 
-export interface CurrencyCellConfig<T> {
+export interface CurrencyCellConfig {
   currency?: string;
   style?: string;
   defaultValue?: string | React.ReactChild | React.ElementType;
@@ -24,7 +24,7 @@ const CurrencyCell = <T extends IdType>({
   locales = 'en-us',
   displayTooltip = true,
   tooltipProps,
-}: CurrencyCellConfig<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
+}: CurrencyCellConfig): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
   const CurrencyCellDef = ({ value, row, column }: CellProps<T>): JSX.Element => {
     let formattedValue;
 

--- a/packages/table/src/CellDefinitions/CurrencyCell.tsx
+++ b/packages/table/src/CellDefinitions/CurrencyCell.tsx
@@ -45,6 +45,7 @@ const CurrencyCell = <T extends IdType>({
         <span id={`currency-cell-${row.id}-${column.id}`}>{formattedValue}</span>
         {displayTooltip && typeof formattedValue === 'string' && (
           <UncontrolledTooltip
+            role="tooltip"
             placement="top"
             target={`currency-cell-${row.id}-${column.id}`}
             boundary="window"

--- a/packages/table/src/CellDefinitions/CurrencyCell.tsx
+++ b/packages/table/src/CellDefinitions/CurrencyCell.tsx
@@ -1,23 +1,31 @@
 import React from 'react';
+import { UncontrolledTooltip, UncontrolledTooltipProps } from 'reactstrap';
+import { Column, IdType, Row } from '../types/ReactTable';
 
-type CellProps = {
+type CellProps<T extends IdType> = {
   value: string | number;
+  row: Row<T>;
+  column: Column<T>;
 };
 
-export interface CurrencyCellConfig {
+export interface CurrencyCellConfig<T> {
   currency?: string;
   style?: string;
   defaultValue?: string | React.ReactChild | React.ElementType;
   locales?: string;
+  displayTooltip?: boolean;
+  tooltipProps?: UncontrolledTooltipProps;
 }
 
-const CurrencyCell = ({
+const CurrencyCell = <T extends IdType>({
   currency = 'USD',
   defaultValue = '',
   style = 'currency',
   locales = 'en-us',
-}: CurrencyCellConfig): JSX.Element | ((cell: CellProps) => JSX.Element) => {
-  const CurrencyCellDef = ({ value }: CellProps): JSX.Element => {
+  displayTooltip = true,
+  tooltipProps,
+}: CurrencyCellConfig<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
+  const CurrencyCellDef = ({ value, row, column }: CellProps<T>): JSX.Element => {
     let formattedValue;
 
     if (!value) {
@@ -31,8 +39,21 @@ const CurrencyCell = ({
 
       formattedValue = formatNum(value);
     }
+
     return formattedValue !== defaultValue ? (
-      <span title={typeof formattedValue === 'string' ? formattedValue : undefined}>{formattedValue}</span>
+      <>
+        <span id={`currency-cell-${row.id}-${column.id}`}>{formattedValue}</span>
+        {displayTooltip && typeof formattedValue === 'string' && (
+          <UncontrolledTooltip
+            placement="top"
+            target={`currency-cell-${row.id}-${column.id}`}
+            boundary="window"
+            {...tooltipProps}
+          >
+            {typeof formattedValue === 'string' ? formattedValue : undefined}
+          </UncontrolledTooltip>
+        )}
+      </>
     ) : (
       <>{defaultValue}</>
     );

--- a/packages/table/src/CellDefinitions/DateCell.tsx
+++ b/packages/table/src/CellDefinitions/DateCell.tsx
@@ -35,6 +35,7 @@ const DateCell = <T extends IdType>({
         <span id={`date-cell-${row.id}-${column.id}`}>{formattedValue}</span>
         {displayTooltip && typeof formattedValue === 'string' && (
           <UncontrolledTooltip
+            role="tooltip"
             placement="top"
             target={`date-cell-${row.id}-${column.id}`}
             boundary="window"

--- a/packages/table/src/CellDefinitions/DateCell.tsx
+++ b/packages/table/src/CellDefinitions/DateCell.tsx
@@ -9,7 +9,7 @@ type CellProps<T extends IdType> = {
   column: Column<T>;
 };
 
-export interface DateTimeCellConfig<T> {
+export interface DateTimeCellConfig {
   dateFormat: string;
   defaultValue?: string | React.ReactChild | React.ElementType;
   displayTooltip?: boolean;
@@ -21,14 +21,9 @@ const DateCell = <T extends IdType>({
   defaultValue,
   displayTooltip = true,
   tooltipProps,
-}: DateTimeCellConfig<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
+}: DateTimeCellConfig): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
   const DateCellDef = ({ value, row, column }: CellProps<T>): JSX.Element => {
-    let formattedValue;
-    if (!value) {
-      formattedValue = defaultValue;
-    } else {
-      formattedValue = moment(value).format(dateFormat);
-    }
+    const formattedValue = !value ? defaultValue : moment(value).format(dateFormat);
 
     return formattedValue !== defaultValue ? (
       <>

--- a/packages/table/src/CellDefinitions/DateCell.tsx
+++ b/packages/table/src/CellDefinitions/DateCell.tsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import moment from 'moment';
+import { UncontrolledTooltip, UncontrolledTooltipProps } from 'reactstrap';
+import { Column, IdType, Row } from '../types/ReactTable';
 
-export type CellProps = {
+type CellProps<T extends IdType> = {
   value: string;
+  row: Row<T>;
+  column: Column<T>;
 };
 
-export interface DateTimeCellConfig {
+export interface DateTimeCellConfig<T> {
   dateFormat: string;
   defaultValue?: string | React.ReactChild | React.ElementType;
+  displayTooltip?: boolean;
+  tooltipProps?: UncontrolledTooltipProps;
 }
 
-const DateCell = ({
+const DateCell = <T extends IdType>({
   dateFormat,
   defaultValue,
-}: DateTimeCellConfig): JSX.Element | ((cell: CellProps) => JSX.Element) => {
-  const DateCellDef = ({ value }: CellProps): JSX.Element => {
+  displayTooltip = true,
+  tooltipProps,
+}: DateTimeCellConfig<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element) => {
+  const DateCellDef = ({ value, row, column }: CellProps<T>): JSX.Element => {
     let formattedValue;
     if (!value) {
       formattedValue = defaultValue;
@@ -23,7 +31,19 @@ const DateCell = ({
     }
 
     return formattedValue !== defaultValue ? (
-      <span title={typeof formattedValue === 'string' ? formattedValue : undefined}>{formattedValue}</span>
+      <>
+        <span id={`date-cell-${row.id}-${column.id}`}>{formattedValue}</span>
+        {displayTooltip && typeof formattedValue === 'string' && (
+          <UncontrolledTooltip
+            placement="top"
+            target={`date-cell-${row.id}-${column.id}`}
+            boundary="window"
+            {...tooltipProps}
+          >
+            {typeof formattedValue === 'string' ? formattedValue : undefined}
+          </UncontrolledTooltip>
+        )}
+      </>
     ) : (
       <>{defaultValue}</>
     );

--- a/packages/table/src/CellDefinitions/DefaultValueCell.tsx
+++ b/packages/table/src/CellDefinitions/DefaultValueCell.tsx
@@ -12,7 +12,7 @@ export type DefaultValueCellProps<T> = {
 const DefaultValueCell = <T extends unknown>({
   defaultValue = '',
 }: DefaultValueCellProps<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element | null) => {
-  const DefaultValueCellDef = ({ value }: CellProps<T>): JSX.Element | null => <>{value ? value : defaultValue}</>;
+  const DefaultValueCellDef = ({ value }: CellProps<T>): JSX.Element | null => <>{value || defaultValue}</>;
 
   return DefaultValueCellDef;
 };

--- a/packages/table/src/CellDefinitions/DefaultValueCell.tsx
+++ b/packages/table/src/CellDefinitions/DefaultValueCell.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type CellValue<T> = T;
+type CellProps<T> = {
+  value: CellValue<T>;
+};
+
+export type DefaultValueCellProps<T> = {
+  defaultValue?: string | React.ReactChild | React.ElementType;
+};
+
+const DefaultValueCell = <T extends unknown>({
+  defaultValue = '',
+}: DefaultValueCellProps<T>): JSX.Element | ((cell: CellProps<T>) => JSX.Element | null) => {
+  const DefaultValueCellDef = ({ value }: CellProps<T>): JSX.Element | null => <>{value ? value : defaultValue}</>;
+
+  return DefaultValueCellDef;
+};
+
+export default DefaultValueCell;

--- a/packages/table/src/CellDefinitions/IconWIthTooltipCell.tsx
+++ b/packages/table/src/CellDefinitions/IconWIthTooltipCell.tsx
@@ -34,7 +34,7 @@ const IconWithTooltipCell = <T extends IdType>({
       <>
         <Icon id={idVal} name={name} {...attributes} />
         {idVal && (
-          <UncontrolledTooltip target={idVal} {...tooltipProps}>
+          <UncontrolledTooltip role="tooltip" target={idVal} {...tooltipProps}>
             {tooltip}
           </UncontrolledTooltip>
         )}

--- a/packages/table/src/CellDefinitions/index.ts
+++ b/packages/table/src/CellDefinitions/index.ts
@@ -2,10 +2,12 @@ export { default as ActionCell } from './ActionCell';
 export { default as BadgeCell } from './BadgeCell';
 export { default as CurrencyCell } from './CurrencyCell';
 export { default as DateCell } from './DateCell';
+export { default as DefaultValueCell } from './DefaultValueCell';
 export { default as IconCell } from './IconCell';
 export { default as IconWithTooltipCell } from './IconWIthTooltipCell';
 
 export type { ActionCellConfig } from './ActionCell';
 export type { CurrencyCellConfig } from './CurrencyCell';
 export type { DateTimeCellConfig } from './DateCell';
+export type { DefaultValueCellProps } from './DefaultValueCell';
 export type { IconConfig } from './IconCell';

--- a/packages/table/src/Controls/BulkTableActions.tsx
+++ b/packages/table/src/Controls/BulkTableActions.tsx
@@ -16,7 +16,7 @@ import { useTableContext } from '../TableContext';
 import { BulkRecordAction } from '../types/BulkRecordAction';
 import { IdType, TableInstance } from '../types/ReactTable';
 
-type Props<T extends IdType> = {
+export type BulkTableActionsProps<T extends IdType> = {
   id?: string;
   disabled?: boolean;
   recordName?: string;
@@ -44,7 +44,7 @@ const BulkTableActions = <T extends IdType>({
   dropdownToggleProps,
   dropdownMenuProps,
   onRecordsSelected,
-}: Props<T>): JSX.Element | null => {
+}: BulkTableActionsProps<T>): JSX.Element | null => {
   const { instance } = useTableContext();
   const { isAllRowsSelected, toggleAllRowsSelected, selectedFlatRows } = instance as TableInstance<T>;
 

--- a/packages/table/src/Controls/BulkTableActions.tsx
+++ b/packages/table/src/Controls/BulkTableActions.tsx
@@ -88,7 +88,9 @@ const BulkTableActions = <T extends IdType>({
               };
 
               if (isVisible) {
-                return (
+                return action.divider ? (
+                  <DropdownItem data-testid={`bulk_action_${action.id}`} key={action.id} divider />
+                ) : (
                   <DropdownItem data-testid={`bulk_action_${action.id}`} key={`${action.id}`} {...setProps()}>
                     {action.displayText}
                   </DropdownItem>

--- a/packages/table/src/Controls/BulkTableActions.tsx
+++ b/packages/table/src/Controls/BulkTableActions.tsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { Badge, Button, ButtonDropdown, ButtonGroup, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap';
+import {
+  Badge,
+  Button,
+  ButtonDropdown,
+  ButtonDropdownProps,
+  ButtonGroup,
+  ButtonGroupProps,
+  DropdownItem,
+  DropdownMenu,
+  DropdownMenuProps,
+  DropdownToggle,
+  DropdownToggleProps,
+} from 'reactstrap';
 import { useTableContext } from '../TableContext';
 import { BulkRecordAction } from '../types/BulkRecordAction';
 import { IdType, TableInstance } from '../types/ReactTable';
@@ -10,6 +22,13 @@ type Props<T> = {
   recordName?: string;
   bulkActions?: BulkRecordAction<T>[];
   color?: string;
+  container?: string;
+
+  buttonGroupProps?: ButtonGroupProps;
+  buttonDropdownProps?: ButtonDropdownProps;
+  dropdownToggleProps?: DropdownToggleProps;
+  dropdownMenuProps?: DropdownMenuProps;
+
   onRecordsSelected?: (records: T[]) => void;
 } & React.HTMLAttributes<HTMLElement>;
 
@@ -18,7 +37,12 @@ const BulkTableActions = <T extends IdType>({
   disabled,
   color,
   recordName = 'Records',
+  container = 'body',
   bulkActions,
+  buttonGroupProps,
+  buttonDropdownProps,
+  dropdownToggleProps,
+  dropdownMenuProps,
   onRecordsSelected,
 }: Props<T>): JSX.Element | null => {
   const { instance } = useTableContext();
@@ -57,7 +81,13 @@ const BulkTableActions = <T extends IdType>({
   };
 
   return (
-    <ButtonGroup data-testid="bulk_actions_btn_group" id={id} disabled={isDisabled} className="btn-group">
+    <ButtonGroup
+      data-testid="bulk_actions_btn_group"
+      id={id}
+      disabled={isDisabled}
+      className="btn-group"
+      {...buttonGroupProps}
+    >
       <Button
         data-testid="select_deselect_all_records"
         disabled={disabled}
@@ -69,14 +99,15 @@ const BulkTableActions = <T extends IdType>({
         <Badge pill>{numberOfSelectedRows}</Badge> {selectionButtonText} All {recordName}
       </Button>
       {bulkActions && (
-        <ButtonDropdown isOpen={isSelectionDropdownOpen} toggle={toggleSelectionDropdown}>
+        <ButtonDropdown isOpen={isSelectionDropdownOpen} toggle={toggleSelectionDropdown} {...buttonDropdownProps}>
           <DropdownToggle
             data-testid="bulk_actions_toggle"
             disabled={numberOfSelectedRows === 0 || disabled}
             color={color}
             caret
+            {...dropdownToggleProps}
           />
-          <DropdownMenu color={color}>
+          <DropdownMenu color={color} container={container} {...dropdownMenuProps}>
             {bulkActions?.map((action) => {
               const isVisible = action.isVisible ? action.isVisible(selectedFlatRows.map((row) => row.original)) : true;
               const setProps = () => {
@@ -84,12 +115,20 @@ const BulkTableActions = <T extends IdType>({
                   return null;
                 }
                 const clickEvent = action.onClick;
-                return { onClick: () => clickEvent(selectedFlatRows.map((row) => row.original)) };
+                return {
+                  onClick: () => clickEvent(selectedFlatRows.map((row) => row.original)),
+                  ...action.dropdownItemProps,
+                };
               };
 
               if (isVisible) {
                 return action.divider ? (
-                  <DropdownItem data-testid={`bulk_action_${action.id}`} key={action.id} divider />
+                  <DropdownItem
+                    data-testid={`bulk_action_${action.id}`}
+                    key={action.id}
+                    divider
+                    {...action.dropdownItemProps}
+                  />
                 ) : (
                   <DropdownItem data-testid={`bulk_action_${action.id}`} key={`${action.id}`} {...setProps()}>
                     {action.displayText}

--- a/packages/table/src/Controls/BulkTableActions.tsx
+++ b/packages/table/src/Controls/BulkTableActions.tsx
@@ -16,7 +16,7 @@ import { useTableContext } from '../TableContext';
 import { BulkRecordAction } from '../types/BulkRecordAction';
 import { IdType, TableInstance } from '../types/ReactTable';
 
-type Props<T> = {
+type Props<T extends IdType> = {
   id?: string;
   disabled?: boolean;
   recordName?: string;
@@ -109,14 +109,23 @@ const BulkTableActions = <T extends IdType>({
           />
           <DropdownMenu color={color} container={container} {...dropdownMenuProps}>
             {bulkActions?.map((action) => {
-              const isVisible = action.isVisible ? action.isVisible(selectedFlatRows.map((row) => row.original)) : true;
+              const isVisible = action.isVisible
+                ? action.isVisible(
+                    selectedFlatRows.map((row) => row.original),
+                    selectedFlatRows
+                  )
+                : true;
               const setProps = () => {
                 if (!action.onClick) {
                   return null;
                 }
                 const clickEvent = action.onClick;
                 return {
-                  onClick: () => clickEvent(selectedFlatRows.map((row) => row.original)),
+                  onClick: () =>
+                    clickEvent(
+                      selectedFlatRows.map((row) => row.original),
+                      selectedFlatRows
+                    ),
                   ...action.dropdownItemProps,
                 };
               };

--- a/packages/table/src/Controls/index.ts
+++ b/packages/table/src/Controls/index.ts
@@ -3,3 +3,4 @@ export { default as TableControls } from './TableControls';
 export { default as TableSorter } from './TableSorter';
 
 export { default as BulkTableActions } from './BulkTableActions';
+export type { BulkTableActionsProps } from './BulkTableActions';

--- a/packages/table/src/ScrollableContainer.tsx
+++ b/packages/table/src/ScrollableContainer.tsx
@@ -1,7 +1,9 @@
 import React, { cloneElement, isValidElement } from 'react';
 
 type Props = {
+  /** This is a unique id that is prepended to the element **/
   id?: string;
+  /** Children can be a react child. **/
   children?: React.ReactNode | React.ReactChild;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/ScrollableContainer.tsx
+++ b/packages/table/src/ScrollableContainer.tsx
@@ -1,9 +1,9 @@
 import React, { cloneElement, isValidElement } from 'react';
 
 type Props = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element */
   id?: string;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children?: React.ReactNode | React.ReactChild;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -32,9 +32,9 @@ const columns = [
     Footer: 'First Name',
     defaultCanSort: true,
     disableSortBy: false,
-    width: 150,
-    minWidth: 150,
-    maxWidth: 150,
+    width: 200,
+    minWidth: 200,
+    maxWidth: 200,
   },
   {
     Header: 'Last Name',
@@ -64,7 +64,7 @@ const columns = [
     accessor: 'amount',
     Footer: (info: any) => {
       const total = React.useMemo(
-        () => info.rows.reduce((sum: number, row: any) => parseFloat(info.rows[0].original.amount) + sum, 0),
+        () => info.rows.reduce((sum: number) => Number.parseFloat(info.rows[0].original.amount) + sum, 0),
         [info.rows]
       );
 
@@ -233,7 +233,6 @@ export const WithAdditionalContent: Story = ({ columns, data }) => {
   );
 
   const [records, setRecords] = useState([]);
-  const [selectedRows, setSelectedRow] = useState([]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -18,6 +18,7 @@ import Table, {
   IconWithTooltipCell,
 } from '.';
 import '../styles.scss';
+import { truncate } from 'fs/promises';
 
 const columns = [
   {
@@ -70,6 +71,7 @@ const columns = [
     Header: 'Actions',
     className: 'action-column',
     Cell: ActionCell({
+      isSticky: true,
       actions: [
         {
           id: 'action1',

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -63,7 +63,6 @@ const columns = [
     Header: 'Currency Cell',
     accessor: 'amount',
     Footer: (info: any) => {
-      // Only calculate total visits if rows change
       const total = React.useMemo(
         () => info.rows.reduce((sum: number, row: any) => parseFloat(info.rows[0].original.amount) + sum, 0),
         [info.rows]
@@ -365,12 +364,7 @@ export const PropsStory: Story = () => (
     <hr />
     <h4>Availity Props</h4>
     <h5>Table</h5>
-    <div className="argstable-remove-default">
-      <ArgsTable of={hidden_avTable} />
-    </div>
-    <hr />
-    <h4>React-Table Props</h4>
-    Visit <a href="https://react-table-v7.tanstack.com/">react-table</a> for full documentation of this.
+    <ArgsTable of={hidden_avTable} />
   </>
 );
 PropsStory.storyName = 'props';

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -19,12 +19,19 @@ import Table, {
 } from '.';
 import '../styles.scss';
 
+const defaultColumn = {
+  width: 'auto',
+};
+
 const columns = [
   {
     Header: 'First Name',
     accessor: 'firstName',
     defaultCanSort: true,
     disableSortBy: false,
+    width: 500,
+    minWidth: 500,
+    maxWidth: 500,
   },
   {
     Header: 'Last Name',
@@ -69,6 +76,9 @@ const columns = [
     id: 'actions',
     Header: 'Actions',
     className: 'action-column',
+    minWidth: 96,
+    width: 96,
+    maxWidth: 96,
     Cell: ActionCell({
       isSticky: true,
       actions: [
@@ -148,6 +158,7 @@ export const BasicTable: Story = ({ sortable, selectable, columns, data, headerP
     data={data}
     headerProps={headerProps}
     bodyProps={bodyProps}
+    defaultColumn={defaultColumn}
     onRowSelected={(event) => {
       // eslint-disable-next-line no-console
       console.log('Row selected', event);
@@ -175,17 +186,19 @@ export const WithControls: Story = ({ sortable, selectable, columns, data, heade
     paged
     sortable={sortable}
     selectable={selectable}
+    selectionColumnProps={{ width: 50 }}
     columns={columns}
     data={data}
     headerProps={headerProps}
     bodyProps={bodyProps}
+    defaultColumn={defaultColumn}
     onRowSelected={(event) => {
       // eslint-disable-next-line no-console
       console.log('Row selected', event);
     }}
   >
     <TableControls className="pb-2">
-      <BulkTableActions color="light" bulkActions={bulkActions} />
+      <BulkTableActions color="light" bulkActions={bulkActions} dropdownMenuProps={{ right: true }} />
       <TableSorter
         color="light"
         className="ml-1"

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -18,7 +18,6 @@ import Table, {
   IconWithTooltipCell,
 } from '.';
 import '../styles.scss';
-import { truncate } from 'fs/promises';
 
 const columns = [
   {
@@ -94,15 +93,15 @@ const columns = [
           },
         },
       ],
-    }),
-    primaryAction: {
-      iconName: 'file-pdf',
-      title: 'View File',
-      onClick: (record?: Record<string, unknown>) => {
-        // eslint-disable-next-line no-console
-        console.log(`action on record ${record?.id}`);
+      primaryAction: {
+        iconName: 'file-pdf',
+        title: 'View File',
+        onClick: (record?: Record<string, unknown>) => {
+          // eslint-disable-next-line no-console
+          console.log(`action on record ${record?.id}`);
+        },
       },
-    },
+    }),
   },
 ];
 

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -30,11 +30,13 @@ type HeaderProps = {
 export type CommonTableProps<T extends IdType> = {
   /** The Id of the table, utilized to create ids for table rows, table cells, etc. */
   id?: string;
-  /** Additional properties  to pass to the `<table/>` element.*/
+  /** Any DOM properties properties that should be passed to the `<table/>` element. */
   tableProps?: React.HTMLAttributes<HTMLElement>;
-  /** Additional properties to pass into the `<tbody/> component */
+  /** Any DOM properties that should be passed onto the `<thead>` element. A special boolean property `sticky` is added here to allow for designating the header as 'sticky' or not. */
+  headerProps?: HeaderProps;
+  /** Any DOM properties that should be passed into the `<tbody/> component. */
   bodyProps?: React.HTMLAttributes<HTMLElement>;
-  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell.   */
+  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell. */
   getCellProps?: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
   /** This function provides any DOM properties that should be passed onto the `<tr>` element. Optionally pass in the Row object in order to conditionally add DOM properties based on the data of the row. */
   getRowProps?: (row: Row<T>) => RowProps;
@@ -44,14 +46,12 @@ export type CommonTableProps<T extends IdType> = {
   onRowClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
   /** When a table is selectable, this event is called whenever a row is selected. */
   onRowSelected?: (event: OnRowSelectedEvent<T>) => void;
-  /** Any DOM properties that should be passed onto the `<thead>` element. A special boolean property `sticky'` is added here to allow for designating the header as 'sticky' or not.*/
-  headerProps?: HeaderProps;
   /** The function that is called whenever the table is sorted. Sortable must be true and columns must be configured to allow for sorting. */
   onSort?: (sortBy: TableSort[]) => void;
 
-  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.  */
+  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky. */
   additionalContent?: React.ElementType;
-  /**  Additional Properties that should be added to the additional content component when it is rendered. */
+  /** Additional Properties that should be added to the additional content component when it is rendered. */
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
 
   /** Determines whether a footer should be displayed. */
@@ -60,9 +60,9 @@ export type CommonTableProps<T extends IdType> = {
   scrollable?: boolean;
   /** Determines whether the table should be selectable. When true, the first column will be a column of checkboxes to either select/deselect all records or individual records. */
   selectable?: boolean;
-  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column. */
   useColumnWidths?: boolean;
-  /** Because this component dynamically builds the selection column, this allows for any customization to be added to the Selection Column */
+  /** Because this component dynamically builds the selection column, this allows for any customization to be added to the Selection Column. */
   selectionColumnProps?: Partial<Column<T>>;
   /** If rows should be conditionally selected, use this function to indicate the conditions per record. */
   getCanSelectRow?: (record: T) => boolean;
@@ -212,9 +212,9 @@ const TableComponent = <T extends IdType>(
       value={{
         id,
         instance: tableInstance,
-        /* eslint-disable @typescript-eslint/no-explicit-any */
+        /** eslint-disable @typescript-eslint/no-explicit-any */
         getCellProps: getCellProps as (cell: Cell<Record<string, any>>) => React.HTMLAttributes<HTMLTableCellElement>,
-        /* eslint-disable @typescript-eslint/no-explicit-any */
+        /** eslint-disable @typescript-eslint/no-explicit-any */
         getRowProps: getRowProps as (row: Row<Record<string, any>>) => RowProps,
         selectable,
         sortable,

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { ForwardedRef, forwardRef, ReactElement, Ref, useEffect, useImperativeHandle, useState } from 'react';
 import filter from 'lodash/filter';
 import {
   Hooks,
@@ -89,6 +89,10 @@ export type CommonTableProps<T extends IdType> = {
   children?: React.ReactNode | React.ReactChild;
 };
 
+export type TableRef<T extends IdType> = {
+  instance: TableInstance<T>;
+};
+
 export type TableProps<T extends IdType> = {
   /** This is an array of column definitions based off of react-table Column. */
   columns: Column<T>[];
@@ -98,33 +102,36 @@ export type TableProps<T extends IdType> = {
   CommonTableProps<T> &
   TableOptions<T>;
 
-const Table = <T extends IdType>({
-  additionalContent: AdditionalContent,
-  additionalContentProps,
-  columns,
-  data,
-  selectable = false,
-  scrollable,
-  sortable = false,
-  footer = false,
-  id,
-  tableProps,
-  bodyProps,
-  headerProps,
-  selectionColumnProps,
-  useColumnWidths,
-  onRowClick,
-  onCellClick,
-  onRowSelected,
-  getCanSelectRow,
-  getRowProps = () => ({} as RowProps),
-  getCellProps = () => ({} as React.HTMLAttributes<HTMLTableCellElement>),
-  onSort,
-  paged = false,
-  pluginHooks,
-  children,
-  ...rest
-}: TableProps<T>): JSX.Element | null => {
+const TableComponent = <T extends IdType>(
+  {
+    additionalContent: AdditionalContent,
+    additionalContentProps,
+    columns,
+    data,
+    selectable = false,
+    scrollable,
+    sortable = false,
+    footer = false,
+    id,
+    tableProps,
+    bodyProps,
+    headerProps,
+    selectionColumnProps,
+    useColumnWidths,
+    onRowClick,
+    onCellClick,
+    onRowSelected,
+    getCanSelectRow,
+    getRowProps = () => ({} as RowProps),
+    getCellProps = () => ({} as React.HTMLAttributes<HTMLTableCellElement>),
+    onSort,
+    paged = false,
+    pluginHooks,
+    children,
+    ...rest
+  }: TableProps<T>,
+  ref: Ref<TableRef<T>>
+): JSX.Element | null => {
   const [selectedTableRows, setSelectedTableRows] = useState<Row<T>[]>([]);
   const [sortableColumns] = useState<TableSortOption[]>(
     filter(columns, (column) => !column.disableSortBy && column.defaultCanSort).map((column) => {
@@ -205,6 +212,14 @@ const Table = <T extends IdType>({
     }
   }, [selectedTableRows, onRowSelected]);
 
+  useImperativeHandle<TableRef<T>, TableRef<T>>(
+    ref,
+    () => ({
+      instance: tableInstance,
+    }),
+    [tableInstance]
+  );
+
   return (
     <TableContext.Provider
       value={{
@@ -238,4 +253,7 @@ const Table = <T extends IdType>({
   );
 };
 
+const Table = forwardRef(TableComponent) as <T extends IdType>(
+  p: TableProps<T> & { ref?: Ref<TableRef<T>> }
+) => JSX.Element;
 export default Table;

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef, ReactElement, Ref, useEffect, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, Ref, useEffect, useImperativeHandle, useState } from 'react';
 import filter from 'lodash/filter';
 import {
   Hooks,

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -9,9 +9,9 @@ import {
   useTable,
   Column as RtColumn,
   usePagination,
-  PluginHook,
   useRowState,
   useExpanded,
+  PluginHook,
 } from 'react-table';
 import { TableSort } from './types/TableSort';
 import { Cell, Column, IdType, Row, TableInstance, TableOptions, RowProps } from './types/ReactTable';
@@ -28,64 +28,51 @@ type HeaderProps = {
 } & React.HTMLAttributes<HTMLElement>;
 
 export type CommonTableProps<T extends IdType> = {
-  /** This is a unique id that is prepended to the table and nested table elements. **/
+  /** The Id of the table, utilized to create ids for table rows, table cells, etc. */
   id?: string;
-  /** Any DOM properties that should be passed onto the <table> element. **/
+  /** Additional properties  to pass to the `<table/>` element.*/
   tableProps?: React.HTMLAttributes<HTMLElement>;
-  /** Any DOM properties that should be passed onto the <tbody> element. **/
+  /** Additional properties to pass into the `<tbody/> component */
   bodyProps?: React.HTMLAttributes<HTMLElement>;
-  /** This function provides any DOM properties that should be passed
-   * onto the <td> elements. Optionally pass in the Cell object in order
-   * to conditionally add DOM properties based on data of the cell. **/
+  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell.   */
   getCellProps?: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
-  /** This function provides any DOM properties that should be passed onto
-   * the <tr> element. Optionally pass in the Row object in order to
-   * conditionally add DOM properties based on the data of the row. **/
+  /** This function provides any DOM properties that should be passed onto the `<tr>` element. Optionally pass in the Row object in order to conditionally add DOM properties based on the data of the row. */
   getRowProps?: (row: Row<T>) => RowProps;
-
-  /** This function is called whenever a cell on the row has been clicked. **/
+  /** This function is called whenever a cell is clicked. */
   onCellClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
-  /** This function is called whenever a row on the table has been clicked. **/
+  /** This function is called whenever a row on the table has been clicked. */
   onRowClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
-  /** Event handler for when a row is selected. **/
+  /** When a table is selectable, this event is called whenever a row is selected. */
   onRowSelected?: (event: OnRowSelectedEvent<T>) => void;
-  /** Any DOM properties that should be passed onto the <thead> element.
-   * A special boolean property sticky' is added here to allow for
-   * designating the header as 'sticky' or not. **/
+  /** Any DOM properties that should be passed onto the `<thead>` element. A special boolean property `sticky'` is added here to allow for designating the header as 'sticky' or not.*/
   headerProps?: HeaderProps;
-  /** This function will be called whenever the table has been sorted. **/
+  /** The function that is called whenever the table is sorted. Sortable must be true and columns must be configured to allow for sorting. */
   onSort?: (sortBy: TableSort[]) => void;
 
-  /** This designates a Component that will be displayed in the table
-   * row for the record. This content displays in an additional <tr>
-   * with a colspan equal to the number of columns that are NOT sticky. **/
+  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.  */
   additionalContent?: React.ElementType;
-  /**  **/
+  /**  Additional Properties that should be added to the additional content component when it is rendered. */
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
-  footer?: boolean;
-   * container. This will apply fixed column widths to force it to scroll
-   * rather than minify the columns to fit in a set container. **/
-  scrollable?: boolean;
-  /** This determines whether the table is selectable or not. If it is set
-   * to true, then the first column of the table will be a checkbox column
-   * that will toggle selecting and deselecting the row. **/
-  selectable?: boolean;
-  useColumnWidths?: boolean;
-  selectionColumnProps?: Partial<Column<T>>;
-  /** This function determines if a row in a selectable table can be
-   * selected. By default if no function is provided to this property,
-   * all rows in the table are selectable. **/
-  getCanSelectRow?: (record: T) => boolean;
-  /**  **/
-  sortable?: boolean;
-  /** This boolean determines whether the table is paged or not. This
-   * works with the usePagination hook that is documented in react-table.
-   * This defaults to false. **/
-  paged?: boolean;
 
-  /** Custom plugin hooks that should be passed to the table. **/
+  /** Determines whether a footer should be displayed. */
+  footer?: boolean;
+  /** Determines whether the table should be contained in a set scrollable container. */
+  scrollable?: boolean;
+  /** Determines whether the table should be selectable. When true, the first column will be a column of checkboxes to either select/deselect all records or individual records. */
+  selectable?: boolean;
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  useColumnWidths?: boolean;
+  /** Because this component dynamically builds the selection column, this allows for any customization to be added to the Selection Column */
+  selectionColumnProps?: Partial<Column<T>>;
+  /** If rows should be conditionally selected, use this function to indicate the conditions per record. */
+  getCanSelectRow?: (record: T) => boolean;
+  /** Determines whether the table should be scrollable. */
+  sortable?: boolean;
+  /** Determines if this is a paged table. Only set this to true if doing client side paging. */
+  paged?: boolean;
+  /** Custom plugin hooks that should be passed to the table. For more information on how to utilize and apply hooks, refer to the react-table documentation. */
   pluginHooks?: PluginHook<T>[];
-  /** Children can be a react child. **/
+  /** Any child elements that should be added underneath the table context. */
   children?: React.ReactNode | React.ReactChild;
 };
 

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -11,6 +11,7 @@ import {
   usePagination,
   PluginHook,
   useRowState,
+  useExpanded,
 } from 'react-table';
 import { TableSort } from './types/TableSort';
 import { Cell, Column, IdType, Row, TableInstance, TableOptions, RowProps } from './types/ReactTable';
@@ -61,8 +62,7 @@ export type CommonTableProps<T extends IdType> = {
   additionalContent?: React.ElementType;
   /**  **/
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
-
-  /** This property is automatically set when it is wrapped in a scrollable
+  footer?: boolean;
    * container. This will apply fixed column widths to force it to scroll
    * rather than minify the columns to fit in a set container. **/
   scrollable?: boolean;
@@ -70,6 +70,7 @@ export type CommonTableProps<T extends IdType> = {
    * to true, then the first column of the table will be a checkbox column
    * that will toggle selecting and deselecting the row. **/
   selectable?: boolean;
+  selectionColumnProps?: Partial<Column<T>>;
   /** This function determines if a row in a selectable table can be
    * selected. By default if no function is provided to this property,
    * all rows in the table are selectable. **/
@@ -104,10 +105,12 @@ const Table = <T extends IdType>({
   selectable = false,
   scrollable,
   sortable = false,
+  footer = false,
   id,
   tableProps,
   bodyProps,
   headerProps,
+  selectionColumnProps,
   onRowClick,
   onCellClick,
   onRowSelected,
@@ -138,6 +141,7 @@ const Table = <T extends IdType>({
     } as TableOptions<T>,
     ...(pluginHooks || []),
     useSortBy,
+    useExpanded,
     usePagination,
     useRowSelect,
     useColumnOrder,
@@ -146,7 +150,6 @@ const Table = <T extends IdType>({
       const selectionColumn = {
         id: 'selection',
         title: 'Select record(s)',
-        className: 'fixed-width-selection',
         defaultCanSort: false,
         disableSortBy: true,
         disableClick: true,
@@ -172,6 +175,7 @@ const Table = <T extends IdType>({
             </div>
           );
         },
+        ...selectionColumnProps,
       };
 
       hooks.visibleColumns.push((columns: Column<T>[]) => {
@@ -217,6 +221,7 @@ const Table = <T extends IdType>({
         AdditionalContent,
         additionalContentProps,
         paged,
+        footer,
         onRowClick,
         onCellClick,
         getCanSelectRow,

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -70,6 +70,7 @@ export type CommonTableProps<T extends IdType> = {
    * to true, then the first column of the table will be a checkbox column
    * that will toggle selecting and deselecting the row. **/
   selectable?: boolean;
+  useColumnWidths?: boolean;
   selectionColumnProps?: Partial<Column<T>>;
   /** This function determines if a row in a selectable table can be
    * selected. By default if no function is provided to this property,
@@ -111,6 +112,7 @@ const Table = <T extends IdType>({
   bodyProps,
   headerProps,
   selectionColumnProps,
+  useColumnWidths,
   onRowClick,
   onCellClick,
   onRowSelected,
@@ -228,6 +230,7 @@ const Table = <T extends IdType>({
         onSort,
         onRowSelected,
         tableProps,
+        useColumnWidths,
       }}
     >
       {children || <TableContent />}

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -22,6 +22,7 @@ export type TableActionMenuProps = {
   dropdownToggleProps?: DropdownToggleProps;
   /** Reactstrap dropdownMenuProps that should be passed into the DropdownMenu component. **/
   dropdownMenuProps?: DropdownMenuProps;
+  /** Function called whenever the menu is open/closed */
   onMenuToggled?: (isOpen: boolean) => void;
 };
 

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -1,30 +1,68 @@
 import React, { useState } from 'react';
 import Icon from '@availity/icon';
-import { Dropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownProps,
+  DropdownToggleProps,
+  DropdownMenuProps,
+} from 'reactstrap';
 
-type Props = {
-  /** This is a unique id that is prepended to the element **/
+export type TableActionMenuProps = {
   id?: string;
   /** Children can be a react child. **/
   children: React.ReactNode;
   container?: string;
+  dropdownProps?: DropdownProps;
+  dropdownToggleProps?: DropdownToggleProps;
+  dropdownMenuProps?: DropdownMenuProps;
+  onMenuToggled?: (isOpen: boolean) => void;
 };
 
-const TableActionMenu = ({ id, children, container = 'body' }: Props): JSX.Element => {
+const TableActionMenu = ({
+  id,
+  children,
+  container = 'body',
+  dropdownProps,
+  dropdownToggleProps,
+  dropdownMenuProps,
+  onMenuToggled,
+}: TableActionMenuProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
-  const toggle = () => setIsOpen(!isOpen);
+  const toggle = () => {
+    const newIsOpenVal = !isOpen;
+    setIsOpen(newIsOpenVal);
+
+    if (onMenuToggled) {
+      onMenuToggled(newIsOpenVal);
+    }
+  };
 
   return (
-    <Dropdown id={id} className="dropdown-action-menu" direction="left" isOpen={isOpen} toggle={toggle}>
+    <Dropdown
+      id={id}
+      className="dropdown-action-menu"
+      direction="left"
+      isOpen={isOpen}
+      toggle={toggle}
+      {...dropdownProps}
+    >
       <DropdownToggle
         id={`${id}_dropdown_toggle`}
         aria-label="Action Menu"
         data-boundary="viewport"
         className="btn btn-ghost"
+        {...dropdownToggleProps}
       >
         <Icon id={`${id}_dropdown_toggle_icon`} name="menu" />
       </DropdownToggle>
-      <DropdownMenu id={`${id}_dropdown_menu`} className="dropdown-action-menu" container={container}>
+      <DropdownMenu
+        id={`${id}_dropdown_menu`}
+        className="dropdown-action-menu"
+        container={container}
+        {...dropdownMenuProps}
+      >
         {children}
       </DropdownMenu>
     </Dropdown>

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -7,9 +7,10 @@ type Props = {
   id?: string;
   /** Children can be a react child. **/
   children: React.ReactNode;
+  container?: string;
 };
 
-const TableActionMenu = ({ id, children }: Props): JSX.Element => {
+const TableActionMenu = ({ id, children, container = 'body' }: Props): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
 
@@ -23,7 +24,7 @@ const TableActionMenu = ({ id, children }: Props): JSX.Element => {
       >
         <Icon id={`${id}_dropdown_toggle_icon`} name="menu" />
       </DropdownToggle>
-      <DropdownMenu id={`${id}_dropdown_menu`} className="dropdown-action-menu" container=".av-grid-row-even td">
+      <DropdownMenu id={`${id}_dropdown_menu`} className="dropdown-action-menu" container={container}>
         {children}
       </DropdownMenu>
     </Dropdown>

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Icon from '@availity/icon';
 
 import {
@@ -14,9 +14,13 @@ export type TableActionMenuProps = {
   id?: string;
   /** Children can be a react child. **/
   children: React.ReactNode;
+  /** This is utilized for the Popper dropdown menu. Defaults to 'body'. **/
   container?: string;
+  /** Reactstrap DropdownProps that should be passed into the Dropdown component. **/
   dropdownProps?: DropdownProps;
+  /** Reactstrap DropdownToggleProps that should be passed into the DropdownToggle component. **/
   dropdownToggleProps?: DropdownToggleProps;
+  /** Reactstrap dropdownMenuProps that should be passed into the DropdownMenu component. **/
   dropdownMenuProps?: DropdownMenuProps;
   onMenuToggled?: (isOpen: boolean) => void;
 };
@@ -44,6 +48,7 @@ const TableActionMenu = ({
   return (
     <Dropdown
       id={id}
+      data-testid={`${id}_dropdown`}
       className="dropdown-action-menu"
       direction="left"
       isOpen={isOpen}

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -12,15 +12,15 @@ import {
 
 export type TableActionMenuProps = {
   id?: string;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children: React.ReactNode;
-  /** This is utilized for the Popper dropdown menu. Defaults to 'body'. **/
+  /** This is utilized for the Popper dropdown menu. Defaults to 'body'. */
   container?: string;
-  /** Reactstrap DropdownProps that should be passed into the Dropdown component. **/
+  /** Reactstrap DropdownProps that should be passed into the Dropdown component. */
   dropdownProps?: DropdownProps;
-  /** Reactstrap DropdownToggleProps that should be passed into the DropdownToggle component. **/
+  /** Reactstrap DropdownToggleProps that should be passed into the DropdownToggle component. */
   dropdownToggleProps?: DropdownToggleProps;
-  /** Reactstrap dropdownMenuProps that should be passed into the DropdownMenu component. **/
+  /** Reactstrap DropdownMenuProps that should be passed into the DropdownMenu component. */
   dropdownMenuProps?: DropdownMenuProps;
   /** Function called whenever the menu is open/closed */
   onMenuToggled?: (isOpen: boolean) => void;
@@ -58,6 +58,7 @@ const TableActionMenu = ({
     >
       <DropdownToggle
         id={`${id}_dropdown_toggle`}
+        data-testid={`${id}_dropdown_toggle`}
         aria-label="Action Menu"
         data-boundary="viewport"
         className="btn btn-ghost"
@@ -67,6 +68,7 @@ const TableActionMenu = ({
       </DropdownToggle>
       <DropdownMenu
         id={`${id}_dropdown_menu`}
+        data-testid={`${id}_dropdown_menu`}
         className="dropdown-action-menu"
         container={container}
         {...dropdownMenuProps}

--- a/packages/table/src/TableActionMenu.tsx
+++ b/packages/table/src/TableActionMenu.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Icon from '@availity/icon';
+
 import {
   Dropdown,
   DropdownToggle,
@@ -30,6 +31,7 @@ const TableActionMenu = ({
   onMenuToggled,
 }: TableActionMenuProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
+
   const toggle = () => {
     const newIsOpenVal = !isOpen;
     setIsOpen(newIsOpenVal);

--- a/packages/table/src/TableActionMenuItem.tsx
+++ b/packages/table/src/TableActionMenuItem.tsx
@@ -4,11 +4,11 @@ import { IdType } from './types/ReactTable';
 import { RecordAction } from './types/RecordAction';
 
 type Props<T extends IdType> = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element */
   id?: string;
-  /** This is where the isVisible and onClick actions will be passed in **/
+  /** This is where the isVisible and onClick actions will be passed in */
   action: RecordAction<T>;
-  /** The record under observation **/
+  /** The record under observation */
   record: T;
 };
 

--- a/packages/table/src/TableActionMenuItem.tsx
+++ b/packages/table/src/TableActionMenuItem.tsx
@@ -19,11 +19,9 @@ const TableActionMenuItem = <T extends IdType>({ id, action, record }: Props<T>)
   }
 
   const displayText =
-    typeof action.displayText === 'string'
-      ? action.displayText
-      : typeof action.displayText === 'function'
+    typeof action.displayText === 'function'
       ? (action.displayText as (record?: T) => string | React.ReactChild | React.ElementType)(record)
-      : '';
+      : action.displayText;
 
   const setOnClickProps = () => {
     if (!action.onClick) {

--- a/packages/table/src/TableActionMenuItem.tsx
+++ b/packages/table/src/TableActionMenuItem.tsx
@@ -18,6 +18,13 @@ const TableActionMenuItem = <T extends IdType>({ id, action, record }: Props<T>)
     return null;
   }
 
+  const displayText =
+    typeof action.displayText === 'string'
+      ? action.displayText
+      : typeof action.displayText === 'function'
+      ? (action.displayText as (record?: T) => string | React.ReactChild | React.ElementType)(record)
+      : '';
+
   const setOnClickProps = () => {
     if (!action.onClick) {
       return null;
@@ -30,7 +37,7 @@ const TableActionMenuItem = <T extends IdType>({ id, action, record }: Props<T>)
     <DropdownItem id={`${id}_action_${action.id}`} key={action.id} divider />
   ) : (
     <DropdownItem id={`${id}_action_${action.id}`} key={action.id} {...setOnClickProps()}>
-      {action.displayText}
+      {displayText}
     </DropdownItem>
   );
 };

--- a/packages/table/src/TableActionMenuItem.tsx
+++ b/packages/table/src/TableActionMenuItem.tsx
@@ -34,7 +34,12 @@ const TableActionMenuItem = <T extends IdType>({ id, action, record }: Props<T>)
   return action.divider ? (
     <DropdownItem id={`${id}_action_${action.id}`} key={action.id} divider />
   ) : (
-    <DropdownItem id={`${id}_action_${action.id}`} key={action.id} {...setOnClickProps()}>
+    <DropdownItem
+      id={`${id}_action_${action.id}`}
+      key={action.id}
+      data-testid={`${id}_action_${action.id}`}
+      {...setOnClickProps()}
+    >
       {displayText}
     </DropdownItem>
   );

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -4,19 +4,20 @@ import { OnTableClickEvent } from './types/OnTableClickEvent';
 import { Cell, IdType } from './types/ReactTable';
 
 type Props<T extends IdType> = {
-  /**  **/
+  /** This is a unique id that is prepended to the element **/
   id?: string;
-  /**  **/
+  /** This is the react-table Cell that is being displayed.  **/
   cell: Cell<T>;
-  /**  **/
+  /** Determines whether the table is contained in a set scrollable container. */
   scrollable?: boolean;
-  
-  useColumnWidths?: boolean;
-  /**  **/
+  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell.   */
   getCellProps: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
-
-  children: React.ReactNode;
+  /** Callback function that will be called when the cell is clicked if provided. **/
   onCellClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  useColumnWidths?: boolean;
+  /** Children can be a react child. **/
+  children: React.ReactNode;
 } & React.HTMLAttributes<HTMLElement>;
 
 const TableCell = <T extends IdType>({

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -4,19 +4,19 @@ import { OnTableClickEvent } from './types/OnTableClickEvent';
 import { Cell, IdType } from './types/ReactTable';
 
 type Props<T extends IdType> = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element */
   id?: string;
-  /** This is the react-table Cell that is being displayed.  **/
+  /** This is the react-table Cell that is being displayed. */
   cell: Cell<T>;
   /** Determines whether the table is contained in a set scrollable container. */
   scrollable?: boolean;
-  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell.   */
+  /** This function provides any DOM properties that should be passed onto the `<td>` elements. Optionally pass in the Cell object in order to conditionally add DOM properties based on data of the cell. */
   getCellProps: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
-  /** Callback function that will be called when the cell is clicked if provided. **/
+  /** Callback function that will be called when the cell is clicked if provided. */
   onCellClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
-  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column. */
   useColumnWidths?: boolean;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children: React.ReactNode;
 } & React.HTMLAttributes<HTMLElement>;
 
@@ -44,8 +44,7 @@ const TableCell = <T extends IdType>({
   };
 
   const buildCellProps = () => {
-    const props = cell.getCellProps();
-
+    const props = { ...cell.getCellProps(), ...getCellProps(cell) };
     props.className = classNames(
       className || '',
       {
@@ -64,8 +63,9 @@ const TableCell = <T extends IdType>({
             width,
             minWidth,
             maxWidth,
+            ...props.style,
           }
-        : undefined,
+        : props.style,
       ...rest,
     };
   };

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -60,11 +60,13 @@ const TableCell = <T extends IdType>({
     return {
       ...props,
       ...cellProps,
-      style: {
-        width,
-        minWidth,
-        maxWidth,
-      },
+      style: isFixedWidth
+        ? {
+            width,
+            minWidth,
+            maxWidth,
+          }
+        : undefined,
       ...rest,
     };
   };

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -11,7 +11,7 @@ type Props<T extends IdType> = {
   /**  **/
   scrollable?: boolean;
   
-  isFixedWith?: boolean;
+  useColumnWidths?: boolean;
   /**  **/
   getCellProps: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
 
@@ -23,16 +23,14 @@ const TableCell = <T extends IdType>({
   cell,
   scrollable,
   children,
+  useColumnWidths,
   onCellClick,
   getCellProps,
   ...rest
 }: Props<T>): JSX.Element => {
   const { className, disableClick, stickyLeft, stickyRight, width, minWidth, maxWidth } = cell.column;
 
-  const isFixedWidth = scrollable && !className;
-
   const cellProps = {
-    title: cell.value && isFixedWidth ? cell.value.toString() : undefined,
     onClick: (e: React.MouseEvent<HTMLTableCellElement, MouseEvent>) => {
       if (!disableClick && onCellClick)
         onCellClick({
@@ -60,7 +58,7 @@ const TableCell = <T extends IdType>({
     return {
       ...props,
       ...cellProps,
-      style: isFixedWidth
+      style: useColumnWidths
         ? {
             width,
             minWidth,

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -10,6 +10,8 @@ type Props<T extends IdType> = {
   cell: Cell<T>;
   /**  **/
   scrollable?: boolean;
+  
+  isFixedWith?: boolean;
   /**  **/
   getCellProps: (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>;
 
@@ -25,7 +27,7 @@ const TableCell = <T extends IdType>({
   getCellProps,
   ...rest
 }: Props<T>): JSX.Element => {
-  const { className, disableClick, stickyLeft, stickyRight } = cell.column;
+  const { className, disableClick, stickyLeft, stickyRight, width, minWidth, maxWidth } = cell.column;
 
   const isFixedWidth = scrollable && !className;
 
@@ -43,11 +45,11 @@ const TableCell = <T extends IdType>({
   };
 
   const buildCellProps = () => {
-    const props = getCellProps(cell);
+    const props = cell.getCellProps();
+
     props.className = classNames(
       className || '',
       {
-        'fixed-width-text': isFixedWidth,
         'cursor-pointer': !!onCellClick,
         sticky: stickyRight || stickyLeft,
         'sticky-right': stickyRight,
@@ -55,7 +57,16 @@ const TableCell = <T extends IdType>({
       },
       props.className
     );
-    return { ...props, ...cellProps, ...rest };
+    return {
+      ...props,
+      ...cellProps,
+      style: {
+        width,
+        minWidth,
+        maxWidth,
+      },
+      ...rest,
+    };
   };
 
   return <td {...cell.getCellProps(buildCellProps)}>{children}</td>;

--- a/packages/table/src/TableContent.tsx
+++ b/packages/table/src/TableContent.tsx
@@ -114,11 +114,13 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
         })}
       </tbody>
       {footer && (
-        <tfoot>
+        <tfoot data-testid={`${populateId()}table_footer`}>
           {footerGroups.map((group) => (
-            <tr {...group.getFooterGroupProps()}>
+            <tr data-testid={`${populateId()}table_footer_row`} {...group.getFooterGroupProps()}>
               {group.headers.map((column) => (
-                <td {...column.getFooterProps()}>{column.render('Footer')}</td>
+                <td data-testid={`${populateId()}table_footer_row_${column.id}`} {...column.getFooterProps()}>
+                  {column.render('Footer')}
+                </td>
               ))}
             </tr>
           ))}

--- a/packages/table/src/TableContent.tsx
+++ b/packages/table/src/TableContent.tsx
@@ -24,6 +24,7 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
     selectable,
     AdditionalContent,
     additionalContentProps,
+    useColumnWidths,
 
     onRowClick,
     onCellClick,
@@ -61,6 +62,7 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
                     sortable={sortable}
                     manualSortBy={manualSortBy}
                     column={header}
+                    useColumnWidths={useColumnWidths}
                   >
                     {header.render('Header')}
                     {sortable && header.defaultCanSort && header.disableSortBy !== true ? (
@@ -102,6 +104,7 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
                   cell={cell as Cell<T>}
                   onCellClick={selectable ? onRowClick : onCellClick}
                   getCellProps={getCellProps as (cell: Cell<T>) => React.HTMLAttributes<HTMLTableCellElement>}
+                  useColumnWidths={useColumnWidths}
                 >
                   {cell.render('Cell')}
                 </TableCell>

--- a/packages/table/src/TableContent.tsx
+++ b/packages/table/src/TableContent.tsx
@@ -15,6 +15,7 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
     id,
     scrollable,
     sortable,
+    footer,
     tableProps,
     headerProps,
     onSort,
@@ -30,7 +31,7 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
     getRowProps,
   } = useTableContext();
 
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, manualSortBy, page } =
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, manualSortBy, page, footerGroups } =
     tableInstance as TableInstance<T>;
 
   const populateId = () => (id ? `${id}_` : '');
@@ -109,6 +110,17 @@ const TableContent = <T extends IdType>(): JSX.Element | null => {
           );
         })}
       </tbody>
+      {footer && (
+        <tfoot>
+          {footerGroups.map((group) => (
+            <tr {...group.getFooterGroupProps()}>
+              {group.headers.map((column) => (
+                <td {...column.getFooterProps()}>{column.render('Footer')}</td>
+              ))}
+            </tr>
+          ))}
+        </tfoot>
+      )}
     </RsTable>
   );
 };

--- a/packages/table/src/TableContext.tsx
+++ b/packages/table/src/TableContext.tsx
@@ -56,6 +56,7 @@ export type AvTableContext = {
   /** This determines whether the table is sortable or not. **/
   sortable?: boolean;
   footer?: boolean;
+  useColumnWidths?: boolean;
   /** This boolean determines whether the table is paged or not. This
    * works with the usePagination hook that is documented in react-table.
    * This defaults to false. **/
@@ -72,6 +73,7 @@ export const TableContext = React.createContext<AvTableContext>({
   scrollable: false,
   sortable: false,
   footer: false,
+  useColumnWidths: false,
   getRowProps: () => ({} as RowProps),
   getCellProps: () => ({} as React.HTMLAttributes<HTMLTableCellElement>),
 });

--- a/packages/table/src/TableContext.tsx
+++ b/packages/table/src/TableContext.tsx
@@ -4,70 +4,70 @@ import { OnRowSelectedEvent, OnTableClickEvent, TableSort, TableSortOption } fro
 import { Cell, Row, RowProps } from './types/ReactTable';
 
 type HeaderProps = {
-  /**  **/
+  /** This makes the column sticky to the table. This works best when inside a scrollable container. Not supported in IE11. */
   sticky: boolean;
 } & React.HTMLAttributes<HTMLElement>;
 
 export type AvTableContext = {
   /** This is a unique id that is prepended to the element */
   id?: string;
-  /** Any DOM properties that should be passed onto the <table> element. **/
+  /** Any DOM properties that should be passed onto the <table> element. */
   tableProps?: React.HTMLAttributes<HTMLElement>;
-  /** Any DOM properties that should be passed onto the <tbody> element. **/
+  /** Any DOM properties that should be passed onto the <tbody> element. */
   bodyProps?: React.HTMLAttributes<HTMLElement>;
   /** Any DOM properties that should be passed onto the <thead> element.
    * A special boolean property sticky' is added here to allow for
-   * designating the header as 'sticky' or not. **/
+   * designating the header as 'sticky' or not. */
   headerProps?: HeaderProps;
   /** This function provides any DOM properties that should be passed
    * onto the <td> elements. Optionally pass in the Cell object in order
-   * to conditionally add DOM properties based on data of the cell. **/
+   * to conditionally add DOM properties based on data of the cell. */
   getCellProps: (cell: Cell<Record<string, any>>) => React.HTMLAttributes<HTMLTableCellElement>;
   /** This function provides any DOM properties that should be passed onto
    * the <tr> element. Optionally pass in the Row object in order to
-   * conditionally add DOM properties based on the data of the row. **/
+   * conditionally add DOM properties based on the data of the row. */
   getRowProps: (row: Row<Record<string, any>>) => RowProps;
-  /** This function is called whenever a cell on the row has been clicked. **/
+  /** This function is called whenever a cell on the row has been clicked. */
   onCellClick?: (event: OnTableClickEvent<HTMLElement, any>) => void;
-  /** This function is called whenever a row on the table has been clicked. **/
+  /** This function is called whenever a row on the table has been clicked. */
   onRowClick?: (event: OnTableClickEvent<HTMLElement, any>) => void;
-  /** Event handler for when a row is selected. **/
+  /** Event handler for when a row is selected. */
   onRowSelected?: (event: OnRowSelectedEvent<any>) => void;
-  /** This function will be called whenever the table has been sorted. **/
+  /** This function will be called whenever the table has been sorted. */
   onSort?: (sortBy: TableSort[]) => void;
   /** This function determines if a row in a selectable table can be
    * selected. By default if no function is provided to this property,
-   * all rows in the table are selectable. **/
+   * all rows in the table are selectable. */
   getCanSelectRow?: (record: any) => boolean;
   /** This designates a Component that will be displayed in the table
    * row for the record. This content displays in an additional <tr>
-   * with a colspan equal to the number of columns that are NOT sticky. **/
+   * with a colspan equal to the number of columns that are NOT sticky. */
   AdditionalContent?: React.ElementType;
   /**  */
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
   /** This property is automatically set when it is wrapped in a scrollable
    * container. This will apply fixed column widths to force it to scroll
-   * rather than minify the columns to fit in a set container. **/
+   * rather than minify the columns to fit in a set container. */
   scrollable?: boolean;
   /** This determines whether the table is selectable or not. If it is set
    * to true, then the first column of the table will be a checkbox column
-   * that will toggle selecting and deselecting the row. **/
+   * that will toggle selecting and deselecting the row. */
   selectable?: boolean;
-  /** This determines whether the table is sortable or not. **/
+  /** This determines whether the table is sortable or not. */
   sortable?: boolean;
   /** This boolean determines whether the table is paged or not. This
    * works with the usePagination hook that is documented in react-table.
-   * This defaults to false. **/
+   * This defaults to false. */
   paged?: boolean;
   /** This boolean determines whether a footer should be displayed. */
   footer?: boolean;
-  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column. */
   useColumnWidths?: boolean;
-  /**  */
+  /** An array of columns that should be sortable on the table. */
   sortableColumns?: TableSortOption[];
-  /** The react-table Row instance that was clicked */
+  /** The react-table instance. */
   instance?: any;
-  /**  */
+  /** The setting for setting the react-table instance.  */
   setInstance?: React.Dispatch<React.SetStateAction<any>>;
 };
 

--- a/packages/table/src/TableContext.tsx
+++ b/packages/table/src/TableContext.tsx
@@ -61,6 +61,10 @@ export type AvTableContext = {
    * works with the usePagination hook that is documented in react-table.
    * This defaults to false. **/
   paged?: boolean;
+  /** This boolean determines whether a footer should be displayed. */
+  footer?: boolean;
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
+  useColumnWidths?: boolean;
   /**  */
   sortableColumns?: TableSortOption[];
   /** The react-table Row instance that was clicked */

--- a/packages/table/src/TableContext.tsx
+++ b/packages/table/src/TableContext.tsx
@@ -55,8 +55,6 @@ export type AvTableContext = {
   selectable?: boolean;
   /** This determines whether the table is sortable or not. **/
   sortable?: boolean;
-  footer?: boolean;
-  useColumnWidths?: boolean;
   /** This boolean determines whether the table is paged or not. This
    * works with the usePagination hook that is documented in react-table.
    * This defaults to false. **/

--- a/packages/table/src/TableContext.tsx
+++ b/packages/table/src/TableContext.tsx
@@ -55,6 +55,7 @@ export type AvTableContext = {
   selectable?: boolean;
   /** This determines whether the table is sortable or not. **/
   sortable?: boolean;
+  footer?: boolean;
   /** This boolean determines whether the table is paged or not. This
    * works with the usePagination hook that is documented in react-table.
    * This defaults to false. **/
@@ -70,6 +71,7 @@ export type AvTableContext = {
 export const TableContext = React.createContext<AvTableContext>({
   scrollable: false,
   sortable: false,
+  footer: false,
   getRowProps: () => ({} as RowProps),
   getCellProps: () => ({} as React.HTMLAttributes<HTMLTableCellElement>),
 });

--- a/packages/table/src/TableHeader.tsx
+++ b/packages/table/src/TableHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 export type Props = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element */
   id?: string;
-  /** This determines if the element is sticky or not **/
+  /** This determines if the element is sticky or not */
   sticky?: boolean;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/TableHeaderCell.tsx
+++ b/packages/table/src/TableHeaderCell.tsx
@@ -7,7 +7,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 type Props<T extends IdType> = {
   /** This is a unique id that is prepended to the element **/
   id?: string;
-  /**  **/
+  /** The react-table Column that is build displayed.  **/
   column: ExtendedTableHeader<T>;
   /** This function will be called whenever the table has been sorted. **/
   onSort?: (sortBy: TableSort[]) => void;
@@ -20,8 +20,9 @@ type Props<T extends IdType> = {
   scrollable?: boolean;
   /** This determines whether the table is sortable or not. **/
   sortable?: boolean;
-  /**  **/
+  /** Correlates with whether the sorting is done outside of the table component or not. If sorting is performed outside of the component, this should be set to true. **/
   manualSortBy?: boolean;
+  /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
   useColumnWidths?: boolean;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/TableHeaderCell.tsx
+++ b/packages/table/src/TableHeaderCell.tsx
@@ -49,6 +49,8 @@ const TableHeaderCell = <T extends IdType>({
     return null;
   };
 
+  const isFixedWidth = scrollable;
+
   const getHeaderColumnProps = (column: ExtendedTableHeader<T>) => {
     const inheritProps = column.getHeaderProps();
     const props = {
@@ -58,11 +60,13 @@ const TableHeaderCell = <T extends IdType>({
         'sticky-left': column.stickyLeft,
       }),
       title: undefined,
-      style: {
-        width: column.width,
-        minWidth: column.width,
-        maxWidth: column.width,
-      },
+      style: isFixedWidth
+        ? {
+            width: column.width,
+            minWidth: column.width,
+            maxWidth: column.width,
+          }
+        : undefined,
       ...inheritProps,
     };
     return sortable ? { ...column.getSortByToggleProps(props) } : props;

--- a/packages/table/src/TableHeaderCell.tsx
+++ b/packages/table/src/TableHeaderCell.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import classNames from 'classnames';
+import { UncontrolledTooltip } from 'reactstrap';
 import { ExtendedTableHeader, IdType } from './types/ReactTable';
 import { TableSort } from './types/TableSort';
-import { UncontrolledTooltip } from 'reactstrap';
 
 type Props<T extends IdType> = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element. */
   id?: string;
-  /** The react-table Column that is build displayed.  **/
+  /** The react-table Column that is displayed. */
   column: ExtendedTableHeader<T>;
-  /** This function will be called whenever the table has been sorted. **/
+  /** This function will be called whenever the table has been sorted. */
   onSort?: (sortBy: TableSort[]) => void;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children: React.ReactNode | React.ReactNode[];
 
   /** This property is automatically set when it is wrapped in a
    * scrollable container. This will apply fixed column widths to force
-   * it to scroll rather than minify the columns to fit in a set container. **/
+   * it to scroll rather than minify the columns to fit in a set container. */
   scrollable?: boolean;
-  /** This determines whether the table is sortable or not. **/
+  /** This determines whether the table is sortable or not. */
   sortable?: boolean;
-  /** Correlates with whether the sorting is done outside of the table component or not. If sorting is performed outside of the component, this should be set to true. **/
+  /** Correlates with whether the sorting is done outside of the table component or not. If sorting is performed outside of the component, this should be set to true. */
   manualSortBy?: boolean;
   /** When true, it will take the width as defined in the column configuration and apply it to the styles of each column.  */
   useColumnWidths?: boolean;
@@ -64,8 +64,8 @@ const TableHeaderCell = <T extends IdType>({
       style: useColumnWidths
         ? {
             width: column.width,
-            minWidth: column.width,
-            maxWidth: column.width,
+            minWidth: column.minWidth,
+            maxWidth: column.maxWidth,
           }
         : undefined,
       ...inheritProps,

--- a/packages/table/src/TableHeaderCell.tsx
+++ b/packages/table/src/TableHeaderCell.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { ExtendedTableHeader, IdType } from './types/ReactTable';
 import { TableSort } from './types/TableSort';
+import { UncontrolledTooltip } from 'reactstrap';
 
 type Props<T extends IdType> = {
   /** This is a unique id that is prepended to the element **/
@@ -49,21 +50,33 @@ const TableHeaderCell = <T extends IdType>({
   };
 
   const getHeaderColumnProps = (column: ExtendedTableHeader<T>) => {
+    const inheritProps = column.getHeaderProps();
     const props = {
       className: classNames(column.className || '', {
-        'fixed-width-text': scrollable && !column.className,
         sticky: column.stickyRight || column.stickyLeft,
         'sticky-right': column.stickyRight,
         'sticky-left': column.stickyLeft,
       }),
-      title: column.label || typeof column.Header === 'string' ? column.Header?.toString() : undefined,
+      title: undefined,
+      style: {
+        width: column.width,
+        minWidth: column.width,
+        maxWidth: column.width,
+      },
+      ...inheritProps,
     };
     return sortable ? { ...column.getSortByToggleProps(props) } : props;
   };
 
   return (
     <th {...column.getHeaderProps(getHeaderColumnProps(column))} {...getOnClick()} {...rest}>
-      <>{children}</>
+      <span id={`${column.id}-th-title`}>{children}</span>
+      {column.label ||
+        (typeof column.Header === 'string' && (
+          <UncontrolledTooltip placement="top" target={`${column.id}-th-title`} boundary="window">
+            {column.Header?.toString()}
+          </UncontrolledTooltip>
+        ))}
     </th>
   );
 };

--- a/packages/table/src/TableHeaderCell.tsx
+++ b/packages/table/src/TableHeaderCell.tsx
@@ -22,6 +22,7 @@ type Props<T extends IdType> = {
   sortable?: boolean;
   /**  **/
   manualSortBy?: boolean;
+  useColumnWidths?: boolean;
 } & React.HTMLAttributes<HTMLElement>;
 
 const TableHeaderCell = <T extends IdType>({
@@ -32,6 +33,7 @@ const TableHeaderCell = <T extends IdType>({
   scrollable,
   sortable,
   manualSortBy,
+  useColumnWidths,
 
   ...rest
 }: Props<T>): JSX.Element => {
@@ -49,8 +51,6 @@ const TableHeaderCell = <T extends IdType>({
     return null;
   };
 
-  const isFixedWidth = scrollable;
-
   const getHeaderColumnProps = (column: ExtendedTableHeader<T>) => {
     const inheritProps = column.getHeaderProps();
     const props = {
@@ -60,7 +60,7 @@ const TableHeaderCell = <T extends IdType>({
         'sticky-left': column.stickyLeft,
       }),
       title: undefined,
-      style: isFixedWidth
+      style: useColumnWidths
         ? {
             width: column.width,
             minWidth: column.width,

--- a/packages/table/src/TableHeaderRow.tsx
+++ b/packages/table/src/TableHeaderRow.tsx
@@ -5,7 +5,7 @@ import { IdType } from './types/ReactTable';
 export type Props<T extends IdType> = {
   /** This is a unique id that is prepended to the element **/
   id?: string;
-  /**  **/
+  /** The react-table header **/
   headerGroup: ExtendedTableHeader<T>;
   /** This function will be called whenever the table has been sorted. **/
   onSort?: (sortBy: TableSort[]) => void;

--- a/packages/table/src/TableHeaderRow.tsx
+++ b/packages/table/src/TableHeaderRow.tsx
@@ -3,17 +3,17 @@ import { ExtendedTableHeader, TableSort } from './types';
 import { IdType } from './types/ReactTable';
 
 export type Props<T extends IdType> = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element. */
   id?: string;
-  /** The react-table header **/
+  /** The react-table header */
   headerGroup: ExtendedTableHeader<T>;
-  /** This function will be called whenever the table has been sorted. **/
+  /** This function will be called whenever the table has been sorted. */
   onSort?: (sortBy: TableSort[]) => void;
   /** This property is automatically set when it is wrapped in a
    * scrollable container. This will apply fixed column widths to force
-   * it to scroll rather than minify the columns to fit in a set container. **/
+   * it to scroll rather than minify the columns to fit in a set container. */
   scrollable?: boolean;
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/TableRow.tsx
+++ b/packages/table/src/TableRow.tsx
@@ -8,25 +8,25 @@ import { Column, IdType, Row, RowProps, TableInstance } from './types/ReactTable
 export type Props<T extends IdType> = {
   /** This is a unique id that is prepended to the element **/
   id?: string;
-  /**  **/
+  /** The Row that is being displayed. **/
   row: Row<T>;
   /** The index of the row that was clicked. **/
   index: number;
-  /**  **/
+  /** Callback function that will be called when the row is clicked if provided. **/
   onRowClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
-  /**  **/
+  /** Callback function that will be called when the cell is clicked if provided. **/
   onCellClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
 
-  /**  **/
+  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.  */
   AdditionalContent?: React.ElementType;
-  /**  **/
+  /**  Additional Properties that should be added to the additional content component when it is rendered. */
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
-  /**  **/
+  /** Determines whether the table is contained in a set scrollable container. */
   scrollable?: boolean;
-  /**  **/
+  /** The react-table table instance **/
   instance?: TableInstance<T>;
 
-  /**  **/
+  /** This function provides any DOM properties that should be passed onto the `<tr>` element. Optionally pass in the Row object in order to conditionally add DOM properties based on the data of the row. */
   getRowProps?: (row: Row<T>) => RowProps;
 
   /** Children can be a react child. **/

--- a/packages/table/src/TableRow.tsx
+++ b/packages/table/src/TableRow.tsx
@@ -102,7 +102,7 @@ const TableRow = <T extends IdType>({
       {AdditionalContent && (
         <tr {...buildRowProps()} id={`${id}_additional_content`}>
           {isFirstColumnSticky && <td className="sticky sticky-left" />}
-          <td colSpan={numberOfNonStickyColumns} style={{ borderTop: 0 }} {...definedCellProps}>
+          <td colSpan={numberOfNonStickyColumns} className="border-0" {...definedCellProps}>
             <AdditionalContent row={row} record={row.original} {...additionalContentProps} />
           </td>
           {isLastColumnSticky && <td className="sticky sticky-right" />}

--- a/packages/table/src/TableRow.tsx
+++ b/packages/table/src/TableRow.tsx
@@ -6,30 +6,30 @@ import { OnTableClickEvent } from './types/OnTableClickEvent';
 import { Column, IdType, Row, RowProps, TableInstance } from './types/ReactTable';
 
 export type Props<T extends IdType> = {
-  /** This is a unique id that is prepended to the element **/
+  /** This is a unique id that is prepended to the element */
   id?: string;
-  /** The Row that is being displayed. **/
+  /** The Row that is being displayed. */
   row: Row<T>;
-  /** The index of the row that was clicked. **/
+  /** The index of the row that was clicked. */
   index: number;
-  /** Callback function that will be called when the row is clicked if provided. **/
+  /** Callback function that will be called when the row is clicked if provided. */
   onRowClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
-  /** Callback function that will be called when the cell is clicked if provided. **/
+  /** Callback function that will be called when the cell is clicked if provided. */
   onCellClick?: (event: OnTableClickEvent<HTMLElement, T>) => void;
 
-  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky.  */
+  /** This designates a Component that will be displayed in the table row for the record. This content displays in an additional `<tr>` with a colspan equal to the number of columns that are NOT sticky. */
   AdditionalContent?: React.ElementType;
   /**  Additional Properties that should be added to the additional content component when it is rendered. */
   additionalContentProps?: Record<string, string | number | boolean | undefined | null>;
   /** Determines whether the table is contained in a set scrollable container. */
   scrollable?: boolean;
-  /** The react-table table instance **/
+  /** The react-table table instance */
   instance?: TableInstance<T>;
 
   /** This function provides any DOM properties that should be passed onto the `<tr>` element. Optionally pass in the Row object in order to conditionally add DOM properties based on the data of the row. */
   getRowProps?: (row: Row<T>) => RowProps;
 
-  /** Children can be a react child. **/
+  /** Children can be a react child. */
   children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLElement>;
 

--- a/packages/table/src/TableRow.tsx
+++ b/packages/table/src/TableRow.tsx
@@ -103,7 +103,7 @@ const TableRow = <T extends IdType>({
         <tr {...buildRowProps()} id={`${id}_additional_content`}>
           {isFirstColumnSticky && <td className="sticky sticky-left" />}
           <td colSpan={numberOfNonStickyColumns} style={{ borderTop: 0 }} {...definedCellProps}>
-            <AdditionalContent record={row.original} {...additionalContentProps} />
+            <AdditionalContent row={row} record={row.original} {...additionalContentProps} />
           </td>
           {isLastColumnSticky && <td className="sticky sticky-right" />}
         </tr>

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -47,3 +47,4 @@ export { default as TableContent } from './TableContent';
 export { default as ScrollableContainer } from './ScrollableContainer';
 
 export { TableSorter, TableControls, BulkTableActions } from './Controls';
+export type { BulkTableActionsProps } from './Controls';

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -1,6 +1,20 @@
-export { ActionCell, BadgeCell, CurrencyCell, DateCell, IconCell, IconWithTooltipCell } from './CellDefinitions';
+export {
+  ActionCell,
+  BadgeCell,
+  CurrencyCell,
+  DateCell,
+  DefaultValueCell,
+  IconCell,
+  IconWithTooltipCell,
+} from './CellDefinitions';
 
-export type { ActionCellConfig, CurrencyCellConfig, DateTimeCellConfig, IconConfig } from './CellDefinitions';
+export type {
+  ActionCellConfig,
+  CurrencyCellConfig,
+  DateTimeCellConfig,
+  DefaultValueCellProps,
+  IconConfig,
+} from './CellDefinitions';
 
 export type {
   OnRowSelectedEvent,

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -35,6 +35,9 @@ export type {
 
 export { default } from './Table';
 
+export { default as TableActionMenu } from './TableActionMenu';
+export type { TableActionMenuProps } from './TableActionMenu';
+
 export { useTableContext, TableContext } from './TableContext';
 export type { AvTableContext } from './TableContext';
 

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -34,6 +34,7 @@ export type {
 } from './types';
 
 export { default } from './Table';
+export type { CommonTableProps } from './Table';
 
 export { default as TableActionMenu } from './TableActionMenu';
 export type { TableActionMenuProps } from './TableActionMenu';

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -34,7 +34,7 @@ export type {
 } from './types';
 
 export { default } from './Table';
-export type { CommonTableProps } from './Table';
+export type { CommonTableProps, TableRef } from './Table';
 
 export { default as TableActionMenu } from './TableActionMenu';
 export type { TableActionMenuProps } from './TableActionMenu';

--- a/packages/table/src/tests/BulkTableActions.test.tsx
+++ b/packages/table/src/tests/BulkTableActions.test.tsx
@@ -8,6 +8,8 @@ import { Column } from '../types/ReactTable';
 import Table from '../Table';
 import TableContent from '../TableContent';
 
+jest.mock('@availity/hooks');
+
 const basicColumns = [
   {
     Header: 'First Name',

--- a/packages/table/src/tests/BulkTableActions.test.tsx
+++ b/packages/table/src/tests/BulkTableActions.test.tsx
@@ -45,6 +45,10 @@ const bulkActions = [
     onClick: jest.fn(),
     isVisible: () => false,
   },
+  {
+    id: 'action3',
+    displayText: () => 'Populated By function',
+  },
 ];
 
 describe('BulkTableActions', () => {

--- a/packages/table/src/tests/BulkTableActions.test.tsx
+++ b/packages/table/src/tests/BulkTableActions.test.tsx
@@ -42,6 +42,10 @@ const bulkActions = [
     onClick: jest.fn(),
   },
   {
+    id: 'actionDivider',
+    divider: true,
+  },
+  {
     id: 'action2',
     displayText: 'Action 2',
     onClick: jest.fn(),
@@ -190,5 +194,34 @@ describe('BulkTableActions', () => {
     await waitFor(() => {
       expect(onRowsSelected).toHaveBeenCalled();
     });
+  });
+
+  test('should populate buttonGroupProps when provided', async () => {
+    const props = { vertical: true };
+
+    const { getByTestId } = render(
+      <Table data={basicData} columns={basicColumns}>
+        <TableControls>
+          <BulkTableActions bulkActions={bulkActions} buttonGroupProps={props} />
+        </TableControls>
+        <TableContent />
+      </Table>
+    );
+
+    expect(getByTestId('bulk_actions_btn_group')).toHaveAttribute('class', 'btn-group btn-group-vertical');
+  });
+
+  test('should add divider to bulk action menu when provided', async () => {
+    const { getByTestId } = render(
+      <Table data={basicData} columns={basicColumns}>
+        <TableControls>
+          <BulkTableActions bulkActions={bulkActions} />
+        </TableControls>
+        <TableContent />
+      </Table>
+    );
+
+    expect(getByTestId('bulk_action_actionDivider')).not.toBeNull();
+    expect(getByTestId('bulk_action_actionDivider')).toHaveClass('dropdown-divider');
   });
 });

--- a/packages/table/src/tests/Table.test.tsx
+++ b/packages/table/src/tests/Table.test.tsx
@@ -511,6 +511,55 @@ describe('Table', () => {
 });
 
 describe('ActionCell', () => {
+  test('should allow displayText to be set via a function for action', async () => {
+    const columDefs = [
+      {
+        id: 'actions',
+        Header: 'Actions',
+        Cell: ActionCell({
+          actions: [
+            {
+              id: 'myAction',
+              displayText: (record: Record<string, string | boolean | number | undefined>) =>
+                record?.conditionalValue ? 'THIS' : 'OR_THIS',
+            },
+          ],
+        }),
+      },
+    ] as Column<Record<string, string | boolean | number | undefined>>[];
+
+    const currentData = [
+      {
+        id: '1',
+        conditionalValue: false,
+      },
+      {
+        id: '2',
+        conditionalValue: true,
+      },
+    ];
+
+    const { debug } = render(
+      <Table data={currentData} columns={columDefs}>
+        <TableContent />
+      </Table>
+    );
+
+    debug();
+
+    await waitFor(() => {
+      const actionItem1 = screen.getByTestId('table_row_action_menu_item_0_action_myAction');
+      expect(actionItem1).not.toBeNull();
+
+      expect(actionItem1).toHaveTextContent('OR_THIS');
+
+      const actionItem2 = screen.getByTestId('table_row_action_menu_item_1_action_myAction');
+      expect(actionItem2).not.toBeNull();
+
+      expect(actionItem2).toHaveTextContent('THIS');
+    });
+  });
+
   test('should allow display text to be set via a function for primary action', async () => {
     const columDefs = [
       {
@@ -546,7 +595,7 @@ describe('ActionCell', () => {
       },
     ];
 
-    render(
+    const { debug } = render(
       <Table data={currentData} columns={columDefs}>
         <TableContent />
       </Table>
@@ -684,5 +733,31 @@ describe('DefaultValueCell', () => {
 
     const cell1 = screen.getByTestId('table_row_0_cell_0');
     expect(cell1.querySelector('[data-testid=default-text]')).not.toBeNull();
+  });
+
+  test('should just display empty string when no default value is provided', () => {
+    const columDefs = [
+      {
+        accessor: 'conditionalValue',
+        Header: 'Default1',
+        Cell: DefaultValueCell({}),
+      },
+    ] as Column<Record<string, string | boolean | number | undefined>>[];
+
+    const currentData = [
+      {
+        id: '1',
+        conditionalValue: undefined,
+      },
+    ];
+
+    render(
+      <Table data={currentData} columns={columDefs}>
+        <TableContent />
+      </Table>
+    );
+
+    const cell1 = screen.getByTestId('table_row_0_cell_0');
+    expect(cell1).toHaveTextContent('');
   });
 });

--- a/packages/table/src/tests/Table.test.tsx
+++ b/packages/table/src/tests/Table.test.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { UsePaginationInstanceProps, UseTableInstanceProps } from 'react-table';
 
 import basicData from './data/basicData.json';
 import formattedData from './data/needsFormattedData.json';
@@ -15,7 +14,6 @@ import DefaultValueCell from '../CellDefinitions/DefaultValueCell';
 import IconWithTooltipCell from '../CellDefinitions/IconWIthTooltipCell';
 import { Cell, Column, Row } from '../types/ReactTable';
 import TableContent from '../TableContent';
-import { act } from 'react-dom/test-utils';
 
 const basicColumns = [
   {

--- a/packages/table/src/tests/__snapshots__/BulkTableActions.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/BulkTableActions.test.tsx.snap
@@ -70,6 +70,11 @@ exports[`BulkTableActions should render default bulk actions 1`] = `
             >
               Action 2
             </button>
+            <div
+              class="dropdown-divider"
+              data-testid="bulk_action_actionDivider"
+              tabindex="-1"
+            />
             <button
               class="dropdown-item"
               data-testid="bulk_action_action3"

--- a/packages/table/src/tests/__snapshots__/BulkTableActions.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/BulkTableActions.test.tsx.snap
@@ -70,6 +70,13 @@ exports[`BulkTableActions should render default bulk actions 1`] = `
             >
               Action 2
             </button>
+            <button
+              class="dropdown-item"
+              data-testid="bulk_action_action3"
+              role="menuitem"
+              tabindex="0"
+              type="button"
+            />
           </div>
         </div>
       </div>

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -347,6 +347,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
+            data-testid="table_row_action_menu_0_dropdown"
             id="table_row_action_menu_0"
           >
             <button
@@ -373,6 +374,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
             >
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_0_action_action1"
                 id="table_row_action_menu_item_0_action_action1"
                 role="menuitem"
                 tabindex="0"
@@ -387,6 +389,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
               />
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_0_action_action2"
                 id="table_row_action_menu_item_0_action_action2"
                 role="menuitem"
                 tabindex="0"
@@ -479,6 +482,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
+            data-testid="table_row_action_menu_1_dropdown"
             id="table_row_action_menu_1"
           >
             <button
@@ -510,6 +514,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
               />
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_1_action_action2"
                 id="table_row_action_menu_item_1_action_action2"
                 role="menuitem"
                 tabindex="0"
@@ -1393,6 +1398,7 @@ exports[`Table should render with formatted cells 1`] = `
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
+            data-testid="table_row_action_menu_0_dropdown"
             id="table_row_action_menu_0"
           >
             <button
@@ -1419,6 +1425,7 @@ exports[`Table should render with formatted cells 1`] = `
             >
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_0_action_action1"
                 id="table_row_action_menu_item_0_action_action1"
                 role="menuitem"
                 tabindex="0"
@@ -1433,6 +1440,7 @@ exports[`Table should render with formatted cells 1`] = `
               />
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_0_action_action2"
                 id="table_row_action_menu_item_0_action_action2"
                 role="menuitem"
                 tabindex="0"
@@ -1525,6 +1533,7 @@ exports[`Table should render with formatted cells 1`] = `
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
+            data-testid="table_row_action_menu_1_dropdown"
             id="table_row_action_menu_1"
           >
             <button
@@ -1556,6 +1565,7 @@ exports[`Table should render with formatted cells 1`] = `
               />
               <button
                 class="dropdown-item"
+                data-testid="table_row_action_menu_item_1_action_action2"
                 id="table_row_action_menu_item_1_action_action2"
                 role="menuitem"
                 tabindex="0"

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -20,27 +20,36 @@ exports[`Table should not display hidden columns 1`] = `
           data-testid="table_header_row_0_cell_0_first_name"
           id="table_header_row_0_cell_0_first_name"
           role="columnheader"
-          title="First Name"
         >
-          First Name
+          <span
+            id="first_name-th-title"
+          >
+            First Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_1_last_name"
           id="table_header_row_0_cell_1_last_name"
           role="columnheader"
-          title="Last Name"
         >
-          Last Name
+          <span
+            id="last_name-th-title"
+          >
+            Last Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_2_email"
           id="table_header_row_0_cell_2_email"
           role="columnheader"
-          title="Email"
         >
-          Email
+          <span
+            id="email-th-title"
+          >
+            Email
+          </span>
         </th>
       </tr>
     </thead>
@@ -56,18 +65,21 @@ exports[`Table should not display hidden columns 1`] = `
         <td
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           Barbra
         </td>
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           Tull
         </td>
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           btull0@usatoday.com
         </td>
@@ -81,18 +93,21 @@ exports[`Table should not display hidden columns 1`] = `
         <td
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           Karlis
         </td>
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           Yurshev
         </td>
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           kyurshev1@spotify.com
         </td>
@@ -106,18 +121,21 @@ exports[`Table should not display hidden columns 1`] = `
         <td
           data-testid="table_row_2_cell_0"
           id="table_row_2_cell_0"
+          role="cell"
         >
           Bordie
         </td>
         <td
           data-testid="table_row_2_cell_1"
           id="table_row_2_cell_1"
+          role="cell"
         >
           Marsy
         </td>
         <td
           data-testid="table_row_2_cell_2"
           id="table_row_2_cell_2"
+          role="cell"
         >
           bmarsy2@elegantthemes.com
         </td>
@@ -127,7 +145,7 @@ exports[`Table should not display hidden columns 1`] = `
 </div>
 `;
 
-exports[`Table should not display primary action column when provided 1`] = `
+exports[`Table should not display primary action column when not provided 1`] = `
 <div>
   <table
     class="av-grid table"
@@ -147,72 +165,96 @@ exports[`Table should not display primary action column when provided 1`] = `
           data-testid="table_header_row_0_cell_0_text"
           id="table_header_row_0_cell_0_text"
           role="columnheader"
-          title="Basic Text"
         >
-          Basic Text
+          <span
+            id="text-th-title"
+          >
+            Basic Text
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_1_currency"
           id="table_header_row_0_cell_1_currency"
           role="columnheader"
-          title="Currency"
         >
-          Currency
+          <span
+            id="currency-th-title"
+          >
+            Currency
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_2_badge"
           id="table_header_row_0_cell_2_badge"
           role="columnheader"
-          title="Badge"
         >
-          Badge
+          <span
+            id="badge-th-title"
+          >
+            Badge
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_3_icon"
           id="table_header_row_0_cell_3_icon"
           role="columnheader"
-          title="Icon"
         >
-          Icon
+          <span
+            id="icon-th-title"
+          >
+            Icon
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_4_icon2"
           id="table_header_row_0_cell_4_icon2"
           role="columnheader"
-          title="icon2"
         >
-          icon2
+          <span
+            id="icon2-th-title"
+          >
+            icon2
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_5_date"
           id="table_header_row_0_cell_5_date"
           role="columnheader"
-          title="Date"
         >
-          Date
+          <span
+            id="date-th-title"
+          >
+            Date
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_6_iconWithTooltip"
           id="table_header_row_0_cell_6_iconWithTooltip"
           role="columnheader"
-          title="Icon With Tooltip"
         >
-          Icon With Tooltip
+          <span
+            id="iconWithTooltip-th-title"
+          >
+            Icon With Tooltip
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_7_actions"
           id="table_header_row_0_cell_7_actions"
           role="columnheader"
-          title="Actions"
         >
-          Actions
+          <span
+            id="actions-th-title"
+          >
+            Actions
+          </span>
         </th>
       </tr>
     </thead>
@@ -228,15 +270,17 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           My Text Field
         </td>
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           <span
-            title="$43.08"
+            id="currency-cell-0-currency"
           >
             $43.08
           </span>
@@ -244,10 +288,10 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           <span
             class="badge badge-badge-success"
-            title="badge field"
           >
             badge field
           </span>
@@ -255,6 +299,7 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_3"
           id="table_row_0_cell_3"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -265,6 +310,7 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_4"
           id="table_row_0_cell_4"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -275,9 +321,10 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_5"
           id="table_row_0_cell_5"
+          role="cell"
         >
           <span
-            title="02/16/1956"
+            id="date-cell-0-date"
           >
             02/16/1956
           </span>
@@ -285,6 +332,7 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_6"
           id="table_row_0_cell_6"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -295,6 +343,7 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_0_cell_7"
           id="table_row_0_cell_7"
+          role="cell"
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
@@ -351,8 +400,8 @@ exports[`Table should not display primary action column when provided 1`] = `
             aria-hidden="true"
             class="icon icon-file-pdf"
             data-testid="table_row_action_menu_item_0_primaryAction"
+            id="table_row_action_menu_item_0_primaryAction"
             style="cursor: pointer;"
-            title="View File"
           />
         </td>
       </tr>
@@ -365,15 +414,17 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           My Text Field
         </td>
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           <span
-            title="$43.08"
+            id="currency-cell-1-currency"
           >
             $43.08
           </span>
@@ -381,10 +432,10 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           <span
             class="badge badge-badge-success"
-            title="badge field"
           >
             badge field
           </span>
@@ -392,21 +443,24 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_1_cell_3"
           id="table_row_1_cell_3"
+          role="cell"
         >
           
         </td>
         <td
           data-testid="table_row_1_cell_4"
           id="table_row_1_cell_4"
+          role="cell"
         >
           
         </td>
         <td
           data-testid="table_row_1_cell_5"
           id="table_row_1_cell_5"
+          role="cell"
         >
           <span
-            title="02/16/1990"
+            id="date-cell-1-date"
           >
             02/16/1990
           </span>
@@ -414,12 +468,14 @@ exports[`Table should not display primary action column when provided 1`] = `
         <td
           data-testid="table_row_1_cell_6"
           id="table_row_1_cell_6"
+          role="cell"
         >
           Not Available
         </td>
         <td
           data-testid="table_row_1_cell_7"
           id="table_row_1_cell_7"
+          role="cell"
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
@@ -490,27 +546,36 @@ exports[`Table should render basic table 1`] = `
           data-testid="table_header_row_0_cell_0_first_name"
           id="table_header_row_0_cell_0_first_name"
           role="columnheader"
-          title="First Name"
         >
-          First Name
+          <span
+            id="first_name-th-title"
+          >
+            First Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_1_last_name"
           id="table_header_row_0_cell_1_last_name"
           role="columnheader"
-          title="Last Name"
         >
-          Last Name
+          <span
+            id="last_name-th-title"
+          >
+            Last Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_2_email"
           id="table_header_row_0_cell_2_email"
           role="columnheader"
-          title="Email"
         >
-          Email
+          <span
+            id="email-th-title"
+          >
+            Email
+          </span>
         </th>
       </tr>
     </thead>
@@ -526,18 +591,21 @@ exports[`Table should render basic table 1`] = `
         <td
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           Barbra
         </td>
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           Tull
         </td>
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           btull0@usatoday.com
         </td>
@@ -551,18 +619,21 @@ exports[`Table should render basic table 1`] = `
         <td
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           Karlis
         </td>
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           Yurshev
         </td>
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           kyurshev1@spotify.com
         </td>
@@ -576,18 +647,21 @@ exports[`Table should render basic table 1`] = `
         <td
           data-testid="table_row_2_cell_0"
           id="table_row_2_cell_0"
+          role="cell"
         >
           Bordie
         </td>
         <td
           data-testid="table_row_2_cell_1"
           id="table_row_2_cell_1"
+          role="cell"
         >
           Marsy
         </td>
         <td
           data-testid="table_row_2_cell_2"
           id="table_row_2_cell_2"
+          role="cell"
         >
           bmarsy2@elegantthemes.com
         </td>
@@ -613,50 +687,62 @@ exports[`Table should render selectable table 1`] = `
         role="row"
       >
         <th
-          class="fixed-width-selection"
           colspan="1"
           data-testid="table_header_row_0_cell_0_selection"
           id="table_header_row_0_cell_0_selection"
           role="columnheader"
         >
-          <div
-            class="text-center"
+          <span
+            id="selection-th-title"
           >
-            <input
-              aria-label="Select all records"
-              data-testid="table_header_select_all"
-              style="cursor: pointer;"
-              title="Toggle All Rows Selected"
-              type="checkbox"
-            />
-          </div>
+            <div
+              class="text-center"
+            >
+              <input
+                aria-label="Select all records"
+                data-testid="table_header_select_all"
+                style="cursor: pointer;"
+                title="Toggle All Rows Selected"
+                type="checkbox"
+              />
+            </div>
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_1_first_name"
           id="table_header_row_0_cell_1_first_name"
           role="columnheader"
-          title="First Name"
         >
-          First Name
+          <span
+            id="first_name-th-title"
+          >
+            First Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_2_last_name"
           id="table_header_row_0_cell_2_last_name"
           role="columnheader"
-          title="Last Name"
         >
-          Last Name
+          <span
+            id="last_name-th-title"
+          >
+            Last Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_3_email"
           id="table_header_row_0_cell_3_email"
           role="columnheader"
-          title="Email"
         >
-          Email
+          <span
+            id="email-th-title"
+          >
+            Email
+          </span>
         </th>
       </tr>
     </thead>
@@ -670,9 +756,9 @@ exports[`Table should render selectable table 1`] = `
         role="row"
       >
         <td
-          class="fixed-width-selection"
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           <div
             class="text-center"
@@ -689,18 +775,21 @@ exports[`Table should render selectable table 1`] = `
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           Barbra
         </td>
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           Tull
         </td>
         <td
           data-testid="table_row_0_cell_3"
           id="table_row_0_cell_3"
+          role="cell"
         >
           btull0@usatoday.com
         </td>
@@ -712,9 +801,9 @@ exports[`Table should render selectable table 1`] = `
         role="row"
       >
         <td
-          class="fixed-width-selection"
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           <div
             class="text-center"
@@ -731,18 +820,21 @@ exports[`Table should render selectable table 1`] = `
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           Karlis
         </td>
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           Yurshev
         </td>
         <td
           data-testid="table_row_1_cell_3"
           id="table_row_1_cell_3"
+          role="cell"
         >
           kyurshev1@spotify.com
         </td>
@@ -754,9 +846,9 @@ exports[`Table should render selectable table 1`] = `
         role="row"
       >
         <td
-          class="fixed-width-selection"
           data-testid="table_row_2_cell_0"
           id="table_row_2_cell_0"
+          role="cell"
         >
           <div
             class="text-center"
@@ -773,18 +865,21 @@ exports[`Table should render selectable table 1`] = `
         <td
           data-testid="table_row_2_cell_1"
           id="table_row_2_cell_1"
+          role="cell"
         >
           Bordie
         </td>
         <td
           data-testid="table_row_2_cell_2"
           id="table_row_2_cell_2"
+          role="cell"
         >
           Marsy
         </td>
         <td
           data-testid="table_row_2_cell_3"
           id="table_row_2_cell_3"
+          role="cell"
         >
           bmarsy2@elegantthemes.com
         </td>
@@ -815,13 +910,16 @@ exports[`Table should render sortable table 1`] = `
           id="table_header_row_0_cell_0_first_name"
           role="columnheader"
           style="cursor: pointer;"
-          title="First Name"
         >
-          First Name
-          <i
-            aria-hidden="true"
-            class="icon icon-sort"
-          />
+          <span
+            id="first_name-th-title"
+          >
+            First Name
+            <i
+              aria-hidden="true"
+              class="icon icon-sort"
+            />
+          </span>
         </th>
         <th
           colspan="1"
@@ -829,13 +927,16 @@ exports[`Table should render sortable table 1`] = `
           id="table_header_row_0_cell_1_last_name"
           role="columnheader"
           style="cursor: pointer;"
-          title="Last Name"
         >
-          Last Name
-          <i
-            aria-hidden="true"
-            class="icon icon-sort"
-          />
+          <span
+            id="last_name-th-title"
+          >
+            Last Name
+            <i
+              aria-hidden="true"
+              class="icon icon-sort"
+            />
+          </span>
         </th>
         <th
           colspan="1"
@@ -843,9 +944,12 @@ exports[`Table should render sortable table 1`] = `
           id="table_header_row_0_cell_2_email"
           role="columnheader"
           style="cursor: pointer;"
-          title="Email"
         >
-          Email
+          <span
+            id="email-th-title"
+          >
+            Email
+          </span>
         </th>
       </tr>
     </thead>
@@ -861,18 +965,21 @@ exports[`Table should render sortable table 1`] = `
         <td
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           Barbra
         </td>
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           Tull
         </td>
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           btull0@usatoday.com
         </td>
@@ -886,18 +993,21 @@ exports[`Table should render sortable table 1`] = `
         <td
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           Karlis
         </td>
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           Yurshev
         </td>
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           kyurshev1@spotify.com
         </td>
@@ -911,18 +1021,21 @@ exports[`Table should render sortable table 1`] = `
         <td
           data-testid="table_row_2_cell_0"
           id="table_row_2_cell_0"
+          role="cell"
         >
           Bordie
         </td>
         <td
           data-testid="table_row_2_cell_1"
           id="table_row_2_cell_1"
+          role="cell"
         >
           Marsy
         </td>
         <td
           data-testid="table_row_2_cell_2"
           id="table_row_2_cell_2"
+          role="cell"
         >
           bmarsy2@elegantthemes.com
         </td>
@@ -953,27 +1066,36 @@ exports[`Table should render with expected ids 1`] = `
           data-testid="my_availity_table_table_header_row_0_cell_0_first_name"
           id="my_availity_table_table_header_row_0_cell_0_first_name"
           role="columnheader"
-          title="First Name"
         >
-          First Name
+          <span
+            id="first_name-th-title"
+          >
+            First Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="my_availity_table_table_header_row_0_cell_1_last_name"
           id="my_availity_table_table_header_row_0_cell_1_last_name"
           role="columnheader"
-          title="Last Name"
         >
-          Last Name
+          <span
+            id="last_name-th-title"
+          >
+            Last Name
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="my_availity_table_table_header_row_0_cell_2_email"
           id="my_availity_table_table_header_row_0_cell_2_email"
           role="columnheader"
-          title="Email"
         >
-          Email
+          <span
+            id="email-th-title"
+          >
+            Email
+          </span>
         </th>
       </tr>
     </thead>
@@ -989,18 +1111,21 @@ exports[`Table should render with expected ids 1`] = `
         <td
           data-testid="my_availity_table_table_row_0_cell_0"
           id="my_availity_table_table_row_0_cell_0"
+          role="cell"
         >
           Barbra
         </td>
         <td
           data-testid="my_availity_table_table_row_0_cell_1"
           id="my_availity_table_table_row_0_cell_1"
+          role="cell"
         >
           Tull
         </td>
         <td
           data-testid="my_availity_table_table_row_0_cell_2"
           id="my_availity_table_table_row_0_cell_2"
+          role="cell"
         >
           btull0@usatoday.com
         </td>
@@ -1014,18 +1139,21 @@ exports[`Table should render with expected ids 1`] = `
         <td
           data-testid="my_availity_table_table_row_1_cell_0"
           id="my_availity_table_table_row_1_cell_0"
+          role="cell"
         >
           Karlis
         </td>
         <td
           data-testid="my_availity_table_table_row_1_cell_1"
           id="my_availity_table_table_row_1_cell_1"
+          role="cell"
         >
           Yurshev
         </td>
         <td
           data-testid="my_availity_table_table_row_1_cell_2"
           id="my_availity_table_table_row_1_cell_2"
+          role="cell"
         >
           kyurshev1@spotify.com
         </td>
@@ -1039,18 +1167,21 @@ exports[`Table should render with expected ids 1`] = `
         <td
           data-testid="my_availity_table_table_row_2_cell_0"
           id="my_availity_table_table_row_2_cell_0"
+          role="cell"
         >
           Bordie
         </td>
         <td
           data-testid="my_availity_table_table_row_2_cell_1"
           id="my_availity_table_table_row_2_cell_1"
+          role="cell"
         >
           Marsy
         </td>
         <td
           data-testid="my_availity_table_table_row_2_cell_2"
           id="my_availity_table_table_row_2_cell_2"
+          role="cell"
         >
           bmarsy2@elegantthemes.com
         </td>
@@ -1080,72 +1211,96 @@ exports[`Table should render with formatted cells 1`] = `
           data-testid="table_header_row_0_cell_0_text"
           id="table_header_row_0_cell_0_text"
           role="columnheader"
-          title="Basic Text"
         >
-          Basic Text
+          <span
+            id="text-th-title"
+          >
+            Basic Text
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_1_currency"
           id="table_header_row_0_cell_1_currency"
           role="columnheader"
-          title="Currency"
         >
-          Currency
+          <span
+            id="currency-th-title"
+          >
+            Currency
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_2_badge"
           id="table_header_row_0_cell_2_badge"
           role="columnheader"
-          title="Badge"
         >
-          Badge
+          <span
+            id="badge-th-title"
+          >
+            Badge
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_3_icon"
           id="table_header_row_0_cell_3_icon"
           role="columnheader"
-          title="Icon"
         >
-          Icon
+          <span
+            id="icon-th-title"
+          >
+            Icon
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_4_icon2"
           id="table_header_row_0_cell_4_icon2"
           role="columnheader"
-          title="icon2"
         >
-          icon2
+          <span
+            id="icon2-th-title"
+          >
+            icon2
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_5_date"
           id="table_header_row_0_cell_5_date"
           role="columnheader"
-          title="Date"
         >
-          Date
+          <span
+            id="date-th-title"
+          >
+            Date
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_6_iconWithTooltip"
           id="table_header_row_0_cell_6_iconWithTooltip"
           role="columnheader"
-          title="Icon With Tooltip"
         >
-          Icon With Tooltip
+          <span
+            id="iconWithTooltip-th-title"
+          >
+            Icon With Tooltip
+          </span>
         </th>
         <th
           colspan="1"
           data-testid="table_header_row_0_cell_7_actions"
           id="table_header_row_0_cell_7_actions"
           role="columnheader"
-          title="Actions"
         >
-          Actions
+          <span
+            id="actions-th-title"
+          >
+            Actions
+          </span>
         </th>
       </tr>
     </thead>
@@ -1161,15 +1316,17 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_0"
           id="table_row_0_cell_0"
+          role="cell"
         >
           My Text Field
         </td>
         <td
           data-testid="table_row_0_cell_1"
           id="table_row_0_cell_1"
+          role="cell"
         >
           <span
-            title="$43.08"
+            id="currency-cell-0-currency"
           >
             $43.08
           </span>
@@ -1177,10 +1334,10 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_2"
           id="table_row_0_cell_2"
+          role="cell"
         >
           <span
             class="badge badge-badge-success"
-            title="badge field"
           >
             badge field
           </span>
@@ -1188,6 +1345,7 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_3"
           id="table_row_0_cell_3"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -1198,6 +1356,7 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_4"
           id="table_row_0_cell_4"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -1208,9 +1367,10 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_5"
           id="table_row_0_cell_5"
+          role="cell"
         >
           <span
-            title="02/16/1956"
+            id="date-cell-0-date"
           >
             02/16/1956
           </span>
@@ -1218,6 +1378,7 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_6"
           id="table_row_0_cell_6"
+          role="cell"
         >
           <i
             aria-hidden="true"
@@ -1228,6 +1389,7 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_0_cell_7"
           id="table_row_0_cell_7"
+          role="cell"
         >
           <div
             class="dropdown-action-menu dropleft dropdown"
@@ -1284,8 +1446,8 @@ exports[`Table should render with formatted cells 1`] = `
             aria-hidden="true"
             class="icon icon-file-pdf"
             data-testid="table_row_action_menu_item_0_primaryAction"
+            id="table_row_action_menu_item_0_primaryAction"
             style="cursor: pointer;"
-            title="View File"
           />
         </td>
       </tr>
@@ -1298,15 +1460,17 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_1_cell_0"
           id="table_row_1_cell_0"
+          role="cell"
         >
           My Text Field
         </td>
         <td
           data-testid="table_row_1_cell_1"
           id="table_row_1_cell_1"
+          role="cell"
         >
           <span
-            title="$43.08"
+            id="currency-cell-1-currency"
           >
             $43.08
           </span>
@@ -1314,10 +1478,10 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_1_cell_2"
           id="table_row_1_cell_2"
+          role="cell"
         >
           <span
             class="badge badge-badge-success"
-            title="badge field"
           >
             badge field
           </span>
@@ -1325,21 +1489,24 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_1_cell_3"
           id="table_row_1_cell_3"
+          role="cell"
         >
           
         </td>
         <td
           data-testid="table_row_1_cell_4"
           id="table_row_1_cell_4"
+          role="cell"
         >
           
         </td>
         <td
           data-testid="table_row_1_cell_5"
           id="table_row_1_cell_5"
+          role="cell"
         >
           <span
-            title="02/16/1990"
+            id="date-cell-1-date"
           >
             02/16/1990
           </span>
@@ -1347,12 +1514,14 @@ exports[`Table should render with formatted cells 1`] = `
         <td
           data-testid="table_row_1_cell_6"
           id="table_row_1_cell_6"
+          role="cell"
         >
           Not Available
         </td>
         <td
           data-testid="table_row_1_cell_7"
           id="table_row_1_cell_7"
+          role="cell"
         >
           <div
             class="dropdown-action-menu dropleft dropdown"

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -345,61 +345,32 @@ exports[`Table should not display primary action column when not provided 1`] = 
           id="table_row_0_cell_7"
           role="cell"
         >
-          <div
-            class="dropdown-action-menu dropleft dropdown"
-            data-testid="table_row_action_menu_0_dropdown"
-            id="table_row_action_menu_0"
-          >
+          <div>
             <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Action Menu"
-              class="btn btn-ghost btn btn-secondary"
-              data-boundary="viewport"
-              data-testid="table_row_action_menu_0_dropdown_toggle"
-              id="table_row_action_menu_0_dropdown_toggle"
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_0_action_action1"
+              id="table_row_action_menu_item_0_action_action1"
+              role="menuitem"
+              tabindex="0"
               type="button"
             >
-              <i
-                aria-hidden="true"
-                class="icon icon-menu"
-                id="table_row_action_menu_0_dropdown_toggle_icon"
-              />
+              Action 1
             </button>
             <div
-              aria-hidden="true"
-              class="dropdown-action-menu dropdown-menu"
-              data-testid="table_row_action_menu_0_dropdown_menu"
-              id="table_row_action_menu_0_dropdown_menu"
-              role="menu"
+              class="dropdown-divider"
+              id="table_row_action_menu_item_0_action_actionDivider"
               tabindex="-1"
+            />
+            <button
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_0_action_action2"
+              id="table_row_action_menu_item_0_action_action2"
+              role="menuitem"
+              tabindex="0"
+              type="button"
             >
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_0_action_action1"
-                id="table_row_action_menu_item_0_action_action1"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 1
-              </button>
-              <div
-                class="dropdown-divider"
-                id="table_row_action_menu_item_0_action_actionDivider"
-                tabindex="-1"
-              />
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_0_action_action2"
-                id="table_row_action_menu_item_0_action_action2"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 2
-              </button>
-            </div>
+              Action 2
+            </button>
           </div>
           <i
             aria-hidden="true"
@@ -482,51 +453,22 @@ exports[`Table should not display primary action column when not provided 1`] = 
           id="table_row_1_cell_7"
           role="cell"
         >
-          <div
-            class="dropdown-action-menu dropleft dropdown"
-            data-testid="table_row_action_menu_1_dropdown"
-            id="table_row_action_menu_1"
-          >
+          <div>
+            <div
+              class="dropdown-divider"
+              id="table_row_action_menu_item_1_action_actionDivider"
+              tabindex="-1"
+            />
             <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Action Menu"
-              class="btn btn-ghost btn btn-secondary"
-              data-boundary="viewport"
-              data-testid="table_row_action_menu_1_dropdown_toggle"
-              id="table_row_action_menu_1_dropdown_toggle"
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_1_action_action2"
+              id="table_row_action_menu_item_1_action_action2"
+              role="menuitem"
+              tabindex="0"
               type="button"
             >
-              <i
-                aria-hidden="true"
-                class="icon icon-menu"
-                id="table_row_action_menu_1_dropdown_toggle_icon"
-              />
+              Action 2
             </button>
-            <div
-              aria-hidden="true"
-              class="dropdown-action-menu dropdown-menu"
-              data-testid="table_row_action_menu_1_dropdown_menu"
-              id="table_row_action_menu_1_dropdown_menu"
-              role="menu"
-              tabindex="-1"
-            >
-              <div
-                class="dropdown-divider"
-                id="table_row_action_menu_item_1_action_actionDivider"
-                tabindex="-1"
-              />
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_1_action_action2"
-                id="table_row_action_menu_item_1_action_action2"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 2
-              </button>
-            </div>
           </div>
         </td>
       </tr>
@@ -1400,61 +1342,32 @@ exports[`Table should render with formatted cells 1`] = `
           id="table_row_0_cell_7"
           role="cell"
         >
-          <div
-            class="dropdown-action-menu dropleft dropdown"
-            data-testid="table_row_action_menu_0_dropdown"
-            id="table_row_action_menu_0"
-          >
+          <div>
             <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Action Menu"
-              class="btn btn-ghost btn btn-secondary"
-              data-boundary="viewport"
-              data-testid="table_row_action_menu_0_dropdown_toggle"
-              id="table_row_action_menu_0_dropdown_toggle"
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_0_action_action1"
+              id="table_row_action_menu_item_0_action_action1"
+              role="menuitem"
+              tabindex="0"
               type="button"
             >
-              <i
-                aria-hidden="true"
-                class="icon icon-menu"
-                id="table_row_action_menu_0_dropdown_toggle_icon"
-              />
+              Action 1
             </button>
             <div
-              aria-hidden="true"
-              class="dropdown-action-menu dropdown-menu"
-              data-testid="table_row_action_menu_0_dropdown_menu"
-              id="table_row_action_menu_0_dropdown_menu"
-              role="menu"
+              class="dropdown-divider"
+              id="table_row_action_menu_item_0_action_actionDivider"
               tabindex="-1"
+            />
+            <button
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_0_action_action2"
+              id="table_row_action_menu_item_0_action_action2"
+              role="menuitem"
+              tabindex="0"
+              type="button"
             >
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_0_action_action1"
-                id="table_row_action_menu_item_0_action_action1"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 1
-              </button>
-              <div
-                class="dropdown-divider"
-                id="table_row_action_menu_item_0_action_actionDivider"
-                tabindex="-1"
-              />
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_0_action_action2"
-                id="table_row_action_menu_item_0_action_action2"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 2
-              </button>
-            </div>
+              Action 2
+            </button>
           </div>
           <i
             aria-hidden="true"
@@ -1537,51 +1450,22 @@ exports[`Table should render with formatted cells 1`] = `
           id="table_row_1_cell_7"
           role="cell"
         >
-          <div
-            class="dropdown-action-menu dropleft dropdown"
-            data-testid="table_row_action_menu_1_dropdown"
-            id="table_row_action_menu_1"
-          >
+          <div>
+            <div
+              class="dropdown-divider"
+              id="table_row_action_menu_item_1_action_actionDivider"
+              tabindex="-1"
+            />
             <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Action Menu"
-              class="btn btn-ghost btn btn-secondary"
-              data-boundary="viewport"
-              data-testid="table_row_action_menu_1_dropdown_toggle"
-              id="table_row_action_menu_1_dropdown_toggle"
+              class="dropdown-item"
+              data-testid="table_row_action_menu_item_1_action_action2"
+              id="table_row_action_menu_item_1_action_action2"
+              role="menuitem"
+              tabindex="0"
               type="button"
             >
-              <i
-                aria-hidden="true"
-                class="icon icon-menu"
-                id="table_row_action_menu_1_dropdown_toggle_icon"
-              />
+              Action 2
             </button>
-            <div
-              aria-hidden="true"
-              class="dropdown-action-menu dropdown-menu"
-              data-testid="table_row_action_menu_1_dropdown_menu"
-              id="table_row_action_menu_1_dropdown_menu"
-              role="menu"
-              tabindex="-1"
-            >
-              <div
-                class="dropdown-divider"
-                id="table_row_action_menu_item_1_action_actionDivider"
-                tabindex="-1"
-              />
-              <button
-                class="dropdown-item"
-                data-testid="table_row_action_menu_item_1_action_action2"
-                id="table_row_action_menu_item_1_action_action2"
-                role="menuitem"
-                tabindex="0"
-                type="button"
-              >
-                Action 2
-              </button>
-            </div>
           </div>
         </td>
       </tr>

--- a/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/src/tests/__snapshots__/Table.test.tsx.snap
@@ -356,6 +356,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
               aria-label="Action Menu"
               class="btn btn-ghost btn btn-secondary"
               data-boundary="viewport"
+              data-testid="table_row_action_menu_0_dropdown_toggle"
               id="table_row_action_menu_0_dropdown_toggle"
               type="button"
             >
@@ -368,6 +369,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
             <div
               aria-hidden="true"
               class="dropdown-action-menu dropdown-menu"
+              data-testid="table_row_action_menu_0_dropdown_menu"
               id="table_row_action_menu_0_dropdown_menu"
               role="menu"
               tabindex="-1"
@@ -491,6 +493,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
               aria-label="Action Menu"
               class="btn btn-ghost btn btn-secondary"
               data-boundary="viewport"
+              data-testid="table_row_action_menu_1_dropdown_toggle"
               id="table_row_action_menu_1_dropdown_toggle"
               type="button"
             >
@@ -503,6 +506,7 @@ exports[`Table should not display primary action column when not provided 1`] = 
             <div
               aria-hidden="true"
               class="dropdown-action-menu dropdown-menu"
+              data-testid="table_row_action_menu_1_dropdown_menu"
               id="table_row_action_menu_1_dropdown_menu"
               role="menu"
               tabindex="-1"
@@ -1407,6 +1411,7 @@ exports[`Table should render with formatted cells 1`] = `
               aria-label="Action Menu"
               class="btn btn-ghost btn btn-secondary"
               data-boundary="viewport"
+              data-testid="table_row_action_menu_0_dropdown_toggle"
               id="table_row_action_menu_0_dropdown_toggle"
               type="button"
             >
@@ -1419,6 +1424,7 @@ exports[`Table should render with formatted cells 1`] = `
             <div
               aria-hidden="true"
               class="dropdown-action-menu dropdown-menu"
+              data-testid="table_row_action_menu_0_dropdown_menu"
               id="table_row_action_menu_0_dropdown_menu"
               role="menu"
               tabindex="-1"
@@ -1542,6 +1548,7 @@ exports[`Table should render with formatted cells 1`] = `
               aria-label="Action Menu"
               class="btn btn-ghost btn btn-secondary"
               data-boundary="viewport"
+              data-testid="table_row_action_menu_1_dropdown_toggle"
               id="table_row_action_menu_1_dropdown_toggle"
               type="button"
             >
@@ -1554,6 +1561,7 @@ exports[`Table should render with formatted cells 1`] = `
             <div
               aria-hidden="true"
               class="dropdown-action-menu dropdown-menu"
+              data-testid="table_row_action_menu_1_dropdown_menu"
               id="table_row_action_menu_1_dropdown_menu"
               role="menu"
               tabindex="-1"

--- a/packages/table/src/types/BulkRecordAction.ts
+++ b/packages/table/src/types/BulkRecordAction.ts
@@ -1,3 +1,4 @@
+import { DropdownItemProps } from 'reactstrap';
 import { TableAction } from './TableAction';
 
 export interface BulkRecordAction<T> extends TableAction {
@@ -8,4 +9,5 @@ export interface BulkRecordAction<T> extends TableAction {
     | React.ReactChild
     | React.ElementType
     | ((records?: T[]) => string | React.ReactChild | React.ElementType);
+  dropdownItemProps?: DropdownItemProps;
 }

--- a/packages/table/src/types/BulkRecordAction.ts
+++ b/packages/table/src/types/BulkRecordAction.ts
@@ -3,4 +3,9 @@ import { TableAction } from './TableAction';
 export interface BulkRecordAction<T> extends TableAction {
   onClick?: (records?: T[]) => void;
   isVisible?: (records?: T[]) => boolean;
+  displayText?:
+    | string
+    | React.ReactChild
+    | React.ElementType
+    | ((records?: T[]) => string | React.ReactChild | React.ElementType);
 }

--- a/packages/table/src/types/BulkRecordAction.ts
+++ b/packages/table/src/types/BulkRecordAction.ts
@@ -1,13 +1,14 @@
 import { DropdownItemProps } from 'reactstrap';
+import { IdType, Row } from './ReactTable';
 import { TableAction } from './TableAction';
 
-export interface BulkRecordAction<T> extends TableAction {
-  onClick?: (records?: T[]) => void;
-  isVisible?: (records?: T[]) => boolean;
+export interface BulkRecordAction<T extends IdType> extends TableAction {
+  onClick?: (records?: T[], rows?: Row<T>[]) => void;
+  isVisible?: (records?: T[], rows?: Row<T>[]) => boolean;
   displayText?:
     | string
     | React.ReactChild
     | React.ElementType
-    | ((records?: T[]) => string | React.ReactChild | React.ElementType);
+    | ((records: T[], rows?: Row<T>[]) => string | React.ReactChild | React.ElementType);
   dropdownItemProps?: DropdownItemProps;
 }

--- a/packages/table/src/types/PrimaryRecordAction.ts
+++ b/packages/table/src/types/PrimaryRecordAction.ts
@@ -1,6 +1,6 @@
 export interface PrimaryRecordAction<T> {
-  iconName: string;
-  title: string;
+  iconName: string | ((record?: T) => string);
+  title: string | ((record?: T) => string);
   onClick: (record?: T) => void;
   isVisible?: (record?: T) => boolean;
 }

--- a/packages/table/src/types/ReactTable.ts
+++ b/packages/table/src/types/ReactTable.ts
@@ -17,6 +17,7 @@ import {
   UsePaginationInstanceProps,
   UseColumnOrderInstanceProps,
   UseRowSelectState,
+  UseExpandedRowProps,
 } from 'react-table';
 
 import { TableSort } from './TableSort';
@@ -24,11 +25,13 @@ import { TableSort } from './TableSort';
 /* eslint-disable-next-line  @typescript-eslint/ban-types */
 export type IdType = { id?: string | number } & object;
 
-export type Row<T extends IdType> = RtRow<T> & {
-  toggleRowSelected: () => void;
-  getToggleRowSelectedProps: () => void;
-  original: T;
-};
+export type Row<T extends IdType> = RtRow<T> &
+  UseExpandedRowProps<T> & {
+    toggleRowSelected: () => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getToggleRowSelectedProps: () => any;
+    original: T;
+  };
 
 export type RowProps = {
   isDisabled?: boolean;

--- a/packages/table/src/types/ReactTable.ts
+++ b/packages/table/src/types/ReactTable.ts
@@ -53,6 +53,7 @@ export type Cell<T extends IdType, V = any> = RtCell<T, V> & {
   row: Row<T>;
   column: Column<T>;
   original: T;
+  data: T[];
 };
 
 export type ExtendedTableHeader<T extends IdType> = HeaderGroup<T> &

--- a/packages/table/src/types/ReactTable.ts
+++ b/packages/table/src/types/ReactTable.ts
@@ -18,6 +18,7 @@ import {
   UseColumnOrderInstanceProps,
   UseRowSelectState,
   UseExpandedRowProps,
+  UseExpandedInstanceProps,
 } from 'react-table';
 
 import { TableSort } from './TableSort';
@@ -84,6 +85,7 @@ export type TableInstance<T extends IdType> = UseSortByInstanceProps<T> &
   UseRowSelectInstanceProps<T> &
   UseRowSelectOptions<T> &
   RtTableInstance<T> &
+  UseExpandedInstanceProps<T> &
   UseColumnOrderInstanceProps<T> &
   UsePaginationInstanceProps<T> & {
     toggleAllPageRowsSelected: (set?: boolean) => void;

--- a/packages/table/src/types/RecordAction.ts
+++ b/packages/table/src/types/RecordAction.ts
@@ -3,4 +3,9 @@ import { TableAction } from './TableAction';
 export interface RecordAction<T> extends TableAction {
   onClick?: (record?: T) => void;
   isVisible?: (record?: T) => boolean;
+  displayText?:
+    | string
+    | React.ReactChild
+    | React.ElementType
+    | ((record?: T) => string | React.ReactChild | React.ElementType);
 }

--- a/packages/table/src/types/TableAction.ts
+++ b/packages/table/src/types/TableAction.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export interface TableAction {
   id: string;
   divider?: boolean;

--- a/packages/table/src/types/TableAction.ts
+++ b/packages/table/src/types/TableAction.ts
@@ -2,6 +2,5 @@ import React from 'react';
 
 export interface TableAction {
   id: string;
-  displayText?: string | React.ReactChild | React.ElementType;
   divider?: boolean;
 }

--- a/packages/table/styles.scss
+++ b/packages/table/styles.scss
@@ -213,8 +213,6 @@ table.av-grid .av-grid-row-header {
 
 table.av-grid > tbody,
 thead > tr {
-  height: $av-table-header-height;
-
   th,
   td.fixed-width-text {
     white-space: nowrap;

--- a/packages/table/tsconfig.spec.json
+++ b/packages/table/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node", "@testing-library/jest-dom"]
+    "types": ["jest", "no,de", "@testing-library/jest-dom"],
+    "allowJs": true
   },
   "include": ["**/*.test.js", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]
 }

--- a/packages/table/tsconfig.spec.json
+++ b/packages/table/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "no,de", "@testing-library/jest-dom"],
+    "types": ["jest", "node", "@testing-library/jest-dom"],
     "allowJs": true
   },
   "include": ["**/*.test.js", "**/*.test.ts", "**/*.test.tsx", "**/*.d.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@availity/table@workspace:packages/table"
   dependencies:
+    "@availity/hooks": "workspace:*"
     "@availity/icon": "workspace:*"
     "@types/react-table": ^7.7.12
     classnames: ^2.3.1


### PR DESCRIPTION
This bundles a few sprints of work with some stylistic updates and functional updates for the table.
- Add more flexibility for BulkActionMenu to pass in ButtonProps, DropdownToggleProps, etc to allow the implementation to have  more flexibility to customize basic Reactstrap props of the action menu
- Action Menu: Allow for display text for both the primary action and the record actions to be conditionally populated by the data in the row. 
- Action Menu - fix issue where action menu was getting cut off in a scrollable container (allow passing in of the 'container' prop to approprately set target) and 'isSticky' so that the menu stays in the same position even when scrolling.
- Add ability to apply a table ref so that parent components can have access to the tableInstance and properties and functions on the tableInstance
- Adjust titles to be Bootstrap Tooltips
- Add DefaultValueCell
- Add support for footers

We have had this tested out in our applications in alpha version, just need get this committed and push to master.