### PR TITLE
fix(favorites): use fake timers to prevent radix-ui tooltip timer leak

### DIFF
--- a/packages/favorites/src/tests/FavoriteHeart.test.jsx
+++ b/packages/favorites/src/tests/FavoriteHeart.test.jsx
@@ -132,6 +132,7 @@ Providers.propTypes = {
 
 describe('FavoriteHeart', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     global.document.createRange = () => ({
       setStart: () => {},
       setEnd: () => {},
@@ -145,6 +146,8 @@ describe('FavoriteHeart', () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     vi.clearAllMocks();
     queryClient.clear();
     global.document.createRange = null;


### PR DESCRIPTION
## Summary

Fixes unhandled `ReferenceError: window is not defined` error in CI caused by `@radix-ui/react-tooltip`'s internal `setTimeout` firing after jsdom teardown.

## Changes

- Added `vi.useFakeTimers({ shouldAdvanceTime: true })` in `beforeEach`
- Added `vi.runOnlyPendingTimers()` and `vi.useRealTimers()` in `afterEach`

## Testing

All 17 FavoriteHeart tests pass with no unhandled errors.