### PR TITLE
feat(page-header): require spaces ^8.0.0

### DIFF
--- a/packages/page-header/package.json
+++ b/packages/page-header/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@availity/api-axios": "^8.0.0",
-    "@availity/spaces": "^4.0.1 || ^5.0.0 || ^6.0.0",
+    "@availity/spaces": "^8.0.0",
     "axios": "^1.0.0",
     "formik": "^2.0.1",
     "react": ">=16.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,7 +778,7 @@ __metadata:
     yup: ^0.32.11
   peerDependencies:
     "@availity/api-axios": ^8.0.0
-    "@availity/spaces": ^4.0.1 || ^5.0.0 || ^6.0.0
+    "@availity/spaces": ^8.0.0
     axios: ^1.0.0
     formik: ^2.0.1
     react: ">=16.11.0"


### PR DESCRIPTION
BREAKING CHANGE: the @availity/spaces peer dependency must be ^8.0.0 in order to use this package now

