### PR TITLE
fix(authorize): return null instead of undefined from getRegion when region is false

### DIFF
--- a/packages/authorize/src/api.test.ts
+++ b/packages/authorize/src/api.test.ts
@@ -16,9 +16,9 @@ describe('authorize api', () => {
     expect(region).toBe('FL');
   });
 
-  test('getRegion returns undefined when given falsey value', async () => {
+  test('getRegion returns null when given falsey value', async () => {
     const region = await getRegion(false);
-    expect(region).toBeUndefined();
+    expect(region).toBeNull();
   });
 
   test('getRegion returns value when not falsey', async () => {

--- a/packages/authorize/src/api.ts
+++ b/packages/authorize/src/api.ts
@@ -7,14 +7,14 @@ import type { Permission, RequestedPermissions, RequestedResources } from './typ
  *
  * If the region is a string then it will be returned without fetching.
  */
-export const getRegion = async (region?: boolean | string): Promise<string | undefined> => {
+export const getRegion = async (region?: boolean | string): Promise<string | null> => {
   if (region === true) {
     const resp = await avRegionsApi.getCurrentRegion();
 
-    return resp?.data?.regions?.[0]?.id;
+    return resp?.data?.regions?.[0]?.id || null;
   }
 
-  return region || undefined;
+  return region || null;
 };
 
 /**

--- a/packages/authorize/src/api.ts
+++ b/packages/authorize/src/api.ts
@@ -22,12 +22,12 @@ export const getRegion = async (region?: boolean | string): Promise<string | nul
  */
 export const getPermissions = async (
   permissions: RequestedPermissions,
-  region?: string
+  region?: string | null
 ): Promise<Record<string, Permission>> => {
   if (!permissions) return {};
 
   // TODO: fix these types
-  const response = await avUserPermissionsApi.getPermissions(permissions as string[], region);
+  const response = await avUserPermissionsApi.getPermissions(permissions as string[], region || undefined);
 
   return response.reduce<Record<string, Permission>>((prev, cur) => {
     prev[cur.id] = cur;
@@ -91,7 +91,7 @@ export const checkPermission = (
  */
 export const checkPermissions = async (
   permissions: RequestedPermissions,
-  region?: string,
+  region?: string | null,
   resources?: RequestedResources,
   organizationId?: string,
   customerId?: string


### PR DESCRIPTION
Fixes React Query error 'Query data cannot be undefined' when useAuthorize hook is called with the region: false parameter, changed the getRegion function to return null instead of undefined to comply with React Query requirements.

Fixes #1584

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/availity/availity-react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Make sure your code passed the conventional commits check. Read more about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
