### PR TITLE
feat/tree: fix alignment of Select All Text

### DIFF
--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.3.1-alpha.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.3.0...@availity/tree@0.3.1-alpha.0) (2023-03-06)
+
+
+### Features
+
+* **table:** fix alignment of select all link to be right aligned to the right of the expand all text ([6daef1b](https://github.com/Availity/availity-react/commit/6daef1b060c8fe65d16eed87128a67d89213ebcb))
+
+
+
 # [0.3.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.2.2...@availity/tree@0.3.0) (2023-02-15)
 
 

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.0",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/src/Tree.tsx
+++ b/packages/tree/src/Tree.tsx
@@ -337,21 +337,35 @@ const Tree = ({
         )}
 
         {isRoot && (
-          <div className="form-group mb-1">
-            <Button
-              data-testid="btn-expand-all"
-              id="btnExpandAll"
-              color="link"
-              className="p-0"
-              onClick={toggleExpandAll}
-            >
-              {rootExpandAllText}
-            </Button>
+          <div className="d-flex justify-content-between">
+            <Col xs="auto" className="pl-0">
+              <Button
+                data-testid="btn-expand-all"
+                id="btnExpandAll"
+                color="link"
+                className="p-0"
+                onClick={toggleExpandAll}
+              >
+                {rootExpandAllText}
+              </Button>
+            </Col>
+            {selectable && (
+              <Col xs="auto" className="pr-0">
+                <Button
+                  data-testid="btn-select-all"
+                  color="link"
+                  className="pb-0 pt-0"
+                  onClick={() => toggleSelectAll()}
+                >
+                  {rootSelectText}
+                </Button>
+              </Col>
+            )}
           </div>
         )}
 
         <ul>
-          {treeItems.map((item, index) => (
+          {treeItems.map((item) => (
             <li data-testid={`tree-view-item-${item.id}`} key={`tree-view-item-${item.id}`}>
               {!item.isHidden && (
                 <div>
@@ -382,16 +396,6 @@ const Tree = ({
                     {item.children && item.children.length > 0 && (
                       <Col sm="5">
                         <div className="form-inline d-flex justify-content-end ml-auto align-items-center">
-                          {isRoot && index === 0 && selectable && (
-                            <Button
-                              data-testid="btn-select-all"
-                              color="link"
-                              className="pb-0 pt-0"
-                              onClick={() => toggleSelectAll()}
-                            >
-                              {rootSelectText}
-                            </Button>
-                          )}
                           {selectable && (
                             <FormGroup check>
                               <Input


### PR DESCRIPTION
This change encompasses a small design review tweak. Instead of having the 'Select All' text aligned with the first list item, have it on the same line as the 'Expand All' text. (this was how it was on the angular component and we just made it the same for the React component but it creates some odd behavior).

They blocked the ability on my machine to copy/paste images here...I would provide them if I could :( 