### PR TITLE
fix: use for over for of

### DIFF
--- a/packages/form-upload/src/FilePicker.js
+++ b/packages/form-upload/src/FilePicker.js
@@ -28,8 +28,10 @@ const FilePicker = ({
   const onChange = (event) => {
     const { files } = event.target;
     const value = [];
-    for (const [i, file_] of files.entries()) {
-      value[i] = file_;
+    // FileList is not iterable
+    // eslint-disable-next-line unicorn/no-for-loop
+    for (let i = 0; i < files.length; i++) {
+      value[i] = files[i];
     }
     setFieldValue(name, value, true);
     if (onChangeCallback) onChangeCallback(event);

--- a/packages/form-upload/src/Upload.js
+++ b/packages/form-upload/src/Upload.js
@@ -150,8 +150,10 @@ const Upload = ({
 
   const setFiles = (files) => {
     let selectedFiles = [];
-    for (const [i, file] of files.entries()) {
-      selectedFiles[i] = file;
+    // FileList is not iterable
+    // eslint-disable-next-line unicorn/no-for-loop
+    for (let i = 0; i < files.length; i++) {
+      selectedFiles[i] = files[i];
     }
 
     if (max && selectedFiles.length + fieldValue.length > max) {

--- a/packages/upload/src/FilePicker.js
+++ b/packages/upload/src/FilePicker.js
@@ -17,9 +17,10 @@ class FilePicker extends Component {
   onChange = (event) => {
     const { files } = event.target;
     const { onChange } = this.props;
-    this.value = [];
-    for (const [i, file] of files.entries()) {
-      this.value[i] = file;
+    // FileList is not iterable
+    // eslint-disable-next-line unicorn/no-for-loop
+    for (let i = 0; i < files.length; i++) {
+      this.value[i] = files[i];
     }
     this.setState({ value: this.value });
     this.validate();

--- a/packages/upload/src/FilePicker.js
+++ b/packages/upload/src/FilePicker.js
@@ -17,6 +17,7 @@ class FilePicker extends Component {
   onChange = (event) => {
     const { files } = event.target;
     const { onChange } = this.props;
+    this.value = [];
     // FileList is not iterable
     // eslint-disable-next-line unicorn/no-for-loop
     for (let i = 0; i < files.length; i++) {

--- a/packages/upload/src/Upload.js
+++ b/packages/upload/src/Upload.js
@@ -43,8 +43,10 @@ class Upload extends Component {
 
   setFiles = (files) => {
     let selectedFiles = [];
-    for (const [i, file] of files.entries()) {
-      selectedFiles[i] = file;
+    // FileList is not iterable
+    // eslint-disable-next-line unicorn/no-for-loop
+    for (let i = 0; i < files.length; i++) {
+      selectedFiles[i] = files[i];
     }
     if (this.props.max && selectedFiles.length + this.state.files.length > this.props.max) {
       selectedFiles = selectedFiles.slice(0, Math.max(0, this.props.max - this.state.files.length));


### PR DESCRIPTION
Fixes an issue where `entries` was being called on a FileList. This is not iterable so using a standard `for` instead
