### PR TITLE
fix(spaces): null check for link type

### DIFF
--- a/packages/spaces/src/SpacesLink.js
+++ b/packages/spaces/src/SpacesLink.js
@@ -261,7 +261,7 @@ const Link = ({
       >
         {!stacked && favoriteIcon}
         {appIcon}
-        {icon && type.toUpperCase() === 'FILE' ? (
+        {icon && type?.toUpperCase() === 'FILE' ? (
           <AvLink target="_blank" href={restLink.url}>
             <Icon data-testid="icon" name={restLink.metadataPairs?.find((pair) => pair.name === 'icon')?.value} />
           </AvLink>


### PR DESCRIPTION
One of our apps was getting an error from the SpacesLink trying to call `toUpperCase` on an `undefined` variable