### PR TITLE
feat(hooks)!: update react-router peer dep and import to v7

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -33,7 +33,7 @@
     "axios": "^1.17.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^7.18.0",
     "tsup": "^8.5.1"
   },
   "peerDependencies": {
@@ -42,7 +42,7 @@
     "@tanstack/react-query": "^5.75.5",
     "axios": "^1.13.2",
     "react": "^18.0.0 || ^19.0.0",
-    "react-router-dom": "^6.26.0"
+    "react-router": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hooks/src/useUpdateNav.ts
+++ b/packages/hooks/src/useUpdateNav.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import avMessage from '@availity/message-core';
 
 const useUpdateNav = (): void => {

--- a/packages/hooks/tests/useUpdateNav.test.tsx
+++ b/packages/hooks/tests/useUpdateNav.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter, useNavigate, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, useNavigate, Routes, Route } from 'react-router';
 import avMessageMock from '@availity/message-core';
 
 import useUpdateNav from '../src/useUpdateNav';
@@ -27,7 +27,8 @@ const Component = () => {
 describe('useUpdateNav', () => {
   test.todo('calls avMessage on location change', () => {
     render(
-      <MemoryRouter initialEntries={['/']}>n        <Routes>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
           <Route path="/" element={<Component />} />
           <Route path="/test" element={<div>Example</div>} />
         </Routes>

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,7 +723,7 @@ __metadata:
     axios: "npm:^1.17.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    react-router-dom: "npm:^6.30.4"
+    react-router: "npm:^7.18.0"
     tsup: "npm:^8.5.1"
   peerDependencies:
     "@availity/api-axios": ^12.0.0 || ^13.0.0
@@ -731,7 +731,7 @@ __metadata:
     "@tanstack/react-query": ^5.75.5
     axios: ^1.13.2
     react: ^18.0.0 || ^19.0.0
-    react-router-dom: ^6.26.0
+    react-router: ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -10101,7 +10101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.1.1":
+"cookie@npm:^1.0.1, cookie@npm:^1.1.1":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10/85538153054791155cf4d38d2e807e3b9382d71bf71d92fc46fca348515ea574049d0d9ef8eb84d2d54a681ad1d7a7316b1989b901dace50a6c0f4c3858dbdb2
@@ -19724,6 +19724,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router@npm:^7.18.0":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
+  dependencies:
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
+  peerDependencies:
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10/e68aa655e5ec2d4143f66ab3b745c50b8588152d89e4ec66c099625357c6a16dfaee5a7e963a9f4f9fbe0adaa37cf9731d63a108a2c4abfaa00124a06da16c24
+  languageName: node
+  linkType: hard
+
 "react-select-async-paginate@npm:^0.6.2":
   version: 0.6.2
   resolution: "react-select-async-paginate@npm:0.6.2"
@@ -20978,6 +20994,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10/7fa9d9c68090f6289976b34fc13c50ac8cd7f16ae6bce08d16459300f7fc61fbc2d7ebfa02884c073ec9d6ab9e7e704c89561882bbe338e99fcacb2912fde737
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10/4b6f5ec4e3fa1aef471d9207117704d217ba6bb6443400b41f5ea945c4a7f6fc08e405a122c1a32b4ebde41f06dea75e02c2af87cee9abb27f3e3fe911e5839b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Change useUpdateNav import from 'react-router-dom' to 'react-router'
- Update peerDependencies: react-router-dom ^6.26.0 -> react-router ^7.0.0
- Update devDependencies: react-router-dom ^6.30.4 -> react-router ^7.18.0
- Update test imports to use 'react-router'
- Fix malformed JSX in useUpdateNav test

BREAKING CHANGE: requires react-router >=7.0.0
