### PR TITLE
fix(tree) - Refactor out Recursive Tree Item into it's own component to resolve data issues

### DIFF
--- a/docusaurus/docs/components/tree.mdx
+++ b/docusaurus/docs/components/tree.mdx
@@ -89,7 +89,7 @@ Defaults to false. When true, the tree view will be entirely expanded on initial
 
 #### `displayDisabledItems?: boolean`
 
-Defaults to true. When true, disabled items will be hidden in the tree..
+Defaults to true. When true, disabled items will be hidden in the tree.
 
 #### `onItemsSelected?: (selectedIds: TreeItem[]) => void`
 

--- a/docusaurus/docs/components/tree.mdx
+++ b/docusaurus/docs/components/tree.mdx
@@ -87,9 +87,17 @@ The label that displays above the text box.
 
 Defaults to false. When true, the tree view will be entirely expanded on initial load.
 
+#### `displayDisabledItems?: boolean`
+
+Defaults to true. When true, disabled items will be hidden in the tree..
+
 #### `onItemsSelected?: (selectedIds: TreeItem[]) => void`
 
 Whenever an item is selected in the tree, it fires this event to let the parent know of the items that are selected.
+
+#### `onItemsExpanded?: (expandedItems: TreeItem[]) => void`
+
+Whenever an item is expanded in the tree, it fires this event.
 
 ### Functions
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.0...@availity/tree@0.4.1-alpha.0) (2023-04-18)
+
+
+### Features
+
+* **tree:** prevent item from being selected when hidden or disabled, add option to hide disabled items, misc bug fixes with searching and selecting ([b9ea327](https://github.com/Availity/availity-react/commit/b9ea3272cd4529a4df7a62a2e48581289a2f3d6a))
+
+
+
 # [0.4.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.3.0...@availity/tree@0.4.0) (2023-03-17)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.3](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.2...@availity/tree@0.4.1-alpha.3) (2023-04-19)
+
+
+### Bug Fixes
+
+* **tree:** fix overall select and collapse behavior when filtering ([d3869df](https://github.com/Availity/availity-react/commit/d3869df78780986b8b4065bf9b446ae94580aa2d))
+
+
+
 ## [0.4.1-alpha.2](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.1...@availity/tree@0.4.1-alpha.2) (2023-04-19)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.5](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.4...@availity/tree@0.4.1-alpha.5) (2023-04-25)
+
+
+### Bug Fixes
+
+* **tree:** add and fix test, documenation ([7236bb3](https://github.com/Availity/availity-react/commit/7236bb32e7abd2985a8b225925140531b9b4c049))
+
+
+
 ## [0.4.1-alpha.4](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.3...@availity/tree@0.4.1-alpha.4) (2023-04-21)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.4](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.3...@availity/tree@0.4.1-alpha.4) (2023-04-21)
+
+
+### Bug Fixes
+
+* **tree:** refactor to fix overall data and state change issues ([eca7fd1](https://github.com/Availity/availity-react/commit/eca7fd1ba039845a58fc7b929e31c465d9a635b2))
+
+
+
 ## [0.4.1-alpha.3](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.2...@availity/tree@0.4.1-alpha.3) (2023-04-19)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.1](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.0...@availity/tree@0.4.1-alpha.1) (2023-04-18)
+
+
+### Bug Fixes
+
+* **tree:** fix nested selected items issue ([55338c0](https://github.com/Availity/availity-react/commit/55338c096eeb895ff27140eed2d80c930c5b2f02))
+
+
+
 ## [0.4.1-alpha.0](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.0...@availity/tree@0.4.1-alpha.0) (2023-04-18)
 
 

--- a/packages/tree/CHANGELOG.md
+++ b/packages/tree/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.4.1-alpha.2](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.1...@availity/tree@0.4.1-alpha.2) (2023-04-19)
+
+
+### Bug Fixes
+
+* **tree:** tweak when tree is displayed under small sizes ([47f613a](https://github.com/Availity/availity-react/commit/47f613ac2c06b88a5e4af6b08a2094b1debf2355))
+
+
+
 ## [0.4.1-alpha.1](https://github.com/Availity/availity-react/compare/@availity/tree@0.4.1-alpha.0...@availity/tree@0.4.1-alpha.1) (2023-04-18)
 
 

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha.0",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.1-alpha.3",
+  "version": "0.4.1-alpha.4",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.1-alpha.0",
+  "version": "0.4.1-alpha.1",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.1-alpha.2",
+  "version": "0.4.1-alpha.3",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.1-alpha.1",
+  "version": "0.4.1-alpha.2",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@availity/tree",
-  "version": "0.4.1-alpha.4",
+  "version": "0.4.1-alpha.5",
   "description": "This is a component for displaying hierarchical data",
   "keywords": [
     "react",

--- a/packages/tree/src/Tree.stories.tsx
+++ b/packages/tree/src/Tree.stories.tsx
@@ -105,7 +105,7 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
             searchLabel={searchLabel}
             items={items}
             onItemsSelected={onItemsSelected}
-            selectedItems={selectedItems}
+            // selectedItems={selectedItems}
             selectable={selectable}
             displayDisabledItems={displayDisabledItems}
           />

--- a/packages/tree/src/Tree.stories.tsx
+++ b/packages/tree/src/Tree.stories.tsx
@@ -20,8 +20,7 @@ export default {
   },
 } as Meta;
 
-export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectable, expandParent }) => {
-  const [newSelectedList, setNewSelectedList] = useState<TreeItem[]>([]);
+export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectable, displayDisabledItems }) => {
   const [isTreeVisible, setIsTreeVisible] = useState(true);
 
   const flatTreeItems: TreeItem[] = [
@@ -52,22 +51,26 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
     },
     {
       id: '7',
-      name: 'Child Test 3',
+      name: 'Child Test 4',
+      isExpanded: true,
+      isDisabled: true,
       parentId: '1',
     },
     {
       id: '6',
-      name: 'Child Test 4',
-      parentId: '7',
+      name: 'Child Test 5',
+      isSelected: true,
+      parentId: '2',
     },
     {
       id: '8',
-      name: 'Child Test 5',
-      parentId: '7',
+      name: 'Child Test 6',
+      parentId: '2',
     },
     {
       id: '9',
       name: '2nd Root',
+      isExpanded: true,
     },
     {
       id: '10',
@@ -76,11 +79,15 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
     },
   ];
 
-  const tree = buildTree(flatTreeItems, [flatTreeItems.find((o) => !o.parentId)?.id || '']);
+  const tree = buildTree(flatTreeItems, ['1']);
   const [items, setItems] = useState(tree);
   const [initialState] = useState<TreeItem[]>(cloneDeep(tree));
 
-  const [selectedItems] = useState<TreeItem[]>([items[0]]);
+  const [selectedItems, setSelectedItems] = useState<TreeItem[]>([items[0]]);
+  const [newSelectedList, setNewSelectedList] = useState<TreeItem[]>([
+    items[0],
+    ...flatTreeItems.filter((item) => item.isSelected === true),
+  ]);
 
   const onItemsSelected = useCallback((selected: TreeItem[]): void => {
     setNewSelectedList(selected);
@@ -109,6 +116,7 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
             onItemsSelected={onItemsSelected}
             selectedItems={selectedItems}
             selectable={selectable}
+            displayDisabledItems={displayDisabledItems}
           />
         )}
       </div>
@@ -149,4 +157,5 @@ Default.args = {
   searchLabel: 'Search Me',
   expandAll: false,
   selectable: true,
+  displayDisabledItems: true,
 };

--- a/packages/tree/src/Tree.stories.tsx
+++ b/packages/tree/src/Tree.stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
   const [items, setItems] = useState(tree);
   const [initialState] = useState<TreeItem[]>(cloneDeep(tree));
 
-  const [selectedItems, setSelectedItems] = useState<TreeItem[]>([items[0]]);
+  const [selectedItems] = useState<TreeItem[]>([items[0]]);
   const [newSelectedList, setNewSelectedList] = useState<TreeItem[]>([
     items[0],
     ...flatTreeItems.filter((item) => item.isSelected === true),
@@ -85,7 +85,7 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
   }, []);
 
   const resetTree = async () => {
-    await setNewSelectedList([]);
+    await setNewSelectedList([items[0], ...flatTreeItems.filter((item) => item.isSelected === true)]);
     await setItems(cloneDeep(initialState));
   };
 
@@ -105,7 +105,7 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
             searchLabel={searchLabel}
             items={items}
             onItemsSelected={onItemsSelected}
-            // selectedItems={selectedItems}
+            selectedItems={selectedItems}
             selectable={selectable}
             displayDisabledItems={displayDisabledItems}
           />

--- a/packages/tree/src/Tree.stories.tsx
+++ b/packages/tree/src/Tree.stories.tsx
@@ -26,11 +26,11 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
   const flatTreeItems: TreeItem[] = [
     {
       id: '1',
-      name: 'Parent that has some long text',
+      name: 'Parent',
     },
     {
       id: '2',
-      name: 'Second Level Parent with long text',
+      name: 'Second Level Parent',
       parentId: '1',
     },
     {
@@ -51,35 +51,26 @@ export const Default: Story = ({ enableSearch, searchLabel, expandAll, selectabl
     },
     {
       id: '7',
-      name: 'Child Test 4',
-      isExpanded: true,
-      isDisabled: true,
+      name: 'Availity Webinars',
       parentId: '1',
     },
     {
       id: '6',
-      name: 'Child Test 5',
-      isSelected: true,
-      parentId: '2',
+      name: 'Validation Office',
+      parentId: '7',
     },
     {
       id: '8',
-      name: 'Child Test 6',
-      parentId: '2',
+      name: '2nd Root',
     },
     {
       id: '9',
-      name: '2nd Root',
-      isExpanded: true,
-    },
-    {
-      id: '10',
       name: '2nd Root Child',
-      parentId: '9',
+      parentId: '8',
     },
   ];
 
-  const tree = buildTree(flatTreeItems, ['1']);
+  const tree = buildTree(flatTreeItems, []);
   const [items, setItems] = useState(tree);
   const [initialState] = useState<TreeItem[]>(cloneDeep(tree));
 

--- a/packages/tree/src/Tree.tsx
+++ b/packages/tree/src/Tree.tsx
@@ -120,7 +120,9 @@ const Tree = ({
 
   useEffect(() => {
     setSelectedList(selectedItems);
+  }, [selectedItems]);
 
+  useEffect(() => {
     if (!treeItems) {
       return;
     }
@@ -130,11 +132,11 @@ const Tree = ({
         item.isExpanded = item.isExpanded || expandAll || false;
         item.isDisabled = item.isDisabled || false;
         item.isHidden = (item.isDisabled && displayDisabledItems === false) || item.isHidden || false;
-        item.isSelected = selectedItems.map((item) => item.id).includes(item.id) || item.isSelected || false;
+        item.isSelected = selectedList.map((item) => item.id).includes(item.id) || item.isSelected || false;
         item.areAllChildrenSelected = areAllChildrenSelected(item);
       });
     }
-  }, [treeItems, expandAll, selectedItems, displayDisabledItems]);
+  }, [treeItems, expandAll, selectedList, displayDisabledItems]);
 
   useEffect(() => {
     const canExpandCollapseItems = (items: TreeItem[]) => {
@@ -389,9 +391,7 @@ const Tree = ({
                               name={`chkSelect_${item.id}`}
                               data-testid={`chk-tree-view-item-select-${item.id}`}
                               type="checkbox"
-                              checked={
-                                selectedList.map((item) => item.id).includes(item.id) || item.isSelected || false
-                              }
+                              checked={item.isSelected || false}
                               onChange={() => toggleSelect(item)}
                             />
                           )}
@@ -445,7 +445,7 @@ const Tree = ({
                     isRoot={false}
                     items={item.children}
                     parentId={item.id}
-                    selectedItems={selectedItems}
+                    selectedItems={selectedList}
                     onItemsSelected={onChildrenSelected}
                     onItemsExpanded={onChildrenExpanded}
                     expandAll={expandAll}

--- a/packages/tree/src/Tree.tsx
+++ b/packages/tree/src/Tree.tsx
@@ -383,7 +383,7 @@ const Tree = ({
                 <li data-testid={`tree-view-item-${item.id}`}>
                   <div>
                     <Row>
-                      <Col sm="7">
+                      <Col xs="10" sm="9">
                         <FormGroup check>
                           {!item.isDisabled && selectable && (
                             <Input
@@ -407,7 +407,7 @@ const Tree = ({
                       </Col>
 
                       {item.children && item.children.length > 0 && (
-                        <Col sm="5">
+                        <Col xs="2" sm="3">
                           <div className="form-inline d-flex justify-content-end ml-auto align-items-center">
                             {selectable && !item.isDisabled && (
                               <FormGroup check>

--- a/packages/tree/src/TreeItemContent.tsx
+++ b/packages/tree/src/TreeItemContent.tsx
@@ -5,11 +5,7 @@ import Icon from '@availity/icon';
 
 import TreeItem from './TreeItem';
 
-const areAllChildrenSelected = (item: TreeItem) =>
-  (item.isSelected && item.children?.every((child) => (!child.isDisabled ? child.isSelected : true))) || false;
-
 type TreeItemContentProps = {
-  parentId?: string;
   items: TreeItem[];
   onItemExpanded: (item: TreeItem) => void;
   onItemsSelected: (items: TreeItem[]) => void;
@@ -18,14 +14,13 @@ type TreeItemContentProps = {
 };
 
 const TreeItemContent = ({
-  parentId,
   items,
   onItemExpanded,
   onItemsSelected,
   selectable,
   toggleSelectChildren,
 }: TreeItemContentProps) => (
-  <ul data-testid={`tree-view-${parentId || 'parent'}`}>
+  <ul>
     {items.map((item) => (
       <React.Fragment key={`tree-view-item-${item.id}`}>
         {!item.isHidden && (
@@ -85,14 +80,13 @@ const TreeItemContent = ({
           </li>
         )}
         {item.children && item.children.length > 0 && item.isExpanded && (
-          <ul>
+          <ul data-testid={`tree-view-${item.id}`}>
             <TreeItemContent
               items={item.children}
               onItemExpanded={onItemExpanded}
               onItemsSelected={onItemsSelected}
               toggleSelectChildren={toggleSelectChildren}
               selectable={selectable}
-              parentId={parentId}
             />
           </ul>
         )}

--- a/packages/tree/src/TreeItemContent.tsx
+++ b/packages/tree/src/TreeItemContent.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
+
+import Icon from '@availity/icon';
+
+import TreeItem from './TreeItem';
+
+const areAllChildrenSelected = (item: TreeItem) =>
+  (item.isSelected && item.children?.every((child) => (!child.isDisabled ? child.isSelected : true))) || false;
+
+type TreeItemContentProps = {
+  parentId?: string;
+  items: TreeItem[];
+  onItemExpanded: (item: TreeItem) => void;
+  onItemsSelected: (items: TreeItem[]) => void;
+  toggleSelectChildren: (item: TreeItem) => void;
+  selectable?: boolean;
+};
+
+const TreeItemContent = ({
+  parentId,
+  items,
+  onItemExpanded,
+  onItemsSelected,
+  selectable,
+  toggleSelectChildren,
+}: TreeItemContentProps) => (
+  <ul data-testid={`tree-view-${parentId || 'parent'}`}>
+    {items.map((item) => (
+      <React.Fragment key={`tree-view-item-${item.id}`}>
+        {!item.isHidden && (
+          <li data-testid={`tree-view-item-${item.id}`}>
+            <div>
+              <Row>
+                <Col xs="10" sm="9">
+                  <FormGroup check>
+                    {!item.isDisabled && selectable && (
+                      <Input
+                        id={`chkSelect_${item.id}`}
+                        name={`chkSelect_${item.id}`}
+                        data-testid={`chk-tree-view-item-select-${item.id}`}
+                        type="checkbox"
+                        checked={item.isSelected || false}
+                        onChange={() => onItemsSelected([item])}
+                      />
+                    )}
+                    <Label
+                      data-testid={`tree-view-item-${item.id}-label`}
+                      className={item.isDisabled ? 'text-muted' : ''}
+                      check
+                      for={`chkSelect_${item.id}`}
+                    >
+                      {item.name}
+                    </Label>
+                  </FormGroup>
+                </Col>
+
+                {item.children && item.children.length > 0 && (
+                  <Col xs="2" sm="3">
+                    <div className="form-inline d-flex justify-content-end ml-auto align-items-center">
+                      {selectable && !item.isDisabled && (
+                        <FormGroup check>
+                          <Input
+                            data-testid={`chkSelectAllChildren_${item.id}`}
+                            id={`chkSelectAllChildren_${item.id}`}
+                            type="checkbox"
+                            checked={item.areAllChildrenSelected || false}
+                            onChange={() => toggleSelectChildren(item)}
+                          />{' '}
+                        </FormGroup>
+                      )}
+                      <Button
+                        data-testid={`btn-expand-all-${item.id}`}
+                        color="link"
+                        className="icon-expand p-0 text-decoration-none"
+                        onClick={() => onItemExpanded(item)}
+                      >
+                        <Icon size="lg" className="expand-tree" name={item.isExpanded ? 'down-dir' : 'right-dir'} />
+                      </Button>
+                    </div>
+                  </Col>
+                )}
+              </Row>
+            </div>
+          </li>
+        )}
+        {item.children && item.children.length > 0 && item.isExpanded && (
+          <ul>
+            <TreeItemContent
+              items={item.children}
+              onItemExpanded={onItemExpanded}
+              onItemsSelected={onItemsSelected}
+              toggleSelectChildren={toggleSelectChildren}
+              selectable={selectable}
+              parentId={parentId}
+            />
+          </ul>
+        )}
+      </React.Fragment>
+    ))}
+  </ul>
+);
+
+export default TreeItemContent;

--- a/packages/tree/src/TreeItemContent.tsx
+++ b/packages/tree/src/TreeItemContent.tsx
@@ -6,9 +6,13 @@ import Icon from '@availity/icon';
 import TreeItem from './TreeItem';
 
 type TreeItemContentProps = {
+  /** The items that are displayed in the tree view item. */
   items: TreeItem[];
+  /** Whenever an item is expanded in the tree, it fires this event to let the parent know of the items that are expanded. */
   onItemExpanded: (item: TreeItem) => void;
+  /** Whenever an item is selected in the tree, it fires this event to let the parent know of the items that are selected. */
   onItemsSelected: (items: TreeItem[]) => void;
+  /** Whenever the select all children checkbox is checked, if fire this event to appropriately select all of the children. */
   toggleSelectChildren: (item: TreeItem) => void;
   selectable?: boolean;
 };

--- a/packages/tree/src/index.ts
+++ b/packages/tree/src/index.ts
@@ -1,2 +1,3 @@
 export { default, buildTree } from './Tree';
 export type { default as TreeItem } from './TreeItem';
+export { default as TreeItemContent } from './TreeItemContent';


### PR DESCRIPTION
This pull requests fixes a few things:
- Ability to configure disabled items from being displayed in the tree. In our implementations any items the user doesn't have access to comes back as disabled, which we were not supporting previously.
- Refactor to help track down data issues - instead of each recursive 'Tree' element having to maintain it's own data and fight with state, the parent component is the one that keeps track of the data and just feed it to a recursive `TreeViewItem` component. 
- Fix visibility of 'Select All' and 'Expand All' text when filtering items. 