### PR TITLE
Feat/select - Make Clear Button More Configurable

### DIFF
--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -128,9 +128,9 @@ Class names to add to clear button (only available when `isMulti` or `isClearabl
 
 Text that should be displayed in the clear button (only available when `isMulti` or `isClearable`). **Default:** `clear`
 
-#### `disableClearButtonWhenNoValue?: boolean`
+#### `clearButtonProps?: ButtonProps`
 
-Disable the clear button if no value is populated (only available when `isMulti` or `isClearable`). **Default:** `false`
+Additional properties that should be set on the clear button (only available when `isMulti` or `isClearable`).
 
 ### `waitUntilFocused?: boolean`
 

--- a/docusaurus/docs/form/select/components/select.md
+++ b/docusaurus/docs/form/select/components/select.md
@@ -124,6 +124,14 @@ Adds a `Select all` option ( when `isMulti` is `true`). Note: `allowSelectAll` i
 
 Class names to add to clear button (only available when `isMulti` or `isClearable`). **Default:** `btn btn-link link`
 
+#### `clearButtonText?: string`
+
+Text that should be displayed in the clear button (only available when `isMulti` or `isClearable`). **Default:** `clear`
+
+#### `disableClearButtonWhenNoValue?: boolean`
+
+Disable the clear button if no value is populated (only available when `isMulti` or `isClearable`). **Default:** `false`
+
 ### `waitUntilFocused?: boolean`
 
 When true, the network request is not made until the dropdown has been focused. Defaults to `false`.

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [3.4.2-alpha.0](https://github.com/Availity/availity-react/compare/@availity/select@3.4.1...@availity/select@3.4.2-alpha.0) (2023-04-10)
+
+
+### Features
+
+* **select:** add ability to configure clear button text and not have it hard-coded with a lower case c, as well as other select props ([8ca554a](https://github.com/Availity/availity-react/commit/8ca554a4bbc76600491bb57f89287efaf19450f1))
+
+
+
 ## [3.4.1](https://github.com/Availity/availity-react/compare/@availity/select@3.4.0...@availity/select@3.4.1) (2023-02-14)
 
 

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/select",
-  "version": "3.4.1",
+  "version": "3.4.2-alpha.0",
   "description": "Wrapper for react-select to work with formik",
   "keywords": [
     "availity",

--- a/packages/select/src/Select.d.ts
+++ b/packages/select/src/Select.d.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { Props as RSelectProps, GroupBase, StylesConfig, ThemeConfig } from 'react-select';
 import type { AsyncPaginateProps } from 'react-select-async-paginate';
 import type { FieldValidator } from 'formik';
+import { ButtonProps } from 'reactstrap';
 
 export interface SelectStyleArgs {
   showError?: boolean;
@@ -20,7 +21,9 @@ export type SelectProps<Option, IsMulti extends boolean, Group extends GroupBase
   autofill?: boolean | Record<string, string | ((value: any) => any)>;
   cacheUniq?: any | any[];
   clearButtonClassName?: string;
+  clearButtonText?: string;
   creatable?: boolean;
+  clearButtonProps?: ButtonProps;
   feedback?: boolean;
   helpMessage?: ReactNode;
   labelKey?: string;

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -189,6 +189,8 @@ const Select = ({
   components: componentOverrides,
   required,
   clearButtonClassName,
+  clearButtonText = 'clear',
+  clearButtonProps = {},
   ...attributes
 }) => {
   const [{ onChange, value: fieldValue, ...field }, { touched, error: fieldError }] = useField({
@@ -445,8 +447,9 @@ const Select = ({
             attributes['aria-label'] || name.replace(/[\W_]+/g, ' ').replace(/[A-Z]/g, ' $&') || ''
           }`}
           onClick={() => onChangeHandler(attributes.isMulti ? [] : null)}
+          {...clearButtonProps}
         >
-          clear
+          {clearButtonText}
         </button>
       ) : null}
     </div>
@@ -500,6 +503,10 @@ Select.propTypes = {
   required: PropTypes.bool,
   /** Class names to add to clear button (only available when isMulti or isClearable). Default: btn btn-link link */
   clearButtonClassName: PropTypes.string,
+  /** Text that should be displayed in the clear button (only available when isMulti or isClearable). Default: clear */
+  clearButtonText: PropTypes.string,
+  /** Additional properties other that should be set on the clear button (only available when isMulti or isClearable). */
+  clearButtonProps: PropTypes.object,
 };
 
 components.Option.propTypes = {

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -447,6 +447,7 @@ const Select = ({
             attributes['aria-label'] || name.replace(/[\W_]+/g, ' ').replace(/[A-Z]/g, ' $&') || ''
           }`}
           onClick={() => onChangeHandler(attributes.isMulti ? [] : null)}
+          disabled={!fieldValue || (Array.isArray(fieldValue) && fieldValue.length === 0)}
           {...clearButtonProps}
         >
           {clearButtonText}

--- a/packages/select/src/Select.js
+++ b/packages/select/src/Select.js
@@ -505,7 +505,7 @@ Select.propTypes = {
   clearButtonClassName: PropTypes.string,
   /** Text that should be displayed in the clear button (only available when isMulti or isClearable). Default: clear */
   clearButtonText: PropTypes.string,
-  /** Additional properties other that should be set on the clear button (only available when isMulti or isClearable). */
+  /** Additional properties that should be set on the clear button (only available when isMulti or isClearable). */
   clearButtonProps: PropTypes.object,
 };
 

--- a/packages/select/stories/select.stories.tsx
+++ b/packages/select/stories/select.stories.tsx
@@ -31,6 +31,8 @@ export default {
     max: 3,
     raw: false,
     required: true,
+    clearButtonText: 'clear',
+    clearButtonProps: {},
   },
 } as Meta;
 
@@ -45,6 +47,8 @@ export const Default: Story = ({
   min,
   raw,
   required,
+  clearButtonText,
+  clearButtonProps,
 }) => (
   <FormikResults
     onSubmit={() => {
@@ -78,6 +82,8 @@ export const Default: Story = ({
               options={autofillOptions}
               raw={raw}
               required={required}
+              clearButtonText={clearButtonText}
+              clearButtonProps={clearButtonProps}
             />
             <Field name="autoFill1" type="text" label="Autofill Value 1" />
             <Field name="autoFill2" type="text" label="Autofill Value 2" />
@@ -95,6 +101,8 @@ export const Default: Story = ({
             options={options}
             raw={raw}
             required={required}
+            clearButtonText={clearButtonText}
+            clearButtonProps={clearButtonProps}
           />
         )}
         <Button className="mt-3" color="primary" type="submit">
@@ -121,6 +129,8 @@ export const _SelectField: Story = ({
   min,
   raw,
   required,
+  clearButtonText,
+  clearButtonProps,
 }) => (
   <FormikResults
     onSubmit={() => {
@@ -155,6 +165,8 @@ export const _SelectField: Story = ({
               options={autofillOptions}
               raw={raw}
               required={required}
+              clearButtonText={clearButtonText}
+              clearButtonProps={clearButtonProps}
             />
             <Field name="autoFill1" type="text" label="Autofill Value 1" />
             <Field name="autoFill2" type="text" label="Autofill Value 2" />
@@ -173,6 +185,8 @@ export const _SelectField: Story = ({
             options={options}
             raw={raw}
             required={required}
+            clearButtonText={clearButtonText}
+            clearButtonProps={clearButtonProps}
           />
         )}
         <Button color="primary" type="submit">

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -857,4 +857,69 @@ describe('Select', () => {
       expect(getByText('Foo')).toBeDefined();
     });
   });
+
+  test('when isClearable should display the clear button', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select name="singleSelect" options={options} data-testid="single-select" isClearable />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const clearButton = await waitFor(() => getByText('clear'));
+    expect(clearButton).toBeDefined();
+  });
+
+  test('when isClearable should display clear button with custom `clear` text when provided', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDefined();
+  });
+
+  test('when isClearable should set clearButtonProps', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+          clearButtonProps={{ disabled: true }}
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDisabled();
+  });
 });

--- a/packages/select/tests/Select.test.js
+++ b/packages/select/tests/Select.test.js
@@ -922,4 +922,220 @@ describe('Select', () => {
     const clearButton = await waitFor(() => getByText('Clear!'));
     expect(clearButton).toBeDisabled();
   });
+
+  test('when isClearable and has no value should disable the clear button', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDisabled();
+  });
+
+  test('when isClearable and isMulti and has no value should disable the clear button', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          isMulti
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDisabled();
+  });
+
+  test('when isClearable and has value should enable the clear button', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: options[0],
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).not.toBeDisabled();
+  });
+
+  test('when isClearable and isMulti and has value should enable the clear button', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: options[0],
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          isMulti
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).not.toBeDisabled();
+  });
+
+  test('when isClearable and has no value should enable the clear button after selecting value', async () => {
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDisabled();
+
+    await selectItem(container, getByText, 'Option 1');
+
+    await waitFor(() => {
+      expect(clearButton).not.toBeDisabled();
+    });
+  });
+
+  test('when isClearable and isMulti and has no value should enable the clear button after selecting value', async () => {
+    const { container, getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: undefined,
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          isMulti
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).toBeDisabled();
+
+    await selectItem(container, getByText, 'Option 1');
+
+    await waitFor(() => {
+      expect(clearButton).not.toBeDisabled();
+    });
+  });
+
+  test('when isClearable and has value should disable the clear button after clearing the value', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: options[0],
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).not.toBeDisabled();
+
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(clearButton).toBeDisabled();
+    });
+  });
+
+  test('when isClearable and isMulti and has value should disable the clear button after clearing the value', async () => {
+    const { getByText } = render(
+      <Form
+        initialValues={{
+          singleSelect: options[0],
+        }}
+        onSubmit={() => {}}
+        validationSchema={singleValueSchema('singleSelect')}
+      >
+        <Select
+          name="singleSelect"
+          options={options}
+          isMulti
+          data-testid="single-select"
+          isClearable
+          clearButtonText="Clear!"
+        />
+        <Button type="submit">Submit</Button>
+      </Form>
+    );
+
+    const clearButton = await waitFor(() => getByText('Clear!'));
+    expect(clearButton).not.toBeDisabled();
+
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(clearButton).toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
Ever since the Select components were updated to hard code the text 'clear' we have been asked my product and users to change this to be 'Clear' to make it more consistent with other buttons. 

With this change we can leave it default to be 'clear' to avoid impact on other areas where this might be expected, but allows us to customize the text. In addition we have a requirement to disable the button whenever there is no option selected, and that is facilitated by the addition of the `clearButtonProps`. 

Again, this just allows us to have more control over the Clear button other than just the 'class' of the button.
