### PR TITLE
feat(form): added logic for changing default help icon to video icon

### DIFF
--- a/docusaurus/docs/form/components/checkbox-group.md
+++ b/docusaurus/docs/form/components/checkbox-group.md
@@ -27,3 +27,7 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/components/checkbox.md
+++ b/docusaurus/docs/form/components/checkbox.md
@@ -70,3 +70,7 @@ Disables the checkbox.
 #### `inline?: boolean`
 
 Will render the checkbox inline with other checkboxes. **Default:** true.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/components/field.md
+++ b/docusaurus/docs/form/components/field.md
@@ -105,3 +105,7 @@ Append an InputAddon to the end of the Input.
 #### `prepend?: React.ReactNode | string`
 
 Append an InputAddon to the start of the Input.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/components/label.md
+++ b/docusaurus/docs/form/components/label.md
@@ -60,3 +60,7 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/components/radio-group.md
+++ b/docusaurus/docs/form/components/radio-group.md
@@ -31,3 +31,7 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Determines if `<RequiredAsterisk />` is added to label.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/components/radio.md
+++ b/docusaurus/docs/form/components/radio.md
@@ -59,3 +59,7 @@ Value of the radio button.
 #### `disabled?: boolean`
 
 Disables the radio button.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/date/components/date-field.md
+++ b/docusaurus/docs/form/date/components/date-field.md
@@ -74,3 +74,7 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/date/components/date-range-field.md
+++ b/docusaurus/docs/form/date/components/date-range-field.md
@@ -91,3 +91,7 @@ Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within l
 #### `required?: boolean`
 
 Will add `<RequiredAsterisk />` to label.
+
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help

--- a/docusaurus/docs/form/select/components/select-field.md
+++ b/docusaurus/docs/form/select/components/select-field.md
@@ -83,6 +83,10 @@ Class names to pass to the `Feedback`.
 
 Class names to pass to the `FormGroup`.
 
+#### `isHelpVideoType?: boolean`
+
+Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help
+
 ### 508 Compliance
 
 `<SelectField />` will automatically associate the `FormGroup` and `Label` based on its `name` prop, not an `id` prop. Using an `id` prop that is the same as `name` on this component will result in an orphaned form label and break 508 compliance.

--- a/packages/date/src/DateField.d.ts
+++ b/packages/date/src/DateField.d.ts
@@ -10,6 +10,7 @@ export type DateFieldProps = {
   labelAttrs?: LabelProps;
   required?: boolean;
   helpId?: string;
+  isHelpVideoType?: boolean;
 } & DateProps;
 
 declare const DateField: (props: DateFieldProps) => JSX.Element;

--- a/packages/date/src/DateField.js
+++ b/packages/date/src/DateField.js
@@ -4,7 +4,18 @@ import { FormGroup, Feedback, Label } from '@availity/form';
 
 import Date from './Date';
 
-const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name, required, helpId, ...props }) => (
+const DateField = ({
+  name,
+  label,
+  labelClass,
+  labelHidden,
+  labelAttrs,
+  id = name,
+  required,
+  helpId,
+  isHelpVideoType,
+  ...props
+}) => (
   <FormGroup for={name}>
     {label && (
       <Label
@@ -13,6 +24,7 @@ const DateField = ({ name, label, labelClass, labelHidden, labelAttrs, id = name
         hidden={labelHidden}
         required={required}
         helpId={helpId}
+        isHelpVideoType={isHelpVideoType}
         {...labelAttrs}
       >
         {label}
@@ -41,6 +53,8 @@ DateField.propTypes = {
   helpId: PropTypes.string,
   /** Placeholder input when no values have been entered. */
   placeholder: PropTypes.string,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default DateField;

--- a/packages/date/src/DateRangeField.d.ts
+++ b/packages/date/src/DateRangeField.d.ts
@@ -9,6 +9,7 @@ export type DateRangeFieldProps = {
   labelAttrs?: React.HTMLAttributes<HTMLLabelElement>;
   required?: boolean;
   helpId?: string;
+  isHelpVideoType?: boolean;
 } & DateRangeProps;
 
 declare const DateRangeField: (props: DateRangeFieldProps) => JSX.Element;

--- a/packages/date/src/DateRangeField.js
+++ b/packages/date/src/DateRangeField.js
@@ -13,6 +13,7 @@ const DateRangeField = ({
   id = name,
   required,
   helpId,
+  isHelpVideoType,
   ...props
 }) => (
   <FormGroup for={name}>
@@ -23,6 +24,7 @@ const DateRangeField = ({
         hidden={labelHidden}
         required={required}
         helpId={helpId}
+        isHelpVideoType={isHelpVideoType}
         {...labelAttrs}
       >
         {label}
@@ -49,6 +51,8 @@ DateRangeField.propTypes = {
   required: PropTypes.bool,
   /** Help topic id, adds `<FieldHelpIcon/>` next to the label (should not be within label for accessibility). */
   helpId: PropTypes.string,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default DateRangeField;

--- a/packages/form/src/Checkbox.d.ts
+++ b/packages/form/src/Checkbox.d.ts
@@ -10,6 +10,7 @@ export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   groupClassName?: string;
   groupName?: string;
   helpId?: string;
+  isHelpVideoType?: boolean;
 }
 
 declare const Checkbox: (props: CheckboxProps) => JSX.Element;

--- a/packages/form/src/Checkbox.d.ts
+++ b/packages/form/src/Checkbox.d.ts
@@ -10,7 +10,7 @@ export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   groupClassName?: string;
   groupName?: string;
   helpId?: string;
-  isVideoType?: boolean | false;
+  isHelpVideoType?: boolean;
 }
 
 declare const Checkbox: (props: CheckboxProps) => JSX.Element;

--- a/packages/form/src/Checkbox.d.ts
+++ b/packages/form/src/Checkbox.d.ts
@@ -10,6 +10,7 @@ export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   groupClassName?: string;
   groupName?: string;
   helpId?: string;
+  isVideoType?: boolean | false;
 }
 
 declare const Checkbox: (props: CheckboxProps) => JSX.Element;

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -17,6 +17,7 @@ const Checkbox = ({
   inline,
   label,
   value: checkValue,
+  isVideoType,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -48,7 +49,7 @@ const Checkbox = ({
         checked={value}
         onChange={toggle}
       />
-      <Label check id={labelId} for={inputId} helpId={helpId}>
+      <Label check id={labelId} for={inputId} helpId={helpId} isVideoType={isVideoType}>
         {label}
       </Label>
     </FormGroup>
@@ -72,6 +73,8 @@ Checkbox.propTypes = {
   label: PropTypes.node,
   /** Value of the checkbox. */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
+  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
+  isVideoType: PropTypes.bool,
 };
 
 Checkbox.defaultProps = {

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -17,7 +17,7 @@ const Checkbox = ({
   inline,
   label,
   value: checkValue,
-  isVideoType,
+  isHelpVideoType,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -49,7 +49,7 @@ const Checkbox = ({
         checked={value}
         onChange={toggle}
       />
-      <Label check id={labelId} for={inputId} helpId={helpId} isVideoType={isVideoType}>
+      <Label check id={labelId} for={inputId} helpId={helpId} isHelpVideoType={isHelpVideoType}>
         {label}
       </Label>
     </FormGroup>
@@ -73,8 +73,8 @@ Checkbox.propTypes = {
   label: PropTypes.node,
   /** Value of the checkbox. */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
-  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
-  isVideoType: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 Checkbox.defaultProps = {

--- a/packages/form/src/Checkbox.js
+++ b/packages/form/src/Checkbox.js
@@ -17,6 +17,7 @@ const Checkbox = ({
   inline,
   label,
   value: checkValue,
+  isHelpVideoType,
   ...attributes
 }) => {
   const { value, toggle, metadata } = useCheckboxGroup(checkValue);
@@ -48,7 +49,7 @@ const Checkbox = ({
         checked={value}
         onChange={toggle}
       />
-      <Label check id={labelId} for={inputId} helpId={helpId}>
+      <Label check id={labelId} for={inputId} helpId={helpId} isHelpVideoType={isHelpVideoType}>
         {label}
       </Label>
     </FormGroup>
@@ -72,6 +73,8 @@ Checkbox.propTypes = {
   label: PropTypes.node,
   /** Value of the checkbox. */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 Checkbox.defaultProps = {

--- a/packages/form/src/CheckboxGroup.d.ts
+++ b/packages/form/src/CheckboxGroup.d.ts
@@ -9,7 +9,8 @@ export interface CheckboxGroupProps extends FormGroupProps {
   groupClassName?: string;
   onChange?: (value: any) => void;
   helpId?: string;
-  required?: boolean | false;
+  required?: boolean;
+  isHelpVideoType?: boolean;
 }
 
 declare const CheckboxGroup: (props: CheckboxGroupProps) => JSX.Element;

--- a/packages/form/src/CheckboxGroup.js
+++ b/packages/form/src/CheckboxGroup.js
@@ -43,6 +43,7 @@ const CheckboxGroup = ({
   labelClassName,
   required,
   helpId,
+  isHelpVideoType,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
@@ -71,7 +72,7 @@ const CheckboxGroup = ({
           {label}
         </legend>
         <div className={labelClasses} style={styles}>
-          <Label tag="div" aria-hidden helpId={helpId} required={required}>
+          <Label tag="div" aria-hidden helpId={helpId} required={required} isHelpVideoType={isHelpVideoType}>
             {label}
           </Label>
         </div>
@@ -107,6 +108,8 @@ CheckboxGroup.propTypes = {
   labelClassName: PropTypes.string,
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default CheckboxGroup;

--- a/packages/form/src/Field.d.ts
+++ b/packages/form/src/Field.d.ts
@@ -25,6 +25,7 @@ export interface FieldProps extends InputProps {
   append?: string | ReactNode;
   prepend?: string | ReactNode;
   helpId?: string;
+  isVideoType?: boolean | false;
 }
 
 declare const Field: (props: FieldProps) => JSX.Element;

--- a/packages/form/src/Field.d.ts
+++ b/packages/form/src/Field.d.ts
@@ -11,9 +11,9 @@ interface FieldChildProps {
 
 export interface FieldProps extends InputProps {
   label?: ReactNode;
-  labelHidden?: boolean | false;
-  disabled?: boolean | false;
-  readOnly?: boolean | false;
+  labelHidden?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
   inputClass?: string;
   labelClass?: string;
   helpMessage?: string | object;
@@ -25,7 +25,7 @@ export interface FieldProps extends InputProps {
   append?: string | ReactNode;
   prepend?: string | ReactNode;
   helpId?: string;
-  isVideoType?: boolean | false;
+  isHelpVideoType?: boolean;
 }
 
 declare const Field: (props: FieldProps) => JSX.Element;

--- a/packages/form/src/Field.d.ts
+++ b/packages/form/src/Field.d.ts
@@ -11,9 +11,9 @@ interface FieldChildProps {
 
 export interface FieldProps extends InputProps {
   label?: ReactNode;
-  labelHidden?: boolean | false;
-  disabled?: boolean | false;
-  readOnly?: boolean | false;
+  labelHidden?: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
   inputClass?: string;
   labelClass?: string;
   helpMessage?: string | object;
@@ -25,6 +25,7 @@ export interface FieldProps extends InputProps {
   append?: string | ReactNode;
   prepend?: string | ReactNode;
   helpId?: string;
+  isHelpVideoType?: boolean;
 }
 
 declare const Field: (props: FieldProps) => JSX.Element;

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -28,6 +28,7 @@ const Field = ({
   prepend,
   append,
   children,
+  isHelpVideoType,
   ...attributes
 }) => {
   let row = false;
@@ -111,6 +112,7 @@ const Field = ({
           required={!!required}
           helpId={helpId}
           disabled={disabled}
+          isHelpVideoType={isHelpVideoType}
           {...labelCol}
           {...labelAttrs}
         >
@@ -161,6 +163,8 @@ Field.propTypes = {
   size: PropTypes.string,
   /** The Node or tag to substitute as the input field. Default is reactstrap Input tag. */
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 Field.defaultProps = {

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -28,7 +28,7 @@ const Field = ({
   prepend,
   append,
   children,
-  isVideoType,
+  isHelpVideoType,
   ...attributes
 }) => {
   let row = false;
@@ -112,9 +112,9 @@ const Field = ({
           required={!!required}
           helpId={helpId}
           disabled={disabled}
+          isHelpVideoType={isHelpVideoType}
           {...labelCol}
           {...labelAttrs}
-          isVideoType={isVideoType}
         >
           {label}
         </Label>
@@ -163,8 +163,8 @@ Field.propTypes = {
   size: PropTypes.string,
   /** The Node or tag to substitute as the input field. Default is reactstrap Input tag. */
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
-  isVideoType: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 Field.defaultProps = {

--- a/packages/form/src/Field.js
+++ b/packages/form/src/Field.js
@@ -28,6 +28,7 @@ const Field = ({
   prepend,
   append,
   children,
+  isVideoType,
   ...attributes
 }) => {
   let row = false;
@@ -113,6 +114,7 @@ const Field = ({
           disabled={disabled}
           {...labelCol}
           {...labelAttrs}
+          isVideoType={isVideoType}
         >
           {label}
         </Label>
@@ -161,6 +163,8 @@ Field.propTypes = {
   size: PropTypes.string,
   /** The Node or tag to substitute as the input field. Default is reactstrap Input tag. */
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
+  isVideoType: PropTypes.bool,
 };
 
 Field.defaultProps = {

--- a/packages/form/src/FieldHelpIcon.d.ts
+++ b/packages/form/src/FieldHelpIcon.d.ts
@@ -7,6 +7,8 @@ type FieldHelpIconProps = {
   size?: string;
   /** The id of the associated label for aria-describedby, needed for accessibility. */
   labelId?: string;
+  /** The prop that allows the type of icon to be changed to video-help, if needed  */
+  isHelpVideoType?: boolean;
 };
 
 declare const FieldHelpIcon: (props: FieldHelpIconProps) => JSX.Element;

--- a/packages/form/src/FieldHelpIcon.d.ts
+++ b/packages/form/src/FieldHelpIcon.d.ts
@@ -7,6 +7,8 @@ type FieldHelpIconProps = {
   size?: string;
   /** The id of the associated label for aria-describedby, needed for accessibility. */
   labelId?: string;
+  /** The prop that allows the type of icon to be changed to video-help, if needed  */
+  isVideoType?: boolean;
 };
 
 declare const FieldHelpIcon: (props: FieldHelpIconProps) => JSX.Element;

--- a/packages/form/src/FieldHelpIcon.d.ts
+++ b/packages/form/src/FieldHelpIcon.d.ts
@@ -8,7 +8,7 @@ type FieldHelpIconProps = {
   /** The id of the associated label for aria-describedby, needed for accessibility. */
   labelId?: string;
   /** The prop that allows the type of icon to be changed to video-help, if needed  */
-  isVideoType?: boolean;
+  isHelpVideoType?: boolean;
 };
 
 declare const FieldHelpIcon: (props: FieldHelpIconProps) => JSX.Element;

--- a/packages/form/src/FieldHelpIcon.js
+++ b/packages/form/src/FieldHelpIcon.js
@@ -18,11 +18,11 @@ const handleKeyPress = (event, id) => {
   }
 };
 
-const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId }) => (
+const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId, isHelpVideoType }) => (
   <Icon
     role="link"
     data-testid="field-help-icon"
-    name="help-circle"
+    name={isHelpVideoType ? 'video-help' : 'help-circle'}
     size={size}
     color={color}
     onClick={() => triggerFieldHelp(id)}
@@ -39,6 +39,7 @@ FieldHelpIcon.propTypes = {
   color: PropTypes.string,
   size: PropTypes.string,
   labelId: PropTypes.string,
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default FieldHelpIcon;

--- a/packages/form/src/FieldHelpIcon.js
+++ b/packages/form/src/FieldHelpIcon.js
@@ -18,11 +18,11 @@ const handleKeyPress = (event, id) => {
   }
 };
 
-const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId, isVideoType }) => (
+const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId, isHelpVideoType }) => (
   <Icon
     role="link"
     data-testid="field-help-icon"
-    name={isVideoType ? 'video-help' : 'help-circle'}
+    name={isHelpVideoType ? 'video-help' : 'help-circle'}
     size={size}
     color={color}
     onClick={() => triggerFieldHelp(id)}
@@ -39,7 +39,7 @@ FieldHelpIcon.propTypes = {
   color: PropTypes.string,
   size: PropTypes.string,
   labelId: PropTypes.string,
-  isVideoType: PropTypes.bool,
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default FieldHelpIcon;

--- a/packages/form/src/FieldHelpIcon.js
+++ b/packages/form/src/FieldHelpIcon.js
@@ -18,11 +18,11 @@ const handleKeyPress = (event, id) => {
   }
 };
 
-const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId }) => (
+const FieldHelpIcon = ({ id, color = 'primary', size = '1x', labelId, isVideoType }) => (
   <Icon
     role="link"
     data-testid="field-help-icon"
-    name="help-circle"
+    name={isVideoType ? 'video-help' : 'help-circle'}
     size={size}
     color={color}
     onClick={() => triggerFieldHelp(id)}
@@ -39,6 +39,7 @@ FieldHelpIcon.propTypes = {
   color: PropTypes.string,
   size: PropTypes.string,
   labelId: PropTypes.string,
+  isVideoType: PropTypes.bool,
 };
 
 export default FieldHelpIcon;

--- a/packages/form/src/Label.d.ts
+++ b/packages/form/src/Label.d.ts
@@ -3,6 +3,7 @@ import { LabelProps as RSLabelProps } from 'reactstrap';
 export interface LabelProps extends RSLabelProps {
   helpId?: string;
   required?: boolean | false;
+  isVideoType?: boolean | false;
 }
 
 declare const Label: (props: LabelProps) => JSX.Element;

--- a/packages/form/src/Label.d.ts
+++ b/packages/form/src/Label.d.ts
@@ -2,8 +2,8 @@ import { LabelProps as RSLabelProps } from 'reactstrap';
 
 export interface LabelProps extends RSLabelProps {
   helpId?: string;
-  required?: boolean | false;
-  isVideoType?: boolean | false;
+  required?: boolean;
+  isHelpVideoType?: boolean;
 }
 
 declare const Label: (props: LabelProps) => JSX.Element;

--- a/packages/form/src/Label.d.ts
+++ b/packages/form/src/Label.d.ts
@@ -2,7 +2,8 @@ import { LabelProps as RSLabelProps } from 'reactstrap';
 
 export interface LabelProps extends RSLabelProps {
   helpId?: string;
-  required?: boolean | false;
+  required?: boolean;
+  isHelpVideoType?: boolean;
 }
 
 declare const Label: (props: LabelProps) => JSX.Element;

--- a/packages/form/src/Label.js
+++ b/packages/form/src/Label.js
@@ -25,7 +25,7 @@ export const RequiredKey = () => (
   </div>
 );
 
-const Label = ({ helpId, id, required, children, ...attributes }) => {
+const Label = ({ helpId, id, required, children, isVideoType, ...attributes }) => {
   const labelId = id || uuid();
   const Wrapper = ({ children }) => {
     if (helpId && (attributes.className || attributes.style)) {
@@ -48,7 +48,7 @@ const Label = ({ helpId, id, required, children, ...attributes }) => {
         ) : null}
         {children}
       </RSLabel>
-      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} /> : null}
+      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} isVideoType={isVideoType} /> : null}
     </Wrapper>
   );
 };
@@ -61,6 +61,8 @@ Label.propTypes = {
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
+  isVideoType: PropTypes.bool,
 };
 
 export default Label;

--- a/packages/form/src/Label.js
+++ b/packages/form/src/Label.js
@@ -25,7 +25,7 @@ export const RequiredKey = () => (
   </div>
 );
 
-const Label = ({ helpId, id, required, children, isVideoType, ...attributes }) => {
+const Label = ({ helpId, id, required, children, isHelpVideoType, ...attributes }) => {
   const labelId = id || uuid();
   const Wrapper = ({ children }) => {
     if (helpId && (attributes.className || attributes.style)) {
@@ -48,7 +48,7 @@ const Label = ({ helpId, id, required, children, isVideoType, ...attributes }) =
         ) : null}
         {children}
       </RSLabel>
-      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} isVideoType={isVideoType} /> : null}
+      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} isHelpVideoType={isHelpVideoType} /> : null}
     </Wrapper>
   );
 };
@@ -61,8 +61,8 @@ Label.propTypes = {
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
-  isVideoType: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default Label;

--- a/packages/form/src/Label.js
+++ b/packages/form/src/Label.js
@@ -25,7 +25,7 @@ export const RequiredKey = () => (
   </div>
 );
 
-const Label = ({ helpId, id, required, children, ...attributes }) => {
+const Label = ({ helpId, id, required, children, isHelpVideoType, ...attributes }) => {
   const labelId = id || uuid();
   const Wrapper = ({ children }) => {
     if (helpId && (attributes.className || attributes.style)) {
@@ -48,7 +48,7 @@ const Label = ({ helpId, id, required, children, ...attributes }) => {
         ) : null}
         {children}
       </RSLabel>
-      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} /> : null}
+      {helpId ? <FieldHelpIcon labelId={labelId} id={helpId} isHelpVideoType={isHelpVideoType} /> : null}
     </Wrapper>
   );
 };
@@ -61,6 +61,8 @@ Label.propTypes = {
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default Label;

--- a/packages/form/src/Radio.d.ts
+++ b/packages/form/src/Radio.d.ts
@@ -9,6 +9,7 @@ export interface RadioProps extends HTMLAttributes<HTMLInputElement> {
   value?: string | boolean | object;
   disabled?: boolean;
   helpId?: string;
+  isHelpVideoType?: boolean;
 }
 
 declare const Radio: (props: RadioProps) => JSX.Element;

--- a/packages/form/src/Radio.js
+++ b/packages/form/src/Radio.js
@@ -8,7 +8,18 @@ import { useRadioGroup } from './RadioGroup';
 import FormGroup from './FormGroup';
 import Label from './Label';
 
-const Radio = ({ label, id, name, value: checkValue, className, groupClassName, children, helpId, ...attributes }) => {
+const Radio = ({
+  label,
+  id,
+  name,
+  value: checkValue,
+  className,
+  groupClassName,
+  children,
+  helpId,
+  isHelpVideoType,
+  ...attributes
+}) => {
   const { value, setValue, metadata, inline } = useRadioGroup(checkValue);
 
   const [inputId] = useState(id || uuid());
@@ -37,7 +48,7 @@ const Radio = ({ label, id, name, value: checkValue, className, groupClassName, 
         checked={value}
         onChange={setValue}
       />
-      <Label check id={labelId} for={inputId} helpId={helpId}>
+      <Label check id={labelId} for={inputId} helpId={helpId} isHelpVideoType={isHelpVideoType}>
         {label || children}
       </Label>
     </FormGroup>
@@ -60,6 +71,8 @@ Radio.propTypes = {
   name: PropTypes.string,
   /** Value of the radio button. */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.object]),
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default Radio;

--- a/packages/form/src/RadioGroup.d.ts
+++ b/packages/form/src/RadioGroup.d.ts
@@ -8,9 +8,10 @@ export interface RadioGroupProps extends FormGroupProps {
   labelClassName?: string;
   groupClassName?: string;
   onChange?: (value: any) => void;
-  inline?: boolean | false;
+  inline?: boolean;
   helpId?: string;
-  required?: boolean | false;
+  required?: boolean;
+  isHelpVideoType?: boolean;
 }
 
 declare const RadioGroup: (props: RadioGroupProps) => JSX.Element;

--- a/packages/form/src/RadioGroup.js
+++ b/packages/form/src/RadioGroup.js
@@ -33,6 +33,7 @@ const RadioGroup = ({
   helpId,
   labelClassName,
   required,
+  isHelpVideoType,
   ...rest
 }) => {
   const [field, metadata] = useField(name);
@@ -60,7 +61,7 @@ const RadioGroup = ({
           {label}
         </legend>
         <div className={labelClasses} style={styles}>
-          <Label tag="div" aria-hidden helpId={helpId} required={required}>
+          <Label tag="div" aria-hidden helpId={helpId} required={required} isHelpVideoType={isHelpVideoType}>
             {label}
           </Label>
         </div>
@@ -91,6 +92,7 @@ RadioGroup.propTypes = {
   onChange: PropTypes.func,
   labelClassName: PropTypes.string,
   required: PropTypes.bool,
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default RadioGroup;

--- a/packages/select/src/SelectField.d.ts
+++ b/packages/select/src/SelectField.d.ts
@@ -11,6 +11,7 @@ export type SelectFieldProps<Option, IsMulti extends boolean, Group extends Grou
   labelClass?: string;
   labelHidden?: boolean;
   required?: boolean;
+  isVideoType?: boolean;
 } & SelectProps<Option, IsMulti, Group>;
 
 declare const SelectField: <Option, IsMulti extends boolean, Group extends GroupBase<Option> = GroupBase<Option>>(

--- a/packages/select/src/SelectField.d.ts
+++ b/packages/select/src/SelectField.d.ts
@@ -11,6 +11,7 @@ export type SelectFieldProps<Option, IsMulti extends boolean, Group extends Grou
   labelClass?: string;
   labelHidden?: boolean;
   required?: boolean;
+  isHelpVideoType?: boolean;
 } & SelectProps<Option, IsMulti, Group>;
 
 declare const SelectField: <Option, IsMulti extends boolean, Group extends GroupBase<Option> = GroupBase<Option>>(

--- a/packages/select/src/SelectField.d.ts
+++ b/packages/select/src/SelectField.d.ts
@@ -11,7 +11,7 @@ export type SelectFieldProps<Option, IsMulti extends boolean, Group extends Grou
   labelClass?: string;
   labelHidden?: boolean;
   required?: boolean;
-  isVideoType?: boolean;
+  isHelpVideoType?: boolean;
 } & SelectProps<Option, IsMulti, Group>;
 
 declare const SelectField: <Option, IsMulti extends boolean, Group extends GroupBase<Option> = GroupBase<Option>>(

--- a/packages/select/src/SelectField.js
+++ b/packages/select/src/SelectField.js
@@ -16,6 +16,7 @@ const SelectField = ({
   helpId,
   required,
   helpMessage,
+  isHelpVideoType,
   ...attributes
 }) => {
   useEffect(() => {
@@ -35,6 +36,7 @@ const SelectField = ({
       className={labelClass}
       required={required}
       helpId={helpId}
+      isHelpVideoType={isHelpVideoType}
     >
       {label}
     </Label>
@@ -69,6 +71,8 @@ SelectField.propTypes = {
   labelHidden: PropTypes.bool,
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default SelectField;

--- a/packages/select/src/SelectField.js
+++ b/packages/select/src/SelectField.js
@@ -16,6 +16,7 @@ const SelectField = ({
   helpId,
   required,
   helpMessage,
+  isVideoType,
   ...attributes
 }) => {
   useEffect(() => {
@@ -35,6 +36,7 @@ const SelectField = ({
       className={labelClass}
       required={required}
       helpId={helpId}
+      isVideoType={isVideoType}
     >
       {label}
     </Label>
@@ -69,6 +71,8 @@ SelectField.propTypes = {
   labelHidden: PropTypes.bool,
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
+  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
+  isVideoType: PropTypes.bool,
 };
 
 export default SelectField;

--- a/packages/select/src/SelectField.js
+++ b/packages/select/src/SelectField.js
@@ -16,7 +16,7 @@ const SelectField = ({
   helpId,
   required,
   helpMessage,
-  isVideoType,
+  isHelpVideoType,
   ...attributes
 }) => {
   useEffect(() => {
@@ -36,7 +36,7 @@ const SelectField = ({
       className={labelClass}
       required={required}
       helpId={helpId}
-      isVideoType={isVideoType}
+      isHelpVideoType={isHelpVideoType}
     >
       {label}
     </Label>
@@ -71,8 +71,8 @@ SelectField.propTypes = {
   labelHidden: PropTypes.bool,
   /** Will add <RequiredAsterisk /> to label. */
   required: PropTypes.bool,
-  /** Allows the type of FieldIcon to be changed between help-icon and video-help */
-  isVideoType: PropTypes.bool,
+  /** Allows the type of `<FieldHelpIcon/>` to be changed between help-icon and video-help */
+  isHelpVideoType: PropTypes.bool,
 };
 
 export default SelectField;


### PR DESCRIPTION
With this change, we now have the ability to choose between the help icon or the video icon when using the FieldHelpIcon component