### PR TITLE
feat(phone): initial format value

### DIFF
--- a/packages/phone/src/Phone.d.ts
+++ b/packages/phone/src/Phone.d.ts
@@ -13,6 +13,7 @@ export interface PhoneProps extends FieldProps {
   showExtension?: boolean;
   phoneColProps?: object;
   extProps?: ExtensionProps;
+  formatInitialValue?: boolean;
 }
 
 declare const Phone: (props: PhoneProps) => JSX.Element;

--- a/packages/phone/src/Phone.js
+++ b/packages/phone/src/Phone.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from '@availity/form';
 import { useFormikContext } from 'formik';
 import { AsYouType } from 'libphonenumber-js';
 import { Row, Col } from 'reactstrap';
 
-const Phone = ({ name, label, country = 'US', showExtension = false, extProps, phoneColProps, ...restPhoneProps }) => {
-  const { setFieldValue, setFieldTouched } = useFormikContext();
+const Phone = ({
+  name,
+  label,
+  country = 'US',
+  showExtension = false,
+  extProps,
+  phoneColProps,
+  formatInitialValue,
+  ...restPhoneProps
+}) => {
+  const { setFieldValue, setFieldTouched, values } = useFormikContext();
 
   let ext = null;
   if (showExtension) {
@@ -26,6 +35,13 @@ const Phone = ({ name, label, country = 'US', showExtension = false, extProps, p
 
     return asYouType.formattedOutput;
   };
+
+  useEffect(() => {
+    if (formatInitialValue) {
+      setFieldValue(name, asYouFormat(values[name]), false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const formatPhoneOnBlur = ({ target: { value } }) => {
     setFieldValue(name, asYouFormat(value), true);
@@ -60,6 +76,8 @@ Phone.propTypes = {
   country: PropTypes.string,
   /** Used to control props on the `<Col />` for the phone field, if needed. The phone column defaults to xs: { size: 12 } when not rendering an extension field, and defaults to xs: { size: 10 } when rendering an extension field. */
   phoneColProps: PropTypes.object,
+  /** When true, when the field is first rendered, it will trigger the formatter to update the value. */
+  formatInitialValue: PropTypes.bool,
 };
 
 export default Phone;

--- a/packages/phone/tests/Phone.test.js
+++ b/packages/phone/tests/Phone.test.js
@@ -24,11 +24,11 @@ const phoneProps = {
   },
 };
 
-const renderPhone = (props, strictValidation = false) => {
+const renderPhone = (props, strictValidation = false, initialPhoneValue = '201') => {
   const Component = () => (
     <Form
       initialValues={{
-        test_phone: '201',
+        test_phone: initialPhoneValue,
       }}
       onSubmit={() => {}}
       validationSchema={yup.object().shape({
@@ -53,6 +53,12 @@ describe('Phone', () => {
     });
 
     await expect(getByText('Ext.')).toBeDefined();
+  });
+
+  test('Should format valid phone number when it initializes', async () => {
+    const { getByDisplayValue } = renderPhone({ ...phoneProps, formatInitialValue: true }, false, '2015550123');
+
+    await expect(getByDisplayValue('(201) 555-0123')).toBeDefined();
   });
 
   test('Should format valid phone number', async () => {


### PR DESCRIPTION
Currently when an initial value is provided to the `Phone` component, it will not format it until the user blurs the field. This can be jarring to the user as the input appears to change when the value didn't.

To resolve this, a new optional prop `formatInitialValue` was added and defaults to be backwards compatible. When `true` the initial value will be formatted and set.