### PR TITLE
fix: restored style injection lost in package version 0.2.1

### DIFF
--- a/packages/app-tiles/tsup.config.js
+++ b/packages/app-tiles/tsup.config.js
@@ -6,8 +6,8 @@ module.exports = defineConfig({
   format: ['esm', 'cjs'],
   esbuildPlugins: [
     sassPlugin({
+      type: 'style',
       transform: postcssModules({
-        extract: false,
         modules: {
           generateScopedName: '[hash:base64:12]',
         },


### PR DESCRIPTION
This fix restores functionality to inject the classes into the style of the document lost in config changes for 0.2.1.  ~The `index.css` file that was separately generated as of that version is still generated, so applications that use it should still be able to access it.~
Found that `index.css` is **not** generated now (was left over from previous package generations) but it appears to be getting no use in Bitbucket apps.
